### PR TITLE
chore: add deploy and rollback scripts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Keep shell scripts LF-only so busybox on HA doesn't choke on CR.
+# Everything else uses the git default.
+*.sh text eol=lf

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,78 @@
+# HEO II deploy scripts
+
+Push master (or any branch) to Home Assistant, with atomic swap and rollback.
+
+## Files
+
+- **deploy.sh** — shell script that runs on HA (Alpine busybox). Fetches
+  a GitHub tarball, extracts, secret-scans, swaps into place atomically,
+  records provenance (`.deployed_sha`, `.deployed_ref`, `.deployed_at`).
+  Backups go to `/config/heo2_backups/heo2.TIMESTAMP` — explicitly outside
+  `/config/custom_components/` so HA's integration loader doesn't try to
+  import them as Python modules.
+- **deploy-to-ha.ps1** — PowerShell wrapper from Archer. Uploads deploy.sh
+  via scp, runs it via ssh, then reloads the integration via Core API.
+- **rollback.sh** — restores the most recent backup from `/config/heo2_backups/`.
+- **rollback-ha.ps1** — PowerShell wrapper for rollback, with optional
+  reload or full HA restart.
+
+## Usage from Archer (PowerShell)
+
+Deploy master:
+
+```powershell
+.\scripts\deploy-to-ha.ps1
+```
+
+Deploy a specific branch for live testing (use sparingly, and only when
+HEO II is disabled in HA — HACS polling + manual deploy can race):
+
+```powershell
+.\scripts\deploy-to-ha.ps1 -Ref fix/some-branch
+```
+
+Deploy without reloading (for when HEO II is disabled):
+
+```powershell
+.\scripts\deploy-to-ha.ps1 -SkipReload
+```
+
+Rollback to the previous version:
+
+```powershell
+.\scripts\rollback-ha.ps1 -Restart
+```
+
+(Restart is usually needed after rollback because HA caches Python modules
+across config-entry reloads for custom integrations.)
+
+## Requirements
+
+- SSH key auth to `root@homeassistant2.local:2222` (HA SSH add-on).
+- Long-lived HA access token at `$env:USERPROFILE\.heo2\token`
+  (only needed for reload/restart steps, not for the bare deploy).
+- `ssh` and `scp` on PATH (OpenSSH for Windows or Git Bash).
+
+## Why this exists
+
+The HA integration loader scans every directory under
+`/config/custom_components/` as a potential Python module. Naming a
+backup `heo2.bak.TIMESTAMP` causes the loader to try to `import
+custom_components.heo2.bak` on startup, which fails and cascades into
+HEO II itself refusing to load. The scripts here put backups outside
+that scan path so backup artefacts can't brick the integration.
+
+The secret-scan in deploy.sh is belt-and-braces against accidental
+commits of real credentials. It looks for value SHAPES (UUIDs, common
+API-key prefixes) rather than names, so generic-looking variables don't
+false-positive.
+
+## Notes on HACS
+
+HACS tracking the same repo creates a race: HACS can overwrite a manual
+deploy at its own polling cadence. Recommended setup is to either:
+
+1. Remove the repo from HACS entirely (manual deploy is authoritative), or
+2. Publish tagged releases and let HACS handle updates via releases only.
+
+Don't run both HACS auto-update AND manual deploy on the same install.

--- a/scripts/deploy-to-ha.ps1
+++ b/scripts/deploy-to-ha.ps1
@@ -1,0 +1,108 @@
+# deploy-to-ha.ps1 - push HEO II master to Home Assistant and reload.
+#
+# Usage:
+#   .\deploy-to-ha.ps1
+#   .\deploy-to-ha.ps1 -Ref fix/some-branch
+#   .\deploy-to-ha.ps1 -SkipReload   # deploy only, no integration reload
+#
+# Assumes:
+#   - ssh key auth to root@homeassistant2.local:2222
+#   - HA long-lived token in $TokenPath (default C:\Users\paddy\.heo2\token)
+#   - scripts/deploy.sh present alongside this script
+[CmdletBinding()]
+param(
+    [string]$HaHost = "homeassistant2.local",
+    [int]$Port = 2222,
+    [string]$User = "root",
+    [string]$Ref = "master",
+    [string]$Repo = "a1acrity/heo2",
+    [switch]$SkipReload,
+    [string]$TokenPath = "$env:USERPROFILE\.heo2\token"
+)
+
+$ErrorActionPreference = "Stop"
+
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Definition
+$deployScript = Join-Path $scriptDir "deploy.sh"
+if (-not (Test-Path $deployScript)) {
+    throw "Missing deploy.sh at $deployScript"
+}
+
+Write-Host "=== HEO II deploy ===" -ForegroundColor Cyan
+Write-Host ("ref:        {0}" -f $Ref)
+Write-Host ("repo:       {0}" -f $Repo)
+Write-Host ("target:     {0}@{1}:{2}" -f $User, $HaHost, $Port)
+Write-Host ""
+
+# Step 1: write a LF-only copy of deploy.sh so busybox sh doesn't choke on CR.
+# Do it via .NET rather than PowerShell string piping, which re-adds CRLF.
+$lfScript = Join-Path $env:TEMP "heo2-deploy.sh"
+$content = [System.IO.File]::ReadAllText($deployScript) -replace "`r`n", "`n"
+[System.IO.File]::WriteAllText($lfScript, $content)
+
+# Step 2: scp the script to HA, then ssh and run it.
+Write-Host "Step 1: upload deploy.sh to HA"
+& scp -P $Port -o BatchMode=yes $lfScript "${User}@${HaHost}:/tmp/heo2-deploy.sh"
+if ($LASTEXITCODE -ne 0) { throw "scp failed: $LASTEXITCODE" }
+
+Write-Host "Step 2: run deploy.sh on HA"
+$remote = "REPO='$Repo' REF='$Ref' sh /tmp/heo2-deploy.sh"
+& ssh -p $Port -o BatchMode=yes "${User}@${HaHost}" $remote
+if ($LASTEXITCODE -ne 0) { throw "deploy.sh failed with exit $LASTEXITCODE" }
+
+Remove-Item $lfScript -ErrorAction SilentlyContinue
+
+if ($SkipReload) {
+    Write-Host "SkipReload set, done."
+    return
+}
+
+Write-Host ""
+Write-Host "Step 3: reload HEO II integration via Core API"
+if (-not (Test-Path $TokenPath)) {
+    throw "No token at $TokenPath - create a long-lived HA token and save there"
+}
+$token = (Get-Content $TokenPath -Raw).Trim()
+$headers = @{ Authorization = "Bearer $token" }
+$base = "http://${HaHost}:8123/api"
+
+$entries = Invoke-RestMethod -Uri "$base/config/config_entries/entry" `
+                              -Headers $headers -TimeoutSec 10
+$heo = $entries | Where-Object { $_.domain -eq "heo2" } | Select-Object -First 1
+if (-not $heo) {
+    throw "No heo2 config entry found. Is the integration set up?"
+}
+Write-Host ("HEO II entry_id: {0}" -f $heo.entry_id)
+
+$body = @{ entry_id = $heo.entry_id } | ConvertTo-Json -Compress
+Invoke-RestMethod -Uri "$base/services/homeassistant/reload_config_entry" `
+                  -Method Post -Headers $headers -Body $body `
+                  -ContentType "application/json" -TimeoutSec 30 | Out-Null
+Write-Host "Reload dispatched." -ForegroundColor Green
+
+Start-Sleep -Seconds 4
+
+Write-Host ""
+Write-Host "Step 4: health check"
+$healthy = Invoke-RestMethod -Uri "$base/states/binary_sensor.heo_ii_healthy" `
+                             -Headers $headers -TimeoutSec 10
+Write-Host ("binary_sensor.heo_ii_healthy = {0}  (lc={1})" `
+            -f $healthy.state, $healthy.last_changed)
+
+$lastRun = Invoke-RestMethod -Uri "$base/states/sensor.heo_ii_last_run" `
+                             -Headers $headers -TimeoutSec 10
+Write-Host ("sensor.heo_ii_last_run = {0}  (lc={1})" `
+            -f $lastRun.state, $lastRun.last_changed)
+
+$solar = Invoke-RestMethod -Uri "$base/states/sensor.heo_ii_solar_forecast_today" `
+                           -Headers $headers -TimeoutSec 10
+Write-Host ("sensor.heo_ii_solar_forecast_today = {0} kWh  (lc={1})" `
+            -f $solar.state, $solar.last_changed)
+
+$loadp = Invoke-RestMethod -Uri "$base/states/sensor.heo_ii_load_profile" `
+                           -Headers $headers -TimeoutSec 10
+Write-Host ("sensor.heo_ii_load_profile = {0}  (lc={1})" `
+            -f $loadp.state, $loadp.last_changed)
+
+Write-Host ""
+Write-Host "Done." -ForegroundColor Green

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,111 @@
+#!/bin/sh
+# deploy.sh - deploy HEO II from GitHub into Home Assistant.
+#
+# Runs ON the HA SSH add-on (Alpine busybox). Called by deploy-to-ha.ps1
+# from Archer, or directly via ssh.
+#
+# Steps:
+#   1. Fetch current master tarball from GitHub
+#   2. Extract to staging dir under /tmp
+#   3. Verify the extract contains the expected manifest
+#   4. Atomically swap: mv live -> live.bak.TIMESTAMP, then staged -> live
+#   5. Purge __pycache__ so Python recompiles fresh
+#   6. Print the deployed commit SHA for verification
+#
+# On any failure, old directory is restored (nothing destructive until
+# the final rename, which is atomic).
+set -eu
+
+REPO="${REPO:-a1acrity/heo2}"
+REF="${REF:-master}"
+LIVE="/config/custom_components/heo2"
+# Backups MUST live outside /config/custom_components/ or HA's integration
+# loader will try to parse their directory names as Python module paths
+# (e.g. heo2.bak.20260419 -> import heo2.bak) and crash HEO II setup.
+BAK_DIR="/config/heo2_backups"
+STAGE="/tmp/heo2-deploy-$$"
+TS=$(date +%Y%m%d-%H%M%S)
+BAK="${BAK_DIR}/heo2.${TS}"
+
+cleanup() { rm -rf "$STAGE"; }
+trap cleanup EXIT
+
+echo "[deploy] repo=$REPO ref=$REF live=$LIVE"
+
+mkdir -p "$STAGE"
+cd "$STAGE"
+
+# Resolve ref to a commit SHA so we record what we deployed
+SHA=$(wget -qO- "https://api.github.com/repos/$REPO/commits/$REF" \
+      | jq -r '.sha // empty' | head -c 40)
+if [ -z "$SHA" ]; then
+    echo "[deploy] FATAL could not resolve $REPO#$REF to a commit SHA"
+    exit 1
+fi
+echo "[deploy] resolved $REF -> $SHA"
+
+# Fetch tarball
+wget -q -O src.tar.gz "https://codeload.github.com/$REPO/tar.gz/$SHA"
+SIZE=$(wc -c < src.tar.gz)
+if [ "$SIZE" -lt 1000 ]; then
+    echo "[deploy] FATAL tarball too small ($SIZE bytes), aborting"
+    exit 1
+fi
+echo "[deploy] downloaded $SIZE bytes"
+
+tar -xzf src.tar.gz
+EXTRACTED=$(find . -maxdepth 1 -type d -name "heo2-*" | head -1)
+if [ -z "$EXTRACTED" ]; then
+    echo "[deploy] FATAL no heo2-* directory in tarball"
+    exit 1
+fi
+
+SRC="$EXTRACTED/custom_components/heo2"
+if [ ! -f "$SRC/manifest.json" ]; then
+    echo "[deploy] FATAL $SRC/manifest.json missing"
+    exit 1
+fi
+
+VERSION=$(jq -r '.version // "?"' "$SRC/manifest.json")
+echo "[deploy] staged manifest.json version=$VERSION"
+
+# Secret-scan the staged copy before we swap. If any of these patterns
+# appears in tracked .py, .yaml, or .json files something has gone badly
+# wrong and we refuse to deploy. Helps catch accidental commits of real
+# credentials instead of placeholder config. Adjust the list as new
+# integrations bring new secret shapes.
+#
+# We deliberately look for value SHAPES, not names, so generic variable
+# names like `api_key =` don't false-positive.
+SCAN=$(grep -REn \
+    -e '[A-Za-z0-9]{8}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}' \
+    -e '^[0-9]{13}$' \
+    -e 'sk_live_[A-Za-z0-9]{20,}' \
+    -e 'ghp_[A-Za-z0-9]{36,}' \
+    --include='*.py' --include='*.yaml' --include='*.yml' --include='*.json' \
+    "$SRC" 2>/dev/null || true)
+if [ -n "$SCAN" ]; then
+    echo "[deploy] FATAL secret-scan matched suspicious pattern:"
+    echo "$SCAN" | head -5
+    echo "[deploy] refusing to deploy; check the repo for leaked credentials"
+    exit 1
+fi
+
+# Record provenance in the staged copy before the swap
+echo "$SHA" > "$SRC/.deployed_sha"
+echo "$REF" > "$SRC/.deployed_ref"
+date > "$SRC/.deployed_at"
+
+# Atomic swap: rename live to backup (outside scan path), rename staged to live
+mkdir -p "$BAK_DIR"
+if [ -d "$LIVE" ]; then
+    mv "$LIVE" "$BAK"
+    echo "[deploy] backed up previous version to $BAK"
+fi
+mv "$SRC" "$LIVE"
+
+# Remove any stale pycache so Python recompiles cleanly
+rm -rf "$LIVE/__pycache__" "$LIVE/rules/__pycache__" 2>/dev/null || true
+
+echo "[deploy] OK sha=$SHA version=$VERSION backup=$BAK"
+echo "[deploy] next step: reload integration via API or restart HA"

--- a/scripts/rollback-ha.ps1
+++ b/scripts/rollback-ha.ps1
@@ -1,0 +1,83 @@
+# rollback-ha.ps1 - restore the most recent HEO II backup on Home Assistant.
+#
+# Usage:
+#   .\rollback-ha.ps1                # rollback, don't reload
+#   .\rollback-ha.ps1 -Reload        # rollback AND reload config entry
+#   .\rollback-ha.ps1 -Restart       # rollback AND restart HA (for module-cache clearing)
+#
+# Rollback always uses the most recent backup in /config/heo2_backups/.
+[CmdletBinding()]
+param(
+    [string]$HaHost = "homeassistant2.local",
+    [int]$Port = 2222,
+    [string]$User = "root",
+    [switch]$Reload,
+    [switch]$Restart,
+    [string]$TokenPath = "$env:USERPROFILE\.heo2\token"
+)
+
+$ErrorActionPreference = "Stop"
+
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Definition
+$rollbackScript = Join-Path $scriptDir "rollback.sh"
+if (-not (Test-Path $rollbackScript)) {
+    throw "Missing rollback.sh at $rollbackScript"
+}
+
+Write-Host "=== HEO II rollback ===" -ForegroundColor Yellow
+Write-Host ("target: {0}@{1}:{2}" -f $User, $HaHost, $Port)
+
+# Write LF-only copy, scp across, ssh run (same pattern as deploy-to-ha.ps1)
+$lfScript = Join-Path $env:TEMP "heo2-rollback.sh"
+$content = [System.IO.File]::ReadAllText($rollbackScript) -replace "`r`n", "`n"
+[System.IO.File]::WriteAllText($lfScript, $content)
+
+& scp -P $Port -o BatchMode=yes $lfScript "${User}@${HaHost}:/tmp/heo2-rollback.sh"
+if ($LASTEXITCODE -ne 0) { throw "scp failed: $LASTEXITCODE" }
+
+& ssh -p $Port -o BatchMode=yes "${User}@${HaHost}" "sh /tmp/heo2-rollback.sh"
+if ($LASTEXITCODE -ne 0) { throw "rollback.sh failed with exit $LASTEXITCODE" }
+
+Remove-Item $lfScript -ErrorAction SilentlyContinue
+
+if ($Restart) {
+    Write-Host ""
+    Write-Host "Restarting HA to clear module cache..." -ForegroundColor Yellow
+    $token = (Get-Content $TokenPath -Raw).Trim()
+    $headers = @{ Authorization = "Bearer $token" }
+    try {
+        Invoke-RestMethod -Uri "http://${HaHost}:8123/api/services/homeassistant/restart" `
+                          -Method Post -Headers $headers -Body "{}" `
+                          -ContentType "application/json" -TimeoutSec 10 | Out-Null
+    } catch {
+        Write-Host "(restart call timed out, which is normal — HA is stopping)"
+    }
+    Write-Host "Wait ~60s for HA to come back. Check UI for integration status."
+    return
+}
+
+if ($Reload) {
+    Write-Host ""
+    Write-Host "Reloading config entry via Core API..."
+    $token = (Get-Content $TokenPath -Raw).Trim()
+    $headers = @{ Authorization = "Bearer $token" }
+    $base = "http://${HaHost}:8123/api"
+    $entries = Invoke-RestMethod -Uri "$base/config/config_entries/entry" -Headers $headers -TimeoutSec 10
+    $heo = $entries | Where-Object { $_.domain -eq "heo2" } | Select-Object -First 1
+    if ($heo) {
+        $body = @{ entry_id = $heo.entry_id } | ConvertTo-Json -Compress
+        Invoke-RestMethod -Uri "$base/services/homeassistant/reload_config_entry" `
+                          -Method Post -Headers $headers -Body $body `
+                          -ContentType "application/json" -TimeoutSec 30 | Out-Null
+        Write-Host "Reload dispatched." -ForegroundColor Green
+        Write-Host "NOTE: reload only re-runs setup, it does NOT reload Python modules."
+        Write-Host "If you need module changes picked up, use -Restart instead."
+    } else {
+        Write-Host "No heo2 config entry found"
+    }
+    return
+}
+
+Write-Host ""
+Write-Host "Rollback complete. Neither -Reload nor -Restart set; HEO II still running old (cached) code." -ForegroundColor Yellow
+Write-Host "Use -Restart to fully activate the rolled-back code."

--- a/scripts/rollback.sh
+++ b/scripts/rollback.sh
@@ -1,0 +1,43 @@
+#!/bin/sh
+# rollback.sh - restore the most recent backup from /config/heo2_backups
+#
+# Usage on HA:  sh /tmp/rollback.sh
+# Usage from Archer: .\rollback-ha.ps1
+set -eu
+
+LIVE="/config/custom_components/heo2"
+BAK_DIR="/config/heo2_backups"
+
+if [ ! -d "$BAK_DIR" ]; then
+    echo "[rollback] no backup dir at $BAK_DIR, aborting"
+    exit 1
+fi
+
+LATEST=$(ls -1t "$BAK_DIR" 2>/dev/null | head -1)
+if [ -z "$LATEST" ]; then
+    echo "[rollback] no backups found in $BAK_DIR, aborting"
+    exit 1
+fi
+
+SRC="$BAK_DIR/$LATEST"
+if [ ! -f "$SRC/manifest.json" ]; then
+    echo "[rollback] FATAL $SRC looks malformed (no manifest.json)"
+    exit 1
+fi
+
+echo "[rollback] restoring $SRC -> $LIVE"
+TS=$(date +%Y%m%d-%H%M%S)
+mkdir -p "$BAK_DIR"
+if [ -d "$LIVE" ]; then
+    mv "$LIVE" "$BAK_DIR/heo2.pre-rollback.$TS"
+    echo "[rollback] saved current live to $BAK_DIR/heo2.pre-rollback.$TS"
+fi
+
+# Copy rather than move so the backup itself is preserved for repeat rollbacks
+cp -a "$SRC" "$LIVE"
+rm -rf "$LIVE/__pycache__" "$LIVE/rules/__pycache__" 2>/dev/null || true
+
+SHA=$(cat "$LIVE/.deployed_sha" 2>/dev/null || echo unknown)
+REF=$(cat "$LIVE/.deployed_ref" 2>/dev/null || echo unknown)
+echo "[rollback] OK restored ref=$REF sha=$SHA"
+echo "[rollback] next step: restart HA or reload the config entry"


### PR DESCRIPTION
## Summary

Adds `scripts/` with deploy and rollback tooling for the HA SSH add-on. Closes a gap where deploys were being done ad-hoc by copying files across, which earlier today caused two real production incidents.

## Why

**Incident 1 — backup-dir-as-integration crash.** Previous deploys named backups `/config/custom_components/heo2.bak.TIMESTAMP`. HA's integration loader scans every subdirectory of `custom_components/` looking for Python modules and tried to `import custom_components.heo2.bak` from each backup. Import fails, cascade, HEO II fails to set up, all sensors go `unavailable`. Fix: backups now go to `/config/heo2_backups/` outside the scan path.

**Incident 2 — module-cache stale after reload.** `homeassistant.reload_config_entry` only re-runs `async_setup_entry`, it does NOT reload Python modules. After deleting `solcast_client.py` from the repo, the running HA kept executing it from the bytecode cache and continued logging Solcast 429s for an hour. Documented in the README: use `-Restart` on the rollback wrapper (or the equivalent API call after deploy) when module changes need to land.

## What's in the box

| File | Role |
|---|---|
| `scripts/deploy.sh` | Runs on HA. Fetches tarball, secret-scans, atomic swap, writes provenance. |
| `scripts/deploy-to-ha.ps1` | Archer-side wrapper. SCP + SSH + Core API reload. |
| `scripts/rollback.sh` | Restore most recent backup. Preserves the backup by copying (repeat rollback safe). |
| `scripts/rollback-ha.ps1` | Archer-side rollback wrapper with `-Reload` or `-Restart`. |
| `scripts/README.md` | Usage, rationale, HACS guidance. |
| `.gitattributes` | Forces `*.sh` to LF so busybox on Alpine doesn't choke. |

## Features worth calling out

- **Atomic swap**: final `mv` is the only destructive step. If the fetch or scan fails, the live directory is untouched.
- **Provenance**: `.deployed_sha`, `.deployed_ref`, `.deployed_at` written into the live directory every deploy. `ssh root@ha cat /config/custom_components/heo2/.deployed_sha` always tells the truth about what's running.
- **Secret scan**: looks for value shapes (UUIDs, `sk_live_*`, `ghp_*`, 13-digit IDs) in `*.py`, `*.yaml`, `*.yml`, `*.json`. Catches accidental credential commits without false-positives on generic variable names.
- **Rollback preserves its source**: the restored backup is copied, not moved, so you can repeat the rollback or move further back if needed.
- **`-Restart` vs `-Reload`**: rollback wrapper documents that reload alone doesn't clear Python module cache, with a concrete `-Restart` flag that dispatches the full HA restart via Core API.

## What this does NOT do

- No CI integration. These are manual dev-loop tools.
- No auto-publish to HACS. If we want HACS users to get updates via HACS, we tag releases separately; the README lays out the two-pattern choice (remove-from-HACS vs tagged-releases-only) to avoid races with manual deploys.
- No secret scanning for *all* conceivable secret shapes — list is pragmatic, not exhaustive. Extend as new integrations bring new secret formats.

## Test coverage

Not applicable — these are deployment tooling, exercised by actually running them. Both scripts have been used successfully in this session's work to deploy master and a debug branch, and the path in `deploy.sh` matches the `/config/heo2_backups/` layout we cleaned up to earlier.
