### PR TITLE
fix(HEO-5): aggregate from cumulative-kWh meter when entity reports energy

### DIFF
--- a/custom_components/heo2/coordinator.py
+++ b/custom_components/heo2/coordinator.py
@@ -307,7 +307,25 @@ class HEO2Coordinator(DataUpdateCoordinator):
                    else "UTC")
         tz = ZoneInfo(tz_name)
 
-        days = learn_days_from_samples(samples, tz)
+        # Detect whether this entity reports instantaneous power (W) or
+        # a cumulative energy counter (kWh). Units drive the aggregator
+        # choice. Default is power_watts for backward compatibility with
+        # the original HEO-5 design.
+        entity_state = self.hass.states.get(entity_id)
+        unit = (
+            entity_state.attributes.get("unit_of_measurement", "")
+            if entity_state else ""
+        ).lower()
+        if unit in ("kwh", "mwh"):
+            source_type = "cumulative_kwh"
+        else:
+            source_type = "power_watts"
+        logger.warning(
+            "HEO-5: learning from entity=%s unit=%s source_type=%s",
+            entity_id, unit, source_type,
+        )
+
+        days = learn_days_from_samples(samples, tz, source_type=source_type)
         for d, hourly_kwh in days.items():
             # Convert date to datetime at midnight for the builder's
             # existing weekday-or-weekend branching logic.

--- a/custom_components/heo2/load_history.py
+++ b/custom_components/heo2/load_history.py
@@ -150,18 +150,33 @@ def _accumulate_interval(
 def learn_days_from_samples(
     samples: list[tuple[datetime, float]],
     tz: tzinfo,
+    source_type: str = "power_watts",
 ) -> dict[date, list[float]]:
     """Group samples by local date and aggregate each into 24 hourly kWh buckets.
 
     Returns a dict mapping each local date covered by the samples to its
     24-element hourly kWh list. Convenience wrapper for the coordinator
     so it can loop and call LoadProfileBuilder.add_day() per entry.
+
+    Args:
+        samples: list of (timestamp, value) pairs
+        tz: local timezone for day bucketing
+        source_type: either ``"power_watts"`` (the historical behaviour —
+            samples are instantaneous power readings in watts, integrated
+            trapezoidally) or ``"cumulative_kwh"`` (samples are a
+            monotonically-increasing kWh meter, aggregated by delta).
     """
     if not samples:
         return {}
 
+    if source_type == "cumulative_kwh":
+        aggregator = aggregate_cumulative_kwh_to_hourly
+    elif source_type == "power_watts":
+        aggregator = aggregate_samples_to_hourly_kwh
+    else:
+        raise ValueError(f"Unknown source_type: {source_type!r}")
+
     ordered = sorted(samples, key=lambda p: p[0])
-    # Find all local dates touched by the samples
     first_local = ordered[0][0].astimezone(tz)
     last_local = ordered[-1][0].astimezone(tz)
     dates: list[date] = []
@@ -172,7 +187,7 @@ def learn_days_from_samples(
 
     result: dict[date, list[float]] = {}
     for d in dates:
-        result[d] = aggregate_samples_to_hourly_kwh(ordered, d, tz)
+        result[d] = aggregator(ordered, d, tz)
     return result
 
 
@@ -206,3 +221,93 @@ def states_to_power_samples(states) -> list[tuple]:
         out.append((ts, watts))
     out.sort(key=lambda p: p[0])
     return out
+
+
+def aggregate_cumulative_kwh_to_hourly(
+    samples: list[tuple[datetime, float]],
+    target_date: date,
+    tz: tzinfo,
+    max_interval_seconds: float = DEFAULT_MAX_INTERVAL_SECONDS,
+) -> list[float]:
+    """Aggregate (timestamp, cumulative_kwh) samples into 24 hourly kWh values.
+
+    For entities that expose total household consumption as a monotonically
+    increasing kWh counter (``state_class: total_increasing``). The aggregator
+    computes kWh deltas between consecutive samples and prorates them across
+    the hour buckets they span.
+
+    This is the correct entity shape for learning a true household load
+    profile. It captures all consumption regardless of source (grid import,
+    PV self-consumption, or battery discharge), which is exactly what the
+    LoadProfileBuilder's median needs.
+
+    Args:
+        samples: list of (datetime_aware, cumulative_kwh) pairs.
+        target_date: the local date to aggregate for.
+        tz: timezone used to interpret ``target_date`` boundaries.
+        max_interval_seconds: intervals longer than this are dropped,
+            assuming the sensor was offline rather than genuinely flat.
+
+    Returns:
+        24 floats, index 0 is 00:00 local of ``target_date``, etc.
+
+    Notes:
+        - Meter resets (counter going down) are silently skipped for the
+          interval containing the reset. Happens on inverter restart.
+        - The kWh delta is spread across the interval linearly (constant
+          power assumption within the interval). For sub-hour sampling this
+          is equivalent to trapezoidal integration.
+    """
+    if len(samples) < 2:
+        return [0.0] * 24
+
+    ordered = sorted(samples, key=lambda p: p[0])
+
+    day_start_local = datetime(
+        target_date.year, target_date.month, target_date.day, tzinfo=tz,
+    )
+    day_end_local = day_start_local + timedelta(days=1)
+
+    hourly = [0.0] * 24
+
+    for (t1, v1), (t2, v2) in zip(ordered, ordered[1:]):
+        if t2 <= t1:
+            continue
+        interval_seconds = (t2 - t1).total_seconds()
+        if interval_seconds <= 0 or interval_seconds > max_interval_seconds:
+            continue
+
+        delta_kwh = v2 - v1
+        if delta_kwh < 0:
+            # Meter reset (e.g. inverter restart). Don't invent energy.
+            continue
+        if delta_kwh == 0:
+            continue
+
+        # Clip interval to the target day
+        a = max(t1, day_start_local)
+        b = min(t2, day_end_local)
+        if b <= a:
+            continue
+
+        # kWh per second within this interval (constant-power assumption)
+        kwh_per_second = delta_kwh / interval_seconds
+
+        # Walk hour boundaries, prorating the energy
+        cursor = a
+        while cursor < b:
+            local_cursor = cursor.astimezone(tz)
+            next_hour_local = (local_cursor + timedelta(hours=1)).replace(
+                minute=0, second=0, microsecond=0,
+            )
+            next_boundary = min(next_hour_local, b)
+            seg_secs = (next_boundary - cursor).total_seconds()
+            seg_kwh = kwh_per_second * seg_secs
+
+            hour_index = local_cursor.hour
+            if 0 <= hour_index < 24:
+                hourly[hour_index] += seg_kwh
+
+            cursor = next_boundary
+
+    return hourly

--- a/tests/test_load_history.py
+++ b/tests/test_load_history.py
@@ -265,3 +265,72 @@ class TestLearnDaysFromSamples:
         # This spans local dates 2026-04-18 and 2026-04-19
         assert date(2026, 4, 18) in result
         assert date(2026, 4, 19) in result
+
+class TestAggregateCumulativeKwhToHourly:
+    def test_empty_samples_returns_zeros(self):
+        from heo2.load_history import aggregate_cumulative_kwh_to_hourly
+        out = aggregate_cumulative_kwh_to_hourly([], date(2026, 4, 18), UTC)
+        assert out == [0.0] * 24
+
+    def test_single_sample_returns_zeros(self):
+        """One reading gives no interval to compute a delta."""
+        from heo2.load_history import aggregate_cumulative_kwh_to_hourly
+        samples = [(datetime(2026, 4, 18, 12, 0, tzinfo=UTC), 100.0)]
+        out = aggregate_cumulative_kwh_to_hourly(samples, date(2026, 4, 18), UTC)
+        assert out == [0.0] * 24
+
+    def test_one_kwh_in_one_hour(self):
+        """Meter went from 100.0 to 101.0 kWh in the hour: 1 kWh in hour 12."""
+        from heo2.load_history import aggregate_cumulative_kwh_to_hourly
+        samples = [
+            (datetime(2026, 4, 18, 12, 0, tzinfo=UTC), 100.0),
+            (datetime(2026, 4, 18, 13, 0, tzinfo=UTC), 101.0),
+        ]
+        out = aggregate_cumulative_kwh_to_hourly(samples, date(2026, 4, 18), UTC)
+        assert out[12] == pytest.approx(1.0)
+        assert sum(out) == pytest.approx(1.0)
+
+    def test_increase_spanning_hour_boundary_is_prorated(self):
+        """Meter gained 1 kWh between 12:30 and 13:30: 0.5 kWh in each hour."""
+        from heo2.load_history import aggregate_cumulative_kwh_to_hourly
+        samples = [
+            (datetime(2026, 4, 18, 12, 30, tzinfo=UTC), 100.0),
+            (datetime(2026, 4, 18, 13, 30, tzinfo=UTC), 101.0),
+        ]
+        out = aggregate_cumulative_kwh_to_hourly(samples, date(2026, 4, 18), UTC)
+        assert out[12] == pytest.approx(0.5)
+        assert out[13] == pytest.approx(0.5)
+        assert sum(out) == pytest.approx(1.0)
+
+    def test_meter_reset_is_ignored(self):
+        """If the meter counter decreases (restart, rollover), ignore that interval."""
+        from heo2.load_history import aggregate_cumulative_kwh_to_hourly
+        samples = [
+            (datetime(2026, 4, 18, 10, 0, tzinfo=UTC), 100.0),
+            (datetime(2026, 4, 18, 11, 0, tzinfo=UTC), 101.0),
+            # Counter resets to 0 (inverter restart)
+            (datetime(2026, 4, 18, 12, 0, tzinfo=UTC), 0.0),
+            (datetime(2026, 4, 18, 13, 0, tzinfo=UTC), 1.5),
+        ]
+        out = aggregate_cumulative_kwh_to_hourly(samples, date(2026, 4, 18), UTC)
+        # Hour 10 is fine (100 -> 101 = +1)
+        assert out[10] == pytest.approx(1.0)
+        # Hour 11 sees the drop 101 -> 0, ignored
+        assert out[11] == 0.0
+        # Hour 12 is fine (0 -> 1.5 = +1.5)
+        assert out[12] == pytest.approx(1.5)
+
+    def test_stale_gap_is_dropped(self):
+        """Gap > max_interval means meter was offline, don't spread delta across."""
+        from heo2.load_history import aggregate_cumulative_kwh_to_hourly
+        samples = [
+            (datetime(2026, 4, 18, 10, 0, tzinfo=UTC), 100.0),
+            # 6-hour gap
+            (datetime(2026, 4, 18, 16, 0, tzinfo=UTC), 110.0),
+        ]
+        out = aggregate_cumulative_kwh_to_hourly(
+            samples, date(2026, 4, 18), UTC,
+            max_interval_seconds=2 * 3600,
+        )
+        # Gap too long, interval dropped
+        assert sum(out) == 0.0


### PR DESCRIPTION
The load profile was still flat after PRs #22/#23. Investigation showed the configured load_power_entity (`sensor.deye_sunsynk_sol_ark_load_power`) is SIGNED net-flow in watts (range -5049 to +9909 over 3 days). The power-integration aggregator clamps negatives to zero (correct behaviour for a pure load meter, wrong for a signed net-flow entity), collapsing the profile. Correct entity is `sensor.deye_sunsynk_sol_ark_x_2_load_energy` (cumulative kWh counter, monotonic, 26 kWh/day).

Adds `aggregate_cumulative_kwh_to_hourly()` pure function with 6 tests, dispatcher in `learn_days_from_samples()`, coordinator auto-detects from entity unit_of_measurement. Entity change in config still needed separately via SSH+jq edit.