### PR TITLE
fix(HEO-1): build IGO import rates in local time, not UTC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,11 @@ __pycache__/
 dist/
 build/
 .worktrees/
+# Adding dev artefacts that shouldn't be tracked
+.coverage
+.pytest_cache/
+__pycache__/
+*.pyc
+.venv/
+*.egg-info/
+docs/bugs.md.bak

--- a/custom_components/heo2/coordinator.py
+++ b/custom_components/heo2/coordinator.py
@@ -191,24 +191,33 @@ class HEO2Coordinator(DataUpdateCoordinator):
         return state.state.lower() in ("on", "true", "1")
 
     def _build_import_rates(self, now) -> list:
-        from datetime import timezone
-        from .models import RateSlot
+        """Build IGO import rate slots relative to `now`.
+
+        Delegates to `heo2.igo_rates.build_igo_import_rates` so the boundary
+        maths is unit-tested in isolation. Local timezone comes from HA config
+        to keep the night-rate window aligned with real clock time under DST.
+        See docs/bugs.md HEO-1 for history.
+        """
+        from zoneinfo import ZoneInfo
+        from .igo_rates import build_igo_import_rates
         from .const import DEFAULT_IGO_NIGHT_RATE_PENCE, DEFAULT_IGO_DAY_RATE_PENCE
 
-        night_rate = self._config.get("igo_night_rate", DEFAULT_IGO_NIGHT_RATE_PENCE)
-        day_rate = self._config.get("igo_day_rate", DEFAULT_IGO_DAY_RATE_PENCE)
-
-        today = now.replace(hour=0, minute=0, second=0, microsecond=0)
-        rates = [
-            RateSlot(today, today.replace(hour=5, minute=30), night_rate),
-            RateSlot(today.replace(hour=5, minute=30), today.replace(hour=23, minute=30), day_rate),
-            RateSlot(
-                today.replace(hour=23, minute=30),
-                (today + timedelta(days=1)).replace(hour=5, minute=30),
-                night_rate,
+        tz_name = (self.hass.config.time_zone
+                   if self.hass and self.hass.config.time_zone
+                   else "UTC")
+        tz = ZoneInfo(tz_name)
+        return build_igo_import_rates(
+            now=now,
+            tz=tz,
+            night_start=self._config.get("igo_night_start", "23:30"),
+            night_end=self._config.get("igo_night_end", "05:30"),
+            night_rate_pence=self._config.get(
+                "igo_night_rate", DEFAULT_IGO_NIGHT_RATE_PENCE
             ),
-        ]
-        return rates
+            day_rate_pence=self._config.get(
+                "igo_day_rate", DEFAULT_IGO_DAY_RATE_PENCE
+            ),
+        )
 
     @property
     def total_savings(self) -> float:

--- a/custom_components/heo2/igo_rates.py
+++ b/custom_components/heo2/igo_rates.py
@@ -1,0 +1,86 @@
+# custom_components/heo2/igo_rates.py
+"""Builders for Octopus Intelligent Go import rate slots.
+
+Pure functions, no Home Assistant imports. Testable in isolation.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from zoneinfo import ZoneInfo
+
+from .models import RateSlot
+
+UTC = timezone.utc
+
+
+def build_igo_import_rates(
+    now: datetime,
+    tz: ZoneInfo,
+    night_start: str = "23:30",
+    night_end: str = "05:30",
+    night_rate_pence: float = 7.0,
+    day_rate_pence: float = 27.88,
+) -> list[RateSlot]:
+    """Build IGO import rate slots relative to `now`.
+
+    Octopus Intelligent Go charges `night_rate_pence` during the local-time
+    window `night_start` to `night_end` (which crosses midnight), and
+    `day_rate_pence` at all other times.
+
+    Returns three contiguous slots covering from today's local midnight
+    through tomorrow's `night_end` — about 29.5 hours of coverage, enough
+    for any rule making decisions about the next 24 hours.
+
+    All returned datetimes are UTC-aware, matching the convention used
+    by the rule engine's `rate_at()` comparisons.
+
+    Args:
+        now: Current time (any timezone; used only to anchor "today" in `tz`).
+        tz: Local timezone for interpreting the night window.
+        night_start: Local "HH:MM" when the night rate begins.
+        night_end: Local "HH:MM" when the night rate ends (next day).
+        night_rate_pence: Price during the night window.
+        day_rate_pence: Price outside the night window.
+    """
+    nh, nm = _parse_hhmm(night_start)
+    eh, em = _parse_hhmm(night_end)
+
+    # Anchor "today" in local time
+    today_local = now.astimezone(tz).replace(
+        hour=0, minute=0, second=0, microsecond=0
+    )
+
+    # Local-time window boundaries
+    night_end_today = today_local.replace(hour=eh, minute=em)
+    night_start_today = today_local.replace(hour=nh, minute=nm)
+    night_end_tomorrow = night_end_today + timedelta(days=1)
+
+    return [
+        RateSlot(
+            start=today_local.astimezone(UTC),
+            end=night_end_today.astimezone(UTC),
+            rate_pence=night_rate_pence,
+        ),
+        RateSlot(
+            start=night_end_today.astimezone(UTC),
+            end=night_start_today.astimezone(UTC),
+            rate_pence=day_rate_pence,
+        ),
+        RateSlot(
+            start=night_start_today.astimezone(UTC),
+            end=night_end_tomorrow.astimezone(UTC),
+            rate_pence=night_rate_pence,
+        ),
+    ]
+
+
+def _parse_hhmm(s: str) -> tuple[int, int]:
+    """Parse an 'HH:MM' string into (hour, minute). Raises ValueError on bad input."""
+    parts = s.strip().split(":")
+    if len(parts) != 2:
+        raise ValueError(f"Expected HH:MM, got {s!r}")
+    h, m = int(parts[0]), int(parts[1])
+    if not (0 <= h < 24 and 0 <= m < 60):
+        raise ValueError(f"Out of range HH:MM: {s!r}")
+    return h, m

--- a/docs/bugs.md
+++ b/docs/bugs.md
@@ -1,0 +1,233 @@
+# HEO II Bug Register
+
+Diagnosed against running code at `a1acrity/heo2@50d3473` (byte-identical to production).
+Tests run on Python 3.13.13. Baseline before any fix: 149 pass, 0 fail, 71% coverage.
+
+Each entry includes a stable ID so commits and tests can reference it.
+
+## Priority A: blockers before `dry_run=false`
+
+### HEO-1 Timezone bug in `_build_import_rates`
+
+**File**: `custom_components/heo2/coordinator.py:201-216`
+
+**Problem**: `today = now.replace(hour=0, minute=0, ...)` operates on a UTC datetime,
+producing UTC midnight. The night-rate window `23:30-05:30` is then built in UTC.
+During BST the window is shifted by one hour: in the code it runs 23:30-05:30 UTC
+which is 00:30-06:30 BST, not the true IGO window of 23:30-05:30 BST.
+
+**Effect**: Every rule calling `rate.rate_at_time(now)` between 23:30 and 00:30 BST
+gets day-rate 27.88 p when the true rate is night-rate 7 p. Also wrong at DST
+transitions. Invisible to the current test suite because every test fixture uses
+UTC and so is internally consistent.
+
+**Fix**: Use `homeassistant.util.dt.now()` and build rate windows in local time,
+converting to UTC only at RateSlot construction.
+
+**Test gap**: No test asserts behaviour under a non-UTC timezone. Add a test that
+freezes time at 23:45 BST, builds rates, and asserts `rate_at_time(now).rate_pence == 7.0`.
+
+---
+
+### HEO-2 MqttWriter readback raises NotImplementedError
+
+**File**: `custom_components/heo2/mqtt_writer.py` (per original review — to verify in place)
+
+**Problem**: `_wait_for_readback` raises NotImplementedError. Masked in `dry_run=true`.
+First live write will throw.
+
+**Test status**: `test_mqtt_writer.py::test_retries_on_readback_failure` and
+`test_aborts_on_persistent_failure` both pass, which means they are mocking around
+the NotImplementedError rather than exercising the real code path.
+
+**Fix**: Implement MQTT subscribe-and-wait against Solar Assistant's readback topic.
+
+---
+
+## Priority B: Active degradation right now (even in dry_run)
+
+### HEO-3 AgilePredict client schema wrong
+
+**Files**:
+- `custom_components/heo2/agilepredict_client.py:39,62-74`
+- `tests/test_agilepredict_client.py:11-28`
+
+**Problem**: Client calls `GET /api/rates/export` which returns HTTP 404 on Janeway's
+AgilePredict instance (verified). The real endpoint is `GET /api/` returning a
+different schema:
+
+```json
+[{
+  "name": "2026-04-18 16:17",
+  "created_at": "...",
+  "prices": [
+    {"date_time": "...", "agile_pred": 30.78, "agile_low": ..., "agile_high": ..., "region": "X"}
+  ]
+}]
+```
+
+15 regions per response (A-N, P, X). Hull's DNO region is M (NGED Yorkshire).
+
+Tests pass because they mock a fabricated `{valid_from, valid_to, value_inc_vat}`
+schema that doesn't match production.
+
+**Effect observed**: Every 15-minute tick logs `AgilePredict fetch failed: 404`.
+`sensor.heo_ii_current_export_rate = unknown`. ExportWindowRule runs with no
+export rate data.
+
+**Fix**: Rewrite `fetch_export_rates` to hit `/api/`, parse the nested schema,
+filter by region (configurable, default X for unknown), convert `date_time` to
+end-exclusive 30-min RateSlot objects using `agile_pred` as the pence value.
+
+**Test gap**: Rewrite tests using the real schema. Add integration test marker
+that hits `http://192.168.4.84:8001/api/` when a flag is set (skipped in CI).
+
+---
+
+### HEO-4 Solar forecast arithmetic error — double or quadruple counted
+
+**File**: `custom_components/heo2/solcast_client.py:74-93`
+
+**Problem**: Solcast returns `pv_estimate` as **average kW** over each 30-min period.
+Converting to kWh requires multiplying by 0.5h. Current code does
+`hourly[hour] += pv_kw` with no `* 0.5`, then sums every period received.
+
+Additionally, the hour bucket assignment `hourly[hour] += pv_kw` ignores the
+**date** of the period. Solcast returns multi-day forecasts (48+ hours on free
+tier). All days are collapsed into the same 24 hourly buckets, multiplying the
+reported total by N days.
+
+**Effect observed**: `sensor.heo_ii_solar_forecast_today = 147.18` today
+(18 April, cloudy). A realistic upper bound for any UK domestic PV array in
+April would be around 40 kWh on a perfect day. Actual: 147 kWh, ~4x too high.
+This corrupts every rule that compares demand vs generation.
+
+Also produces the nonsense `SolarSurplus: +1234% SOC` in programme_reason.
+
+**Fix**: Filter forecast entries to "today only" (period start >= local midnight,
+< local midnight + 24h). Multiply each pv_kw by 0.5 when adding to the bucket.
+
+**Test gap**: No test feeds multi-day data, so the double-count is invisible.
+Existing tests feed hand-crafted single-day fixtures. Add a test that feeds a
+48-hour Solcast response and asserts the 24 hourly buckets cover only "today".
+
+---
+
+### HEO-5 LoadProfileBuilder never learns
+
+**Files**:
+- `custom_components/heo2/load_profile.py` (correct in isolation)
+- `custom_components/heo2/coordinator.py:45-47,144-146` (never calls add_day)
+
+**Problem**: Coordinator instantiates `LoadProfileBuilder(baseline_w=1900.0)` on
+startup, calls `build()` each tick, but never calls `add_day()`. So `weekday` and
+`weekend` are always `[1.9] * 24`, and `sensor.heo_ii_load_profile.state == "weekend"`
+today because `for_datetime(now)` returns the baseline flat profile either way.
+
+**Effect observed**: daily demand reported as 45.6 kWh (exactly 1.9 × 24) across
+every rule. CheapRateChargeRule concludes "worth charging -101.6 kWh" and sets
+target 20% instead of charging fully.
+
+**Fix**: Two parts.
+1. On startup, query HA recorder (`history.state_changes_during_period`) for the
+   last 7-14 days of `load_power_entity`, aggregate by hour, call `add_day()`.
+2. Persist the builder via HA's Store helper so restart keeps learnings.
+
+**Test gap**: Tests cover add_day() and build() in isolation but never assert
+that the coordinator calls add_day. Add a test that instantiates the coordinator
+with a mock hass providing history data and asserts add_day was called.
+
+---
+
+## Priority C: Still active, lower impact
+
+### HEO-6 EveningProtectRule hour-boundary off-by-one
+
+**File**: `custom_components/heo2/rules/evening_protect.py`
+
+**Status**: Original review flagged `slot_end_mins=1110 vs evening_mins=1080`
+(18:30 vs 18:00). Need to re-read code to confirm and reproduce with a failing
+test. Adding to fix queue but not yet re-verified in this audit.
+
+---
+
+### HEO-7 ExportWindowRule hour arithmetic lossy
+
+**File**: `custom_components/heo2/rules/export_window.py`
+
+**Status**: Original review flagged exclusive-end-hour and ignored sub-hour
+minute boundaries. Verify with targeted test.
+
+---
+
+### HEO-8 IGO dispatches only reacted to, not planned ahead
+
+**File**: `custom_components/heo2/rules/igo_dispatch.py`
+
+**Problem**: Rule only modifies the current slot when `igo_dispatching=True`.
+BottlecapDave's integration exposes planned dispatches at
+`binary_sensor.octopus_energy_..._intelligent_dispatching.attributes.planned_dispatches`
+as a list of upcoming windows. HEO II could plan future slots to maximise SOC
+before each dispatch.
+
+**Fix**: Extend rule input to accept list of planned dispatches; adjust future
+slots' SOC targets to account for them.
+
+---
+
+## Priority D: Configuration drift (not code bugs)
+
+### HEO-9 Three entity IDs misconfigured in config entry
+
+**Location**: `.storage/core.config_entries` entry for HEO II
+
+**Problem**: Three fields point at the IGO dispatching binary sensor instead of
+their correct entities:
+
+- `saving_session_entity` = should be `binary_sensor.octopus_energy_a_8e04cfcf_octoplus_saving_sessions`
+- `tapo_dryer_entity` = should be a smart-plug switch, or empty
+- `tapo_wash_entity` = should be a smart-plug switch, or empty
+
+**Fix**: Correct via HA UI (HEO II integration → Configure), or patch storage
+directly. UI route is safer.
+
+---
+
+### HEO-10 Saving Sessions never triggers a rule
+
+**Problem**: `saving_session_entity` is wired (even if wrongly) but no rule in
+`rules/` reads `inputs.saving_session` except `ev_charging.py` which uses it as
+a flag not a price signal. Octoplus Saving Sessions pay £3+/kWh — missing these
+is expensive.
+
+**Fix**: Add a `SavingSessionRule` that, on saving session active, overrides the
+current slot to drain to `min_soc` regardless of Agile price.
+
+---
+
+## Priority E: Observability & UX
+
+### HEO-11 Rule parameters baked into constructors
+
+Rule thresholds (evening_start_hour, off_peak times, max_target_soc,
+degradation cost) are constructor args with no HA UI. Should be number/select
+entities.
+
+### HEO-12 `reason_log` not persisted
+
+Lives in memory per coordinator tick. Can't review history of why a slot was set.
+Should write to HA Store or a dedicated log sensor with trimmed ring buffer.
+
+### HEO-13 MQTT writer hardcoded to inverter_1
+
+Slave inverter has no MQTT control path. Requires Solar Assistant's own topic
+tree extended to inverter_2, plus a second physical RS485 link (spare USB adapter
+available).
+
+---
+
+## Resolved or obsolete
+
+- ~~Battery capacity default 20 kWh~~: already changed to 10.0 in config entry (close enough to 10.24 actual).
+- ~~AgilePredict service down~~: it's up; bug is in the client code, not the service.
+- ~~178 orphaned tmp files in .storage~~: all zero-byte, safe to delete with backup.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,12 @@
 [project]
 name = "heo2"
 version = "0.1.0"
-description = "HEO II — Rule-based SunSynk 6-slot timer programmer"
+description = "HEO II: Rule-based SunSynk 6-slot timer programmer"
 requires-python = ">=3.12"
 dependencies = [
     "paho-mqtt>=2.0",
     "httpx>=0.27",
+    "tzdata>=2024.1; sys_platform == 'win32'",
 ]
 
 [project.optional-dependencies]
@@ -13,6 +14,7 @@ dev = [
     "pytest>=8.0",
     "pytest-asyncio>=0.24",
     "pytest-httpx>=0.34",
+    "tzdata>=2024.1",
 ]
 
 [tool.pytest.ini_options]

--- a/tests/test_igo_rates.py
+++ b/tests/test_igo_rates.py
@@ -1,0 +1,127 @@
+# tests/test_igo_rates.py
+"""Tests for IGO import rate slot builder.
+
+Covers HEO-1: the original coordinator code built UTC-midnight-relative
+rate windows, producing a one-hour shift during BST. These tests lock
+in the correct local-time semantics.
+"""
+
+from datetime import datetime, timezone, timedelta
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from heo2.igo_rates import build_igo_import_rates
+from heo2.models import RateSlot
+
+UTC = timezone.utc
+LONDON = ZoneInfo("Europe/London")
+
+
+class TestBuildIGOImportRates:
+    def test_returns_three_contiguous_slots(self):
+        """Three slots covering ~29.5 hours: night-start-of-today, day, night-ending-tomorrow."""
+        now = datetime(2026, 4, 18, 18, 0, tzinfo=UTC)  # 19:00 BST
+        rates = build_igo_import_rates(now, tz=LONDON)
+        assert len(rates) == 3
+        assert all(isinstance(r, RateSlot) for r in rates)
+        # Contiguous
+        assert rates[0].end == rates[1].start
+        assert rates[1].end == rates[2].start
+
+    def test_bst_night_rate_starts_at_local_23_30(self):
+        """In BST, the upcoming night-rate window (slot 3) must start at 23:30 LOCAL,
+        which is 22:30 UTC. The original bug produced 23:30 UTC = 00:30 BST."""
+        now = datetime(2026, 4, 18, 18, 0, tzinfo=UTC)  # 19:00 BST
+        rates = build_igo_import_rates(now, tz=LONDON)
+        night = rates[2]
+        # 23:30 BST on 2026-04-18 = 22:30 UTC
+        assert night.start == datetime(2026, 4, 18, 22, 30, tzinfo=UTC)
+        # 05:30 BST on 2026-04-19 = 04:30 UTC
+        assert night.end == datetime(2026, 4, 19, 4, 30, tzinfo=UTC)
+
+    def test_bst_night_rate_value_is_7p(self):
+        now = datetime(2026, 4, 18, 18, 0, tzinfo=UTC)
+        rates = build_igo_import_rates(
+            now, tz=LONDON, night_rate_pence=7.0, day_rate_pence=27.88
+        )
+        assert rates[0].rate_pence == 7.0
+        assert rates[1].rate_pence == 27.88
+        assert rates[2].rate_pence == 7.0
+
+    def test_rate_at_time_just_before_igo_starts(self):
+        """At 23:29 BST the rate is still DAY rate. At 23:30 BST it flips to NIGHT."""
+        now = datetime(2026, 4, 18, 18, 0, tzinfo=UTC)
+        rates = build_igo_import_rates(
+            now, tz=LONDON, night_rate_pence=7.0, day_rate_pence=27.88
+        )
+        # 23:29 BST = 22:29 UTC
+        t_day = datetime(2026, 4, 18, 22, 29, tzinfo=UTC)
+        # 23:30 BST = 22:30 UTC
+        t_night = datetime(2026, 4, 18, 22, 30, tzinfo=UTC)
+
+        def rate_at(dt, rs):
+            for r in rs:
+                if r.start <= dt < r.end:
+                    return r.rate_pence
+            return None
+
+        assert rate_at(t_day, rates) == 27.88
+        assert rate_at(t_night, rates) == 7.0
+
+    def test_rate_at_time_at_igo_boundary_in_bst(self):
+        """01:00 BST on 19 April = 00:00 UTC on 19 April.
+        Should still be NIGHT rate (IGO runs until 05:30 local)."""
+        now = datetime(2026, 4, 18, 18, 0, tzinfo=UTC)
+        rates = build_igo_import_rates(
+            now, tz=LONDON, night_rate_pence=7.0, day_rate_pence=27.88
+        )
+        t = datetime(2026, 4, 19, 0, 0, tzinfo=UTC)  # 01:00 BST
+        hit = None
+        for r in rates:
+            if r.start <= t < r.end:
+                hit = r.rate_pence
+                break
+        assert hit == 7.0, "01:00 BST should be night rate"
+
+    def test_utc_winter_night_rate_unchanged(self):
+        """In winter (GMT = UTC), local and UTC are the same."""
+        now = datetime(2026, 1, 15, 12, 0, tzinfo=UTC)
+        rates = build_igo_import_rates(now, tz=LONDON)
+        # Night window slot 3: 23:30 GMT today = 23:30 UTC today
+        assert rates[2].start == datetime(2026, 1, 15, 23, 30, tzinfo=UTC)
+        assert rates[2].end == datetime(2026, 1, 16, 5, 30, tzinfo=UTC)
+
+    def test_custom_night_window_crossing_midnight(self):
+        """Alternative night schedule 22:30-06:30 BST.
+
+        Exercises the boundary maths with non-default values, still
+        crossing midnight as IGO-like tariffs always do."""
+        now = datetime(2026, 4, 18, 18, 0, tzinfo=UTC)
+        rates = build_igo_import_rates(
+            now, tz=LONDON, night_start="22:30", night_end="06:30"
+        )
+        # 22:30 BST today = 21:30 UTC today
+        assert rates[2].start == datetime(2026, 4, 18, 21, 30, tzinfo=UTC)
+        # 06:30 BST tomorrow = 05:30 UTC tomorrow
+        assert rates[2].end == datetime(2026, 4, 19, 5, 30, tzinfo=UTC)
+
+    def test_slots_are_utc_aware(self):
+        """Every slot datetime must be UTC-aware for rate_at() comparisons."""
+        now = datetime(2026, 4, 18, 18, 0, tzinfo=UTC)
+        rates = build_igo_import_rates(now, tz=LONDON)
+        for r in rates:
+            assert r.start.tzinfo is not None
+            assert r.end.tzinfo is not None
+            assert r.start.utcoffset() == timedelta(0), "start not UTC-normalised"
+            assert r.end.utcoffset() == timedelta(0), "end not UTC-normalised"
+
+    def test_rejects_malformed_hhmm(self):
+        """Bad input should raise ValueError, not silently accept."""
+        now = datetime(2026, 4, 18, 18, 0, tzinfo=UTC)
+        with pytest.raises(ValueError):
+            build_igo_import_rates(now, tz=LONDON, night_start="bogus")
+        with pytest.raises(ValueError):
+            build_igo_import_rates(now, tz=LONDON, night_end="25:00")
+        with pytest.raises(ValueError):
+            build_igo_import_rates(now, tz=LONDON, night_start="23:99")


### PR DESCRIPTION
## Summary

Fixes **HEO-1**: IGO import rate windows were built in UTC, shifting them by one hour during BST.

## The bug

`coordinator._build_import_rates` used
`datetime.now(timezone.utc).replace(hour=0, minute=0, ...)` as "today" and
built 23:30-05:30 slots in UTC. During BST that renders as **00:30-06:30 local**:
the night rate applies one hour too late, and the last hour before IGO's real
start (22:30-23:30 UTC = 23:30-00:30 BST) is wrongly priced as day rate 27.88 p
when it should be night rate 7 p. The same logic would also mis-align at
DST transition boundaries.

## The fix

Extracted the boundary maths into a **pure module-level function** in a new
`heo2.igo_rates` module. The function takes a `ZoneInfo` and interprets
`night_start` / `night_end` as local HH:MM, then returns UTC-aware `RateSlot`
objects. The coordinator now delegates to it, pulling the timezone from
`hass.config.time_zone`.

Benefits of this shape:
- Pure function is unit-testable without the HA framework
- Timezone is explicit in the signature, no hidden UTC assumption
- Natural home for future Agile / Outgoing rate builders

## Test coverage

Nine new tests in `tests/test_igo_rates.py`, all passing:

- `test_returns_three_contiguous_slots`
- `test_bst_night_rate_starts_at_local_23_30` (the headline bug)
- `test_bst_night_rate_value_is_7p`
- `test_rate_at_time_just_before_igo_starts` (23:29 vs 23:30 boundary)
- `test_rate_at_time_at_igo_boundary_in_bst` (01:00 BST = night rate)
- `test_utc_winter_night_rate_unchanged` (GMT = UTC regression)
- `test_custom_night_window_crossing_midnight` (22:30-06:30 variant)
- `test_slots_are_utc_aware` (type invariant)
- `test_rejects_malformed_hhmm` (input validation)

## Before / after

|                       | Before | After |
|-----------------------|--------|-------|
| Total test count      | 149    | 158   |
| Failures              | 0      | 0     |
| Coverage              | 71%    | 73%   |
| BST night rate window | 00:30-06:30 local (wrong) | 23:30-05:30 local (correct) |

## Commits

- `3fc6a19` chore: pin tzdata for cross-platform zoneinfo and fix description mojibake
- `7028b8e` fix(HEO-1): build IGO import rates in local time, not UTC

## Deployment note

Safe to merge with `dry_run=true` in production (current state). Behaviour change
only becomes observable in rule decisions, not inverter writes. When `dry_run=false`
is flipped later (after HEO-2 mqtt readback is fixed), the corrected IGO window
is a prerequisite.

## Follow-ups

- HEO-2 through HEO-13 remain open in `docs/bugs.md`. Will migrate to GitHub Issues
  after this PR merges.
- HEO-4 (solar forecast 4x over-report) is the next priority.
