### PR TITLE
fix(HEO-5): wrap load-profile task so exceptions surface

### DIFF
--- a/custom_components/heo2/__init__.py
+++ b/custom_components/heo2/__init__.py
@@ -30,11 +30,21 @@ async def async_setup_entry(hass, entry) -> bool:
 
     # Seed the load profile from recorder history (HEO-5). Fire-and-forget
     # so we do not block startup on a DB query. The first coordinator tick
-    # will use the flat baseline; the second and later ticks use the
-    # learned profile once this task completes.
-    hass.async_create_task(
-        coordinator.async_refresh_load_profile_from_recorder()
-    )
+    # uses the flat baseline; subsequent ticks use the learned profile
+    # once this task completes.
+    #
+    # Wrap the coroutine so exceptions surface in the log. Without the
+    # wrapper, hass.async_create_task will swallow uncaught exceptions
+    # silently and the caller has no way to see why the task did nothing.
+    async def _seed_load_profile() -> None:
+        logger.info("HEO-5 startup refresh: scheduling load-profile learn")
+        try:
+            n_days = await coordinator.async_refresh_load_profile_from_recorder()
+            logger.info("HEO-5 startup refresh: complete, %d days learned", n_days)
+        except Exception:
+            logger.exception("HEO-5 startup refresh: raised")
+
+    hass.async_create_task(_seed_load_profile())
 
     # Wire up CostTracker state-change listeners
     unsub_callbacks = []


### PR DESCRIPTION
HEO-5 was silent in production - not even the happy-path 'Load profile learned' log line appeared. hass.async_create_task(some_coro()) can swallow exceptions silently when nothing adds a done callback. Wrapping in a local async def with try/except/logger.exception forces any traceback into the log. Also adds an entry-log so 'scheduling' is visible, giving 3 possible outcomes: (a) scheduling+complete, (b) scheduling+raised+traceback, (c) nothing at all (means not even created). This makes the next diagnostic trivial.