### PR TITLE
fix(HEO-4): accept period_start as datetime object, not just string

### DIFF
--- a/custom_components/heo2/solar_forecast.py
+++ b/custom_components/heo2/solar_forecast.py
@@ -45,11 +45,18 @@ def solar_forecast_from_hacs(
 
     for entry in detailed_hourly:
         ts = entry.get("period_start", "")
-        try:
-            period_start = datetime.fromisoformat(ts)
-        except (ValueError, TypeError):
-            # Malformed timestamp: skip, don't fail the whole forecast.
-            continue
+        # HACS solcast_solar publishes period_start as a datetime.datetime
+        # object when read via state.attributes (it's stored as such in HA's
+        # attribute registry). When we query the sensor over REST API HA
+        # serialises it to ISO string. Accept both.
+        if isinstance(ts, datetime):
+            period_start = ts
+        else:
+            try:
+                period_start = datetime.fromisoformat(str(ts))
+            except (ValueError, TypeError):
+                # Malformed timestamp: skip, don't fail the whole forecast.
+                continue
 
         if period_start.date() != target_date:
             continue

--- a/tests/test_solar_forecast.py
+++ b/tests/test_solar_forecast.py
@@ -138,3 +138,42 @@ class TestSolarForecastFromHacs:
         # The synthetic 4x bug would have produced ~200+ kWh. The correct
         # one-day total is around 50 kWh. Set a generous ceiling at 2x.
         assert total < 100, f"Suspiciously high forecast {total} kWh, possible regression of HEO-4"
+
+    def test_period_start_as_datetime_object(self):
+        """HACS solcast delivers period_start as datetime.datetime, not a string.
+
+        When HEO II reads state.attributes.get('detailedHourly') from HA, the
+        HACS solcast integration publishes the datetime already parsed. If
+        the pure function only accepts strings, every entry is silently
+        skipped and the sum collapses to zero. This is the HEO-4 production
+        regression — tests passed because fixtures used strings, but the
+        live code path receives datetimes.
+
+        See https://github.com/a1acrity/heo2/issues/... for the investigation.
+        """
+        from datetime import datetime
+        from zoneinfo import ZoneInfo
+        london = ZoneInfo("Europe/London")
+        entries = [
+            {"period_start": datetime(2026, 4, 18, 11, 0, tzinfo=london),
+             "pv_estimate": 7.4367, "pv_estimate10": 3.0, "pv_estimate90": 10.0},
+            {"period_start": datetime(2026, 4, 18, 12, 0, tzinfo=london),
+             "pv_estimate": 7.2188, "pv_estimate10": 2.9, "pv_estimate90": 9.5},
+        ]
+        out = solar_forecast_from_hacs(entries, TARGET)
+        assert out[11] == pytest.approx(7.4367)
+        assert out[12] == pytest.approx(7.2188)
+        assert sum(out) == pytest.approx(7.4367 + 7.2188)
+
+    def test_period_start_as_datetime_naive_is_handled(self):
+        """Defensive: if a naive datetime somehow appears, don't crash."""
+        from datetime import datetime
+        entries = [
+            {"period_start": datetime(2026, 4, 18, 12, 0),
+             "pv_estimate": 5.0},
+        ]
+        # Should not raise - either gets accepted (interpreted as target_date
+        # local) or skipped cleanly. Specific behaviour can be decided, but
+        # "raises TypeError" is not acceptable.
+        out = solar_forecast_from_hacs(entries, TARGET)
+        assert len(out) == 24


### PR DESCRIPTION
## Summary

Production regression of HEO-4 caught by diagnostic logging on `debug/heo-4-5-production`.

## Root cause

HACS solcast_solar publishes `period_start` as a Python `datetime` object when accessed via `state.attributes.get('detailedHourly')`. The pure function called `datetime.fromisoformat(ts)` expecting a string; this raises `TypeError` when handed a datetime, the broad `except` caught it, and every entry was silently skipped. Result: 24 valid entries in, 0.0 kWh out.

Tests passed locally because fixtures used ISO strings. REST API access also serialises datetimes to strings, so hand-testing via curl also looked fine. Only live Python-to-Python attribute access preserves the native type.

## Fix

`isinstance(ts, datetime)` check first — accept as-is. Otherwise coerce to string and try `fromisoformat` as before. Backward compatible with the string form that tests use.

## Tests

Two new tests in `test_solar_forecast.py`:
- `test_period_start_as_datetime_object` — uses a real tz-aware datetime object (the HACS reality), fails before the fix, passes after.
- `test_period_start_as_datetime_naive_is_handled` — defensive, checks a naive datetime doesn't crash.

Suite: 200 pass → 202 pass, 0 fail.