### PR TITLE
fix(HEO-5): coordinator learns load profile from HA recorder history

### DIFF
--- a/custom_components/heo2/__init__.py
+++ b/custom_components/heo2/__init__.py
@@ -28,6 +28,14 @@ async def async_setup_entry(hass, entry) -> bool:
 
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
 
+    # Seed the load profile from recorder history (HEO-5). Fire-and-forget
+    # so we do not block startup on a DB query. The first coordinator tick
+    # will use the flat baseline; the second and later ticks use the
+    # learned profile once this task completes.
+    hass.async_create_task(
+        coordinator.async_refresh_load_profile_from_recorder()
+    )
+
     # Wire up CostTracker state-change listeners
     unsub_callbacks = []
     config = dict(entry.data)

--- a/custom_components/heo2/coordinator.py
+++ b/custom_components/heo2/coordinator.py
@@ -224,6 +224,102 @@ class HEO2Coordinator(DataUpdateCoordinator):
 
         return solar_forecast_from_hacs(detailed, target_date=target_date)
 
+    async def async_refresh_load_profile_from_recorder(
+        self, days_back: int = 14,
+    ) -> int:
+        """Seed LoadProfileBuilder from HA recorder history.
+
+        Queries the last ``days_back`` days of state history for the
+        configured ``load_power_entity``, aggregates by hour into kWh,
+        and calls ``LoadProfileBuilder.add_day()`` for each covered date.
+
+        Intended to be called once on startup as a fire-and-forget task
+        so the integration does not block on a recorder query. Safe to
+        call again later; add_day() appends samples rather than replacing,
+        so repeated calls grow the median window rather than overwrite.
+
+        Returns the number of days successfully added. Zero on any
+        failure (recorder unavailable, no entity, no history).
+
+        See HEO-5 for history. Scheduled daily refresh and Store-backed
+        persistence are tracked as follow-up enhancements.
+        """
+        from zoneinfo import ZoneInfo
+        from datetime import datetime, timedelta, timezone as _tz
+
+        entity_id = self._config.get("load_power_entity", "")
+        if not entity_id:
+            logger.debug("No load_power_entity configured; skipping history learn")
+            return 0
+
+        try:
+            from homeassistant.components.recorder import (
+                get_instance,
+                history,
+            )
+        except ImportError:
+            logger.warning(
+                "HA recorder component not available; load profile cannot learn"
+            )
+            return 0
+
+        now_utc = datetime.now(_tz.utc)
+        start_utc = now_utc - timedelta(days=days_back)
+
+        try:
+            recorder_instance = get_instance(self.hass)
+            raw = await recorder_instance.async_add_executor_job(
+                history.get_significant_states,
+                self.hass,
+                start_utc,
+                now_utc,
+                [entity_id],
+            )
+        except Exception as exc:  # broad: recorder errors vary
+            logger.warning(
+                "Recorder history fetch failed for %s: %s", entity_id, exc
+            )
+            return 0
+
+        states = raw.get(entity_id) if isinstance(raw, dict) else None
+        if not states:
+            logger.info(
+                "No recorder history for %s in last %d days; "
+                "load profile stays at baseline",
+                entity_id, days_back,
+            )
+            return 0
+
+        from .load_history import (
+            learn_days_from_samples,
+            states_to_power_samples,
+        )
+
+        samples = states_to_power_samples(states)
+        if not samples:
+            logger.info(
+                "No parseable power samples for %s; load profile stays at baseline",
+                entity_id,
+            )
+            return 0
+        tz_name = (self.hass.config.time_zone
+                   if self.hass and self.hass.config.time_zone
+                   else "UTC")
+        tz = ZoneInfo(tz_name)
+
+        days = learn_days_from_samples(samples, tz)
+        for d, hourly_kwh in days.items():
+            # Convert date to datetime at midnight for the builder's
+            # existing weekday-or-weekend branching logic.
+            date_midnight = datetime(d.year, d.month, d.day, tzinfo=tz)
+            self._load_builder.add_day(date_midnight, hourly_kwh)
+
+        logger.info(
+            "Load profile learned from %d samples across %d days for %s",
+            len(samples), len(days), entity_id,
+        )
+        return len(days)
+
     def _build_import_rates(self, now) -> list:
         """Build IGO import rate slots relative to `now`.
 

--- a/custom_components/heo2/load_history.py
+++ b/custom_components/heo2/load_history.py
@@ -174,3 +174,35 @@ def learn_days_from_samples(
     for d in dates:
         result[d] = aggregate_samples_to_hourly_kwh(ordered, d, tz)
     return result
+
+
+def states_to_power_samples(states) -> list[tuple]:
+    """Convert HA recorder State-like objects into (datetime, watts) tuples.
+
+    Defensive against ``unknown`` / ``unavailable`` / ``None`` states and
+    malformed numeric values. Non-numeric states, states missing
+    attributes, and states with a None timestamp are all silently
+    skipped so one bad record cannot break the whole history fetch.
+
+    Returns the list ordered by ``last_changed`` ascending. Caller is
+    responsible for treating the returned watts as "load power" including
+    its sign (negative = export); the aggregator clamps to zero.
+    """
+    out: list[tuple] = []
+    for s in states:
+        try:
+            raw = s.state
+            ts = s.last_changed
+        except AttributeError:
+            continue
+        if raw in (None, "unknown", "unavailable"):
+            continue
+        try:
+            watts = float(raw)
+        except (ValueError, TypeError):
+            continue
+        if ts is None:
+            continue
+        out.append((ts, watts))
+    out.sort(key=lambda p: p[0])
+    return out

--- a/custom_components/heo2/load_history.py
+++ b/custom_components/heo2/load_history.py
@@ -1,0 +1,176 @@
+# custom_components/heo2/load_history.py
+"""Pure aggregation functions that turn HA recorder state history into the
+(date, hourly_kwh_list) shape LoadProfileBuilder.add_day() expects.
+
+The caller (the coordinator) fetches raw recorder history and extracts
+(timestamp, watts) samples, then hands them to these functions. The math
+is deliberately kept in this module - no Home Assistant imports - so it
+can be unit-tested without any HA framework.
+
+Covers HEO-5: previously LoadProfileBuilder.add_day() was never called,
+so the load profile was always flat baseline. This is the missing link.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, date, timedelta, tzinfo
+
+
+SECONDS_PER_HOUR = 3600
+WH_PER_KWH = 1000
+
+# Intervals longer than this are treated as device-offline gaps, not flat
+# extrapolation. HA recorder writes at least hourly even for unchanged
+# values, so any gap longer than this almost certainly means the sensor
+# was unavailable.
+DEFAULT_MAX_INTERVAL_SECONDS = 2 * SECONDS_PER_HOUR
+
+
+def aggregate_samples_to_hourly_kwh(
+    samples: list[tuple[datetime, float]],
+    target_date: date,
+    tz: tzinfo,
+    max_interval_seconds: float = DEFAULT_MAX_INTERVAL_SECONDS,
+) -> list[float]:
+    """Aggregate (timestamp, watts) samples into 24 hourly kWh values for
+    ``target_date`` interpreted in ``tz``.
+
+    Uses trapezoidal integration between consecutive samples. Power is
+    assumed to ramp linearly between samples, which for trapezoidal
+    integration gives the exact integral. Intervals that span hour
+    boundaries are split at the boundary and each portion contributes
+    to its own hour bucket.
+
+    Negative power values (export periods) are clamped to zero because
+    a load profile represents consumption, not net flow.
+
+    Input samples are sorted defensively; caller need not pre-sort.
+    Samples with the same timestamp are collapsed to the first.
+
+    Args:
+        samples: list of (datetime_aware, watts) pairs.
+        target_date: the local date to aggregate for.
+        tz: timezone used to interpret ``target_date`` boundaries.
+
+    Returns:
+        24 floats, index 0 is 00:00 local of ``target_date``, etc.
+    """
+    if len(samples) < 2:
+        return [0.0] * 24
+
+    # Defensive sort and negative clamp
+    ordered = sorted(
+        ((ts, max(0.0, float(w))) for ts, w in samples),
+        key=lambda p: p[0],
+    )
+
+    # Local midnight boundaries for the target day
+    day_start_local = datetime(
+        target_date.year, target_date.month, target_date.day, tzinfo=tz,
+    )
+    day_end_local = day_start_local + timedelta(days=1)
+
+    hourly = [0.0] * 24
+
+    for (t1, w1), (t2, w2) in zip(ordered, ordered[1:]):
+        if t2 <= t1:
+            continue  # duplicate or reversed timestamp, skip
+        interval_seconds = (t2 - t1).total_seconds()
+        if interval_seconds <= 0:
+            continue
+        if interval_seconds > max_interval_seconds:
+            # Gap too large — sensor was probably unavailable. Don't
+            # invent energy by interpolating across the gap.
+            continue
+
+        # Skip intervals that don't touch the target day at all
+        if t2 <= day_start_local or t1 >= day_end_local:
+            continue
+
+        # Walk hour boundaries that fall inside this interval
+        _accumulate_interval(
+            hourly, t1, w1, t2, w2,
+            day_start_local, day_end_local, tz,
+        )
+
+    return hourly
+
+
+def _accumulate_interval(
+    hourly: list[float],
+    t1: datetime, w1: float,
+    t2: datetime, w2: float,
+    day_start: datetime, day_end: datetime,
+    tz: tzinfo,
+) -> None:
+    """Add the energy contribution of one (t1, w1) -> (t2, w2) interval
+    into ``hourly`` buckets, splitting at hour boundaries."""
+    interval_secs = (t2 - t1).total_seconds()
+    slope = (w2 - w1) / interval_secs  # watts per second
+
+    # Clamp the interval to the target day
+    a = max(t1, day_start)
+    b = min(t2, day_end)
+    if b <= a:
+        return
+
+    # Walk from a to b, stopping at every hour boundary in between
+    cursor = a
+    while cursor < b:
+        # Next hour boundary in local time
+        local_cursor = cursor.astimezone(tz)
+        next_hour_local = (local_cursor + timedelta(hours=1)).replace(
+            minute=0, second=0, microsecond=0,
+        )
+        next_boundary = min(next_hour_local, b)
+
+        # Integrate from cursor to next_boundary
+        # Power at cursor: linear interp between t1 and t2
+        dt_a = (cursor - t1).total_seconds()
+        dt_b = (next_boundary - t1).total_seconds()
+        p_a = w1 + slope * dt_a
+        p_b = w1 + slope * dt_b
+        # Clamp again after interpolation in case interval straddles zero
+        p_a = max(0.0, p_a)
+        p_b = max(0.0, p_b)
+
+        seg_secs = (next_boundary - cursor).total_seconds()
+        # Energy (Wh) = avg_W * hours = (p_a + p_b) / 2 * seg_secs / 3600
+        energy_wh = (p_a + p_b) / 2.0 * seg_secs / SECONDS_PER_HOUR
+        energy_kwh = energy_wh / WH_PER_KWH
+
+        # Which local hour does this segment belong to?
+        hour_index = local_cursor.hour
+        if 0 <= hour_index < 24:
+            hourly[hour_index] += energy_kwh
+
+        cursor = next_boundary
+
+
+def learn_days_from_samples(
+    samples: list[tuple[datetime, float]],
+    tz: tzinfo,
+) -> dict[date, list[float]]:
+    """Group samples by local date and aggregate each into 24 hourly kWh buckets.
+
+    Returns a dict mapping each local date covered by the samples to its
+    24-element hourly kWh list. Convenience wrapper for the coordinator
+    so it can loop and call LoadProfileBuilder.add_day() per entry.
+    """
+    if not samples:
+        return {}
+
+    ordered = sorted(samples, key=lambda p: p[0])
+    # Find all local dates touched by the samples
+    first_local = ordered[0][0].astimezone(tz)
+    last_local = ordered[-1][0].astimezone(tz)
+    dates: list[date] = []
+    d = first_local.date()
+    while d <= last_local.date():
+        dates.append(d)
+        d = d + timedelta(days=1)
+
+    result: dict[date, list[float]] = {}
+    for d in dates:
+        result[d] = aggregate_samples_to_hourly_kwh(ordered, d, tz)
+    return result

--- a/tests/test_coordinator_helpers.py
+++ b/tests/test_coordinator_helpers.py
@@ -1,0 +1,104 @@
+# tests/test_coordinator_helpers.py
+"""Tests for the HA recorder state parser.
+
+Originally placed here because the parser lived in coordinator.py, but
+importing heo2.coordinator pulls in homeassistant.* which isn't in the
+test venv. The parser has since moved to heo2.load_history and is imported
+from there. This test file is kept separate because it's semantically
+about the HA recorder integration boundary, not the core aggregator
+maths (which lives in test_load_history.py).
+"""
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+from heo2.load_history import states_to_power_samples
+
+UTC = timezone.utc
+
+
+def _mk_state(ts_iso: str, state: str):
+    """Build a minimal HA State-like object for testing."""
+    dt = datetime.fromisoformat(ts_iso)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=UTC)
+    return SimpleNamespace(last_changed=dt, state=state)
+
+
+class TestStatesToPowerSamples:
+    def test_parses_well_formed_states(self):
+        states = [
+            _mk_state("2026-04-18T12:00:00+00:00", "1500"),
+            _mk_state("2026-04-18T12:05:00+00:00", "2000"),
+        ]
+        out = states_to_power_samples(states)
+        assert len(out) == 2
+        assert out[0][1] == 1500.0
+        assert out[1][1] == 2000.0
+
+    def test_skips_unknown_states(self):
+        states = [
+            _mk_state("2026-04-18T12:00:00+00:00", "unknown"),
+            _mk_state("2026-04-18T12:05:00+00:00", "1500"),
+        ]
+        out = states_to_power_samples(states)
+        assert len(out) == 1
+        assert out[0][1] == 1500.0
+
+    def test_skips_unavailable_states(self):
+        states = [
+            _mk_state("2026-04-18T12:00:00+00:00", "unavailable"),
+            _mk_state("2026-04-18T12:05:00+00:00", "1500"),
+        ]
+        out = states_to_power_samples(states)
+        assert len(out) == 1
+
+    def test_skips_non_numeric_states(self):
+        states = [
+            _mk_state("2026-04-18T12:00:00+00:00", "on"),
+            _mk_state("2026-04-18T12:05:00+00:00", "1500"),
+            _mk_state("2026-04-18T12:10:00+00:00", "n/a"),
+        ]
+        out = states_to_power_samples(states)
+        assert len(out) == 1
+        assert out[0][1] == 1500.0
+
+    def test_handles_negative_and_float_values(self):
+        """Negative (export) and decimal values are accepted as floats;
+        clamping is the aggregator's job, not the parser's."""
+        states = [
+            _mk_state("2026-04-18T12:00:00+00:00", "-500"),
+            _mk_state("2026-04-18T12:05:00+00:00", "1500.5"),
+        ]
+        out = states_to_power_samples(states)
+        assert len(out) == 2
+        assert out[0][1] == -500.0
+        assert out[1][1] == 1500.5
+
+    def test_sorts_by_timestamp(self):
+        """Recorder usually returns sorted, but we don't trust callers."""
+        states = [
+            _mk_state("2026-04-18T12:05:00+00:00", "2000"),
+            _mk_state("2026-04-18T12:00:00+00:00", "1000"),
+            _mk_state("2026-04-18T12:10:00+00:00", "3000"),
+        ]
+        out = states_to_power_samples(states)
+        assert [w for _, w in out] == [1000.0, 2000.0, 3000.0]
+
+    def test_empty_list_returns_empty(self):
+        assert states_to_power_samples([]) == []
+
+    def test_skips_states_missing_attributes(self):
+        """Malformed state objects without the expected attributes are skipped."""
+        states = [
+            object(),  # no attributes
+            _mk_state("2026-04-18T12:00:00+00:00", "1500"),
+        ]
+        out = states_to_power_samples(states)
+        assert len(out) == 1
+        assert out[0][1] == 1500.0
+
+    def test_skips_state_with_none_timestamp(self):
+        s = SimpleNamespace(last_changed=None, state="1500")
+        out = states_to_power_samples([s])
+        assert out == []

--- a/tests/test_load_history.py
+++ b/tests/test_load_history.py
@@ -1,0 +1,267 @@
+# tests/test_load_history.py
+"""Tests for load history aggregator.
+
+Covers HEO-5: LoadProfileBuilder was never fed any historical data because
+the coordinator never called add_day(). This module provides the pure
+functions that convert HA recorder state history into the (date, hourly_kwh)
+shape that add_day() expects.
+"""
+
+from datetime import datetime, date, timezone, timedelta
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from heo2.load_history import (
+    aggregate_samples_to_hourly_kwh,
+    learn_days_from_samples,
+)
+
+UTC = timezone.utc
+LONDON = ZoneInfo("Europe/London")
+
+
+def _mk_samples(*pairs, tz=UTC):
+    """Convenience: build samples from list of (ISO8601-ish, watts) pairs."""
+    out = []
+    for ts, w in pairs:
+        if isinstance(ts, str):
+            dt = datetime.fromisoformat(ts)
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=tz)
+        else:
+            dt = ts
+        out.append((dt, float(w)))
+    return out
+
+
+class TestAggregateSamplesToHourlyKwh:
+    def test_empty_samples_returns_zeros(self):
+        out = aggregate_samples_to_hourly_kwh([], date(2026, 4, 18), UTC)
+        assert out == [0.0] * 24
+
+    def test_single_sample_returns_zeros(self):
+        """One sample alone gives no interval to integrate over."""
+        samples = _mk_samples(("2026-04-18T12:00:00+00:00", 2000))
+        out = aggregate_samples_to_hourly_kwh(samples, date(2026, 4, 18), UTC)
+        assert out == [0.0] * 24
+
+    def test_flat_constant_power_for_one_hour(self):
+        """2 kW held for one hour = 2 kWh in that hour."""
+        samples = _mk_samples(
+            ("2026-04-18T12:00:00+00:00", 2000),
+            ("2026-04-18T13:00:00+00:00", 2000),
+        )
+        out = aggregate_samples_to_hourly_kwh(samples, date(2026, 4, 18), UTC)
+        assert out[12] == pytest.approx(2.0)
+        # Every other hour zero
+        assert sum(out) == pytest.approx(2.0)
+
+    def test_flat_constant_power_across_hour_boundary(self):
+        """2 kW held from 12:30 to 13:30 = 1 kWh in hour 12 and 1 kWh in hour 13."""
+        samples = _mk_samples(
+            ("2026-04-18T12:30:00+00:00", 2000),
+            ("2026-04-18T13:30:00+00:00", 2000),
+        )
+        out = aggregate_samples_to_hourly_kwh(samples, date(2026, 4, 18), UTC)
+        assert out[12] == pytest.approx(1.0)
+        assert out[13] == pytest.approx(1.0)
+
+    def test_trapezoidal_integration(self):
+        """Power ramp 1 kW at 12:00 to 3 kW at 13:00 integrates to 2 kWh.
+
+        Trapezoidal: ((1 + 3) / 2) * 1h = 2 kWh."""
+        samples = _mk_samples(
+            ("2026-04-18T12:00:00+00:00", 1000),
+            ("2026-04-18T13:00:00+00:00", 3000),
+        )
+        out = aggregate_samples_to_hourly_kwh(samples, date(2026, 4, 18), UTC)
+        assert out[12] == pytest.approx(2.0)
+
+    def test_full_day_of_flat_load(self):
+        """1 kW continuous for 24 hours = 24 kWh spread evenly.
+
+        Uses generous max_interval because the synthetic samples are
+        only at day boundaries; real data would have many samples per hour."""
+        samples = _mk_samples(
+            ("2026-04-18T00:00:00+00:00", 1000),
+            ("2026-04-19T00:00:00+00:00", 1000),
+        )
+        out = aggregate_samples_to_hourly_kwh(
+            samples, date(2026, 4, 18), UTC,
+            max_interval_seconds=25 * 3600,
+        )
+        assert sum(out) == pytest.approx(24.0)
+        for h in range(24):
+            assert out[h] == pytest.approx(1.0)
+
+    def test_negative_power_clamped_to_zero(self):
+        """Solar export makes the entity negative. Load profile ignores that."""
+        samples = _mk_samples(
+            ("2026-04-18T12:00:00+00:00", -2000),
+            ("2026-04-18T13:00:00+00:00", -2000),
+        )
+        out = aggregate_samples_to_hourly_kwh(samples, date(2026, 4, 18), UTC)
+        assert out[12] == 0.0
+        assert sum(out) == 0.0
+
+    def test_samples_outside_target_date_bookend_correctly(self):
+        """Sample before midnight provides the initial value; sample after
+        provides the terminal value. Both are needed to integrate the full day."""
+        samples = _mk_samples(
+            ("2026-04-17T23:00:00+00:00", 1000),
+            ("2026-04-18T00:00:00+00:00", 1000),
+            ("2026-04-18T01:00:00+00:00", 1000),
+            ("2026-04-18T12:00:00+00:00", 1000),
+            ("2026-04-18T23:00:00+00:00", 1000),
+            ("2026-04-19T00:00:00+00:00", 1000),
+            ("2026-04-19T01:00:00+00:00", 1000),
+        )
+        out = aggregate_samples_to_hourly_kwh(
+            samples, date(2026, 4, 18), UTC,
+            max_interval_seconds=12 * 3600,
+        )
+        # 1 kW all day = 24 kWh, 1 kWh per hour
+        assert sum(out) == pytest.approx(24.0)
+        assert out[0] == pytest.approx(1.0)
+        assert out[23] == pytest.approx(1.0)
+
+    def test_step_change_mid_hour(self):
+        """1 kW until 12:30, then 3 kW until 13:00.
+
+        Hour 12: 0.5h at 1 kW (0.5 kWh) + 0.5h trapezoid from 1-3 kW
+        trap = ((1+3)/2)*0.5 = 1 kWh. Total hour 12 = 1.5 kWh."""
+        samples = _mk_samples(
+            ("2026-04-18T12:00:00+00:00", 1000),
+            ("2026-04-18T12:30:00+00:00", 1000),
+            ("2026-04-18T13:00:00+00:00", 3000),
+        )
+        out = aggregate_samples_to_hourly_kwh(samples, date(2026, 4, 18), UTC)
+        assert out[12] == pytest.approx(1.5)
+
+    def test_filters_to_target_date_only(self):
+        """Samples from other days must not contribute to today's buckets."""
+        samples = _mk_samples(
+            ("2026-04-17T12:00:00+00:00", 99999),
+            ("2026-04-17T13:00:00+00:00", 99999),
+            ("2026-04-19T12:00:00+00:00", 99999),
+            ("2026-04-19T13:00:00+00:00", 99999),
+            # Only these two pairs are today
+            ("2026-04-18T12:00:00+00:00", 2000),
+            ("2026-04-18T13:00:00+00:00", 2000),
+        )
+        out = aggregate_samples_to_hourly_kwh(samples, date(2026, 4, 18), UTC)
+        assert out[12] == pytest.approx(2.0)
+        assert sum(out) == pytest.approx(2.0)
+
+    def test_bst_date_bucketing(self):
+        """target_date = 2026-04-18 LOCAL means 23:00 UTC 2026-04-17 is today.
+
+        In BST (UTC+1): local midnight 2026-04-18 = 23:00 UTC 2026-04-17."""
+        samples = _mk_samples(
+            # 00:30 BST = 23:30 UTC previous day
+            ("2026-04-17T23:30:00+00:00", 2000),
+            ("2026-04-18T00:30:00+00:00", 2000),
+        )
+        out = aggregate_samples_to_hourly_kwh(samples, date(2026, 4, 18), LONDON)
+        # In local time: 00:30 to 01:30, all hour 0 and hour 1 of 18 April local
+        # 2 kW for 1 hour = 2 kWh split half in hour 0, half in hour 1
+        assert out[0] == pytest.approx(1.0)
+        assert out[1] == pytest.approx(1.0)
+        assert sum(out) == pytest.approx(2.0)
+
+    def test_unsorted_samples_are_sorted(self):
+        """Don't rely on caller to sort. Receive in any order, integrate in time order."""
+        samples = _mk_samples(
+            ("2026-04-18T13:00:00+00:00", 2000),
+            ("2026-04-18T12:00:00+00:00", 2000),
+        )
+        out = aggregate_samples_to_hourly_kwh(samples, date(2026, 4, 18), UTC)
+        assert out[12] == pytest.approx(2.0)
+
+    def test_watts_input_produces_kwh_output(self):
+        """Watt-seconds of energy divided by 3.6e6 gives kWh. Make this explicit."""
+        # 1000 W held for 1 hour = 3600000 watt-seconds = 1 kWh
+        samples = _mk_samples(
+            ("2026-04-18T12:00:00+00:00", 1000),
+            ("2026-04-18T13:00:00+00:00", 1000),
+        )
+        out = aggregate_samples_to_hourly_kwh(samples, date(2026, 4, 18), UTC)
+        assert out[12] == pytest.approx(1.0)
+
+    def test_gap_longer_than_max_interval_is_dropped(self):
+        """Large gaps between samples indicate the device was offline.
+
+        Don't invent energy by interpolating across such gaps."""
+        samples = _mk_samples(
+            ("2026-04-18T10:00:00+00:00", 1000),
+            ("2026-04-18T11:00:00+00:00", 1000),
+            # 3-hour gap - device offline
+            ("2026-04-18T14:00:00+00:00", 1000),
+            ("2026-04-18T15:00:00+00:00", 1000),
+        )
+        out = aggregate_samples_to_hourly_kwh(samples, date(2026, 4, 18), UTC)
+        # Only the 10-11 and 14-15 intervals should contribute
+        assert out[10] == pytest.approx(1.0)
+        assert out[14] == pytest.approx(1.0)
+        # The interpolated 11-14 gap should NOT contribute
+        assert out[11] == 0.0
+        assert out[12] == 0.0
+        assert out[13] == 0.0
+
+    def test_configurable_max_interval_allows_sparse_data(self):
+        """Caller can loosen the stale-interval check for known-sparse data."""
+        samples = _mk_samples(
+            ("2026-04-18T10:00:00+00:00", 1000),
+            # 5-hour gap, but caller says it's fine
+            ("2026-04-18T15:00:00+00:00", 1000),
+        )
+        out = aggregate_samples_to_hourly_kwh(
+            samples, date(2026, 4, 18), UTC,
+            max_interval_seconds=6 * 3600,
+        )
+        # 1 kW over 5 hours = 5 kWh
+        assert sum(out) == pytest.approx(5.0)
+
+
+class TestLearnDaysFromSamples:
+    def test_returns_dict_keyed_by_date(self):
+        """Multi-day samples yield one entry per covered date."""
+        samples = _mk_samples(
+            ("2026-04-16T12:00:00+00:00", 1000),
+            ("2026-04-16T13:00:00+00:00", 1000),
+            ("2026-04-17T12:00:00+00:00", 2000),
+            ("2026-04-17T13:00:00+00:00", 2000),
+            ("2026-04-18T12:00:00+00:00", 3000),
+            ("2026-04-18T13:00:00+00:00", 3000),
+        )
+        result = learn_days_from_samples(samples, UTC)
+        assert set(result.keys()) == {date(2026, 4, 16), date(2026, 4, 17), date(2026, 4, 18)}
+        assert result[date(2026, 4, 16)][12] == pytest.approx(1.0)
+        assert result[date(2026, 4, 17)][12] == pytest.approx(2.0)
+        assert result[date(2026, 4, 18)][12] == pytest.approx(3.0)
+
+    def test_each_day_has_24_buckets(self):
+        samples = _mk_samples(
+            ("2026-04-17T12:00:00+00:00", 1000),
+            ("2026-04-18T12:00:00+00:00", 1000),
+        )
+        result = learn_days_from_samples(samples, UTC)
+        for d, buckets in result.items():
+            assert len(buckets) == 24
+
+    def test_empty_samples_returns_empty_dict(self):
+        assert learn_days_from_samples([], UTC) == {}
+
+    def test_respects_local_timezone(self):
+        """Day boundary is local midnight, not UTC midnight."""
+        samples = _mk_samples(
+            # 22:00 UTC 2026-04-18 = 23:00 BST still 2026-04-18 local
+            ("2026-04-18T22:00:00+00:00", 1000),
+            # 00:00 UTC 2026-04-19 = 01:00 BST on 2026-04-19
+            ("2026-04-19T00:00:00+00:00", 1000),
+        )
+        result = learn_days_from_samples(samples, LONDON)
+        # This spans local dates 2026-04-18 and 2026-04-19
+        assert date(2026, 4, 18) in result
+        assert date(2026, 4, 19) in result


### PR DESCRIPTION
Closes #5.

## Summary

Fixes **HEO-5**: `LoadProfileBuilder` never learned anything. The coordinator instantiated it on startup, called `build()` on every tick, but never called `add_day()`. The weekday and weekend profiles were stuck at the flat baseline (1.9 kW × 24 h = 45.6 kWh) forever, which drove ``CheapRateChargeRule`` to conclude "worth charging -101.6 kWh" and skip overnight charging entirely. Together with HEO-4 (solar forecast 4× over-report), this was the other half of the broken demand-vs-supply maths seen in ``sensor.heo_ii_programme_reason``.

## Approach

Same shape as HEO-1/3/4: pure functions in a dedicated module, thin orchestration in the coordinator.

**New module `heo2.load_history`** with two pure functions:

- ``aggregate_samples_to_hourly_kwh(samples, target_date, tz, max_interval_seconds=7200)`` — trapezoidal integration of (timestamp, watts) samples, splitting at hour boundaries, clamping negatives (export), rejecting stale gaps.
- ``learn_days_from_samples(samples, tz)`` — groups a multi-day sample stream by local date and aggregates each.
- ``states_to_power_samples(states)`` — defensive parser for HA recorder State objects, handles unknown/unavailable/None/non-numeric.

**New coordinator method** `async_refresh_load_profile_from_recorder(days_back=14)`:

- Lazy-imports `homeassistant.components.recorder`
- Queries `get_significant_states` for the configured `load_power_entity` over the last 14 days
- Runs the query via `recorder.get_instance(hass).async_add_executor_job` so we don't block the event loop on a DB read
- Feeds results through `states_to_power_samples` → `learn_days_from_samples` → `LoadProfileBuilder.add_day()`
- Returns the number of days added; zero on any failure so it never breaks the coordinator

**Wiring in `__init__.py`**: the refresh is scheduled with `hass.async_create_task` after `async_config_entry_first_refresh()`. First tick uses the flat baseline; subsequent ticks use the learned profile once the DB query returns. Non-blocking startup.

## Design decisions

1. **Pure functions, thin orchestration.** The orchestration method can't be unit-tested without a live hass, but its three constituent parts (parser + aggregator + LoadProfileBuilder) all have their own isolation tests.
2. **`max_interval_seconds` default 2 hours.** HA recorder writes at least hourly even for unchanged sensors, so a 2+ hour gap means the sensor was unavailable. Don't invent energy by interpolating across such gaps.
3. **Fire-and-forget startup, not scheduled daily refresh.** Simpler and recoverable; reload the integration to force a fresh learn. Daily scheduled refresh is a sensible follow-up.
4. **No Store persistence.** On restart the coordinator re-fetches from recorder. If the 14-day recorder window becomes a bottleneck, Store persistence is a follow-up.
5. **Kept `states_to_power_samples` in `load_history`, not `coordinator`.** Lets tests import the parser without pulling in the full `homeassistant.*` package.

## Test coverage

|                  | Before | After |
|------------------|--------|-------|
| Total tests      | 172    | 200   |
| Failures         | 0      | 0     |
| Runtime          | 2.9s   | 3.1s  |

Net +28 tests split across two new files:

- `tests/test_load_history.py` (19 tests): aggregator correctness including flat load, trapezoidal ramps, hour-boundary splits, negative clamping, BST date bucketing, stale-gap rejection, custom interval thresholds, multi-day grouping.
- `tests/test_coordinator_helpers.py` (9 tests): parser defensiveness against unknown/unavailable/non-numeric/malformed states.

## Commits

- `b5c3fa3` feat(HEO-5): add load_history aggregator for recorder samples
- `5fa4ae7` fix(HEO-5): coordinator learns load profile from recorder on startup

## Deployment note

Safe to merge with ``dry_run=true`` (current production state). Behaviour change visible on next reload/restart of the integration:

- Logs should show "Load profile learned from N samples across D days for sensor.deye_sunsynk_sol_ark_load_power"
- ``sensor.heo_ii_load_profile`` attribute (not yet exposed, see HEO-12) would show real hourly values
- Downstream: ``programme_reason`` daily demand will no longer be 45.6 kWh; it'll reflect your actual historical usage
- Downstream: ``CheapRateChargeRule`` will no longer refuse to charge overnight

Together with HEO-4 (already merged), this closes the loop on the "nonsense numbers in programme_reason" problem.

## Follow-ups filed separately

- Scheduled daily refresh to re-learn from ongoing data (without integration reload)
- Store-backed persistence for accumulated samples
- Widen window to 30 days once persistence is in
