### PR TITLE
fix(HEO-2): implement MqttWriter readback via SA response_message

### DIFF
--- a/custom_components/heo2/ha_mqtt_transport.py
+++ b/custom_components/heo2/ha_mqtt_transport.py
@@ -1,0 +1,45 @@
+# custom_components/heo2/ha_mqtt_transport.py
+"""HA-side MqttTransport implementation.
+
+Wraps homeassistant.components.mqtt so MqttWriter stays pure.
+Only imported when running inside HA - tests use FakeTransport instead.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Awaitable, Callable
+
+logger = logging.getLogger(__name__)
+
+
+class HAMqttTransport:
+    """Thin adapter around HA's mqtt component.
+
+    Matches the MqttTransport protocol defined in mqtt_writer.py
+    without importing from it (avoids a circular import risk).
+    """
+
+    def __init__(self, hass: Any) -> None:
+        self._hass = hass
+
+    async def publish(self, topic: str, payload: str) -> None:
+        from homeassistant.components import mqtt
+        await mqtt.async_publish(self._hass, topic, payload, qos=0, retain=False)
+
+    async def subscribe(
+        self,
+        topic: str,
+        callback: Callable[[str, str], Awaitable[None] | None],
+    ) -> Callable[[], None]:
+        from homeassistant.components import mqtt
+
+        async def _msg_received(msg) -> None:
+            result = callback(msg.topic, msg.payload)
+            if hasattr(result, "__await__"):
+                await result
+
+        unsub = await mqtt.async_subscribe(
+            self._hass, topic, _msg_received, qos=0,
+        )
+        return unsub

--- a/custom_components/heo2/mqtt_writer.py
+++ b/custom_components/heo2/mqtt_writer.py
@@ -1,17 +1,68 @@
 # custom_components/heo2/mqtt_writer.py
-"""MQTT writer: diff-and-write with consecutive register updates. No HA imports."""
+"""MQTT writer: diff-and-write with consecutive register updates.
+
+Pure logic, no HA imports. Transport is injected via an MqttTransport
+protocol so this module can be unit-tested without HA.
+
+The writer implements the Solar Assistant set-write protocol:
+  1. Publish a value to solar_assistant/inverter_1/<setting>/set
+  2. SA applies it to the inverter over RS485
+  3. SA publishes a response on solar_assistant/set/response_message/state
+     e.g. "Set 'Capacity point 1' to '97': Saved."
+     or   "Set 'Grid charge' to 'Disabled': Error: No response."
+  4. We parse "Saved" (success) / "Error" (failure) from that response
+
+See HEO-2 and the SA MQTT docs: https://solar-assistant.io/help/integration/mqtt
+"""
 
 from __future__ import annotations
 
 import asyncio
 import logging
 from dataclasses import dataclass, field
-from typing import Any
+from datetime import time
+from typing import Any, Awaitable, Callable, Protocol
 
 from .models import ProgrammeState, SlotConfig, SlotWrite
 from .const import MQTT_WRITE_TIMEOUT_SECONDS, MQTT_MAX_RETRIES
 
 logger = logging.getLogger(__name__)
+
+
+# Human-readable SA setting name used inside the response_message text.
+# SA capitalises and spaces out the name ("Capacity point 1", not
+# "capacity_point_1"). We need this to parse responses.
+_SETTING_DISPLAY_NAME = {
+    "capacity": "Capacity point {n}",
+    "time": "Time point {n}",
+    "grid_charge": "Grid charge point {n}",
+}
+
+# SA's MQTT topic stem for each settable parameter.
+_SETTING_TOPIC_STEM = {
+    "capacity": "capacity_point_{n}",
+    "time": "time_point_{n}",
+    "grid_charge": "grid_charge_point_{n}",
+}
+
+
+class MqttTransport(Protocol):
+    """Minimal async MQTT transport the writer needs.
+
+    HA wiring will wrap homeassistant.components.mqtt to satisfy this.
+    Tests wire up a fake.
+    """
+
+    async def publish(self, topic: str, payload: str) -> None: ...
+
+    async def subscribe(
+        self,
+        topic: str,
+        callback: Callable[[str, str], Awaitable[None] | None],
+    ) -> Callable[[], None]:
+        """Subscribe to `topic`. `callback(topic, payload)` is called on
+        each incoming message. Returns an unsubscribe callable."""
+        ...
 
 
 @dataclass
@@ -22,36 +73,97 @@ class MqttWriteResult:
     writes_confirmed: int = 0
     failed_slot: int | None = None
     failed_param: str | None = None
+    failed_reason: str | None = None
     dry_run_log: list[str] = field(default_factory=list)
 
 
-class MqttWriter:
-    """Diff new programme against current and write changed registers.
+def format_time(t: time | str) -> str:
+    """SA expects HH:MM. Accept a time or a string."""
+    if isinstance(t, time):
+        return t.strftime("%H:%M")
+    return str(t)
 
-    Writes are consecutive: each register is published, then we wait for
-    read-back confirmation before proceeding to the next.
+
+def format_grid_charge(enabled: bool) -> str:
+    """SA expects 'Enabled' / 'Disabled' as the setting value."""
+    return "Enabled" if enabled else "Disabled"
+
+
+def parse_response_message(
+    response: str, expected_setting: str,
+) -> tuple[bool, str | None]:
+    """Parse an SA response_message payload.
+
+    Returns (success, error_detail_or_none). `success` is True iff the
+    response is for the expected setting and ends with ": Saved."
+    Any other outcome (Error, different setting, malformed) is False.
+
+    SA format observed in production:
+        Set 'Capacity point 1' to '97': Saved.
+        Set 'Grid charge' to 'Disabled': Error: No response.
+    """
+    if not response or "Set '" not in response:
+        return False, f"malformed response: {response!r}"
+
+    if expected_setting not in response:
+        # Response is for some other concurrent write; not ours
+        return False, f"response for different setting: {response!r}"
+
+    if response.rstrip(".").endswith("Saved"):
+        return True, None
+
+    # Everything else is an error; extract the detail after "Error:"
+    marker = "Error:"
+    if marker in response:
+        detail = response[response.index(marker) + len(marker):].strip().rstrip(".")
+        return False, detail
+    return False, f"unknown failure: {response!r}"
+
+
+class MqttWriter:
+    """Diff new programme against current and write changed registers
+    via Solar Assistant's MQTT set-topics.
+
+    Writes are consecutive. After each publish we wait for SA's
+    response_message with a timeout. A "Saved" response short-circuits
+    the wait. An "Error:" response fails the write immediately (no
+    retry, since SA already tried and failed to reach the inverter).
+    A timeout (no response at all) triggers a retry.
     """
 
     def __init__(
         self,
-        client: Any,
+        transport: MqttTransport | None = None,
         base_topic: str = "solar_assistant",
+        inverter_name: str = "inverter_1",
         dry_run: bool = False,
+        *,
+        client: Any = None,  # legacy name, accepted for migration
     ):
-        self._client = client
+        # Accept either `transport` or `client` for backward compatibility
+        # with older tests that passed a MagicMock().
+        self._transport = transport if transport is not None else client
         self._base_topic = base_topic
+        self._inverter = inverter_name
         self._dry_run = dry_run
 
-    def _topic(self, slot_num: int, param: str) -> str:
-        """Build MQTT topic for a slot register."""
-        return f"{self._base_topic}/inverter_1/prog{slot_num}_{param}/set"
+    # --- topic builders -------------------------------------------------
 
-    def _readback_topic(self, slot_num: int, param: str) -> str:
-        """Build MQTT topic for reading back a slot register."""
-        return f"{self._base_topic}/inverter_1/prog{slot_num}_{param}"
+    def _set_topic(self, param: str, slot_num: int) -> str:
+        stem = _SETTING_TOPIC_STEM[param].format(n=slot_num)
+        return f"{self._base_topic}/{self._inverter}/{stem}/set"
+
+    def _response_topic(self) -> str:
+        return f"{self._base_topic}/set/response_message/state"
+
+    def _setting_display(self, param: str, slot_num: int) -> str:
+        return _SETTING_DISPLAY_NAME[param].format(n=slot_num)
+
+
+    # --- diff -----------------------------------------------------------
 
     def diff(self, current: ProgrammeState, new: ProgrammeState) -> list[SlotWrite]:
-        """Compare two programmes and return a list of register writes needed."""
+        """Compare two programmes and return a list of register writes."""
         writes: list[SlotWrite] = []
 
         for i in range(6):
@@ -75,75 +187,137 @@ class MqttWriter:
 
         return writes
 
-    async def write_registers(self, writes: list[SlotWrite]) -> MqttWriteResult:
-        """Write register changes consecutively with read-back verification."""
-        result = MqttWriteResult(writes_attempted=0)
+    # --- per-slot op enumeration ---------------------------------------
 
-        for write in writes:
-            register_ops = self._build_register_ops(write)
-
-            for topic, payload, readback_topic, expected in register_ops:
-                result.writes_attempted += 1
-
-                if self._dry_run:
-                    result.dry_run_log.append(f"Would write {topic} = {payload}")
-                    result.writes_confirmed += 1
-                    continue
-
-                confirmed = False
-                for attempt in range(1, MQTT_MAX_RETRIES + 1):
-                    await self._publish(topic, payload)
-                    ok = await self._wait_for_readback(
-                        readback_topic, expected, MQTT_WRITE_TIMEOUT_SECONDS
-                    )
-                    if ok:
-                        confirmed = True
-                        result.writes_confirmed += 1
-                        break
-
-                if not confirmed:
-                    param = topic.split("/")[-2].split("_", 1)[1] if "/" in topic else "unknown"
-                    result.success = False
-                    result.failed_slot = write.slot_number
-                    result.failed_param = param
-                    return result
-
-        result.success = True
-        return result
-
-    def _build_register_ops(self, write: SlotWrite) -> list[tuple[str, str, str, str]]:
-        """Build (set_topic, payload, readback_topic, expected_value) tuples."""
-        ops = []
+    def _ops_for_slot(self, write: SlotWrite) -> list[tuple[str, str, str, str]]:
+        """Return (param_key, set_topic, payload, setting_display) tuples
+        for each actual change in `write`."""
+        ops: list[tuple[str, str, str, str]] = []
         n = write.slot_number
 
         if write.capacity_soc is not None:
             ops.append((
-                self._topic(n, "capacity"),
+                "capacity",
+                self._set_topic("capacity", n),
                 str(write.capacity_soc),
-                self._readback_topic(n, "capacity"),
-                str(write.capacity_soc),
+                self._setting_display("capacity", n),
             ))
         if write.time_point is not None:
             ops.append((
-                self._topic(n, "time"),
-                write.time_point,
-                self._readback_topic(n, "time"),
-                write.time_point,
+                "time",
+                self._set_topic("time", n),
+                format_time(write.time_point),
+                self._setting_display("time", n),
             ))
         if write.grid_charge is not None:
-            payload = "true" if write.grid_charge else "false"
             ops.append((
-                self._topic(n, "charge"),
-                payload,
-                self._readback_topic(n, "charge"),
-                payload,
+                "grid_charge",
+                self._set_topic("grid_charge", n),
+                format_grid_charge(write.grid_charge),
+                self._setting_display("grid_charge", n),
             ))
         return ops
 
-    async def _publish(self, topic: str, payload: str) -> None:
-        """Publish a message. Override in tests."""
-        self._client.publish(topic, payload)
 
-    async def _wait_for_readback(self, topic: str, expected: str, timeout: float) -> bool:
-        """Wait for a read-back message matching expected value. Override in tests."""
-        raise NotImplementedError("Wire up MQTT subscription in HA integration")
+    # --- the actual write orchestration --------------------------------
+
+    async def write_registers(self, writes: list[SlotWrite]) -> MqttWriteResult:
+        """Publish each setting change and wait for SA to confirm each
+        one via response_message. Returns on first unrecoverable failure
+        or when all writes are confirmed."""
+        result = MqttWriteResult(writes_attempted=0)
+
+        if self._dry_run:
+            for write in writes:
+                for _, topic, payload, _ in self._ops_for_slot(write):
+                    result.writes_attempted += 1
+                    result.dry_run_log.append(f"Would publish {topic} = {payload}")
+                    result.writes_confirmed += 1
+            result.success = True
+            return result
+
+        # Subscribe to the response topic ONCE for the whole batch. Each
+        # write temporarily attaches its own future to the subscription
+        # handler via the shared self._response_futures dict.
+        self._response_futures: dict[str, asyncio.Future[tuple[bool, str | None]]] = {}
+
+        async def _on_response(topic: str, payload: str) -> None:
+            for setting_display, fut in list(self._response_futures.items()):
+                if fut.done():
+                    continue
+                if setting_display in payload:
+                    ok, detail = parse_response_message(payload, setting_display)
+                    if not fut.done():
+                        fut.set_result((ok, detail))
+
+        unsubscribe = await self._transport.subscribe(
+            self._response_topic(), _on_response,
+        )
+        try:
+            for write in writes:
+                for param, topic, payload, setting_display in self._ops_for_slot(write):
+                    result.writes_attempted += 1
+                    ok, reason = await self._publish_and_confirm(
+                        topic, payload, setting_display,
+                    )
+                    if ok:
+                        result.writes_confirmed += 1
+                    else:
+                        result.success = False
+                        result.failed_slot = write.slot_number
+                        result.failed_param = param
+                        result.failed_reason = reason
+                        return result
+            result.success = True
+            return result
+        finally:
+            unsubscribe()
+
+
+    async def _publish_and_confirm(
+        self, topic: str, payload: str, setting_display: str,
+    ) -> tuple[bool, str | None]:
+        """Publish once and wait for response. Retry on timeout only
+        (not on Error responses, since SA already tried and reported
+        failure from the inverter end).
+
+        Returns (success, reason_if_failed).
+        """
+        last_reason: str | None = None
+
+        for attempt in range(1, MQTT_MAX_RETRIES + 1):
+            fut: asyncio.Future[tuple[bool, str | None]] = asyncio.get_event_loop().create_future()
+            self._response_futures[setting_display] = fut
+
+            try:
+                await self._transport.publish(topic, payload)
+
+                try:
+                    ok, detail = await asyncio.wait_for(
+                        fut, timeout=MQTT_WRITE_TIMEOUT_SECONDS,
+                    )
+                except asyncio.TimeoutError:
+                    last_reason = f"no response within {MQTT_WRITE_TIMEOUT_SECONDS}s"
+                    logger.warning(
+                        "HEO-2: %s attempt %d/%d timeout on %s",
+                        setting_display, attempt, MQTT_MAX_RETRIES, topic,
+                    )
+                    continue
+
+                if ok:
+                    logger.info(
+                        "HEO-2: %s confirmed (attempt %d)",
+                        setting_display, attempt,
+                    )
+                    return True, None
+                else:
+                    # Explicit Error from SA. No retry.
+                    logger.warning(
+                        "HEO-2: %s rejected by SA: %s",
+                        setting_display, detail,
+                    )
+                    return False, detail
+            finally:
+                self._response_futures.pop(setting_display, None)
+
+        return False, last_reason

--- a/tests/test_mqtt_writer.py
+++ b/tests/test_mqtt_writer.py
@@ -1,226 +1,412 @@
 # tests/test_mqtt_writer.py
-"""Tests for MQTT diff-and-write logic."""
+"""Tests for MQTT diff-and-write logic.
+
+The writer publishes to Solar Assistant's `/set` topics and waits for
+SA's `response_message/state` topic to say "Saved" or "Error: ...".
+
+Tests use a FakeTransport to script responses without touching real MQTT.
+"""
 
 import asyncio
 from datetime import time
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 
 from heo2.models import SlotConfig, ProgrammeState, SlotWrite
-from heo2.mqtt_writer import MqttWriter, MqttWriteResult
+from heo2.mqtt_writer import (
+    MqttWriter,
+    MqttWriteResult,
+    parse_response_message,
+    format_grid_charge,
+    format_time,
+)
 
+
+# -----------------------------------------------------------------------
+# Fake transport: scripts response_message replies for publish calls.
+# -----------------------------------------------------------------------
+
+class FakeTransport:
+    """Async MQTT transport stub.
+
+    Records every publish. After each publish, optionally dispatches a
+    scripted response to whoever is subscribed to response_message/state.
+
+    Usage:
+        transport = FakeTransport()
+        transport.script_responses([
+            "Set 'Capacity point 1' to '95': Saved.",
+            "Set 'Grid charge point 2' to 'Enabled': Saved.",
+        ])
+    """
+
+    def __init__(self):
+        self.published: list[tuple[str, str]] = []
+        self._subscribers: dict[str, list] = {}
+        self._scripted: list[str | None] = []  # None means "no response"
+
+    def script_responses(self, responses: list[str | None]) -> None:
+        self._scripted = list(responses)
+
+    async def publish(self, topic: str, payload: str) -> None:
+        self.published.append((topic, payload))
+        # Simulate SA receiving the publish, processing it, and replying.
+        if self._scripted:
+            reply = self._scripted.pop(0)
+            if reply is not None:
+                await self._deliver("solar_assistant/set/response_message/state", reply)
+
+    async def _deliver(self, topic: str, payload: str) -> None:
+        # Yield once so the waiting coroutine can attach its future first.
+        await asyncio.sleep(0)
+        for cb in self._subscribers.get(topic, []):
+            result = cb(topic, payload)
+            if asyncio.iscoroutine(result):
+                await result
+
+    async def subscribe(self, topic: str, callback) -> callable:
+        self._subscribers.setdefault(topic, []).append(callback)
+        def _unsub():
+            if callback in self._subscribers.get(topic, []):
+                self._subscribers[topic].remove(callback)
+        return _unsub
+
+
+# Helper to build a consistent baseline programme
+def _baseline_programme(**overrides) -> ProgrammeState:
+    slots = [
+        SlotConfig(time(0, 0), time(5, 30), 100, True),
+        SlotConfig(time(5, 30), time(18, 30), 100, False),
+        SlotConfig(time(18, 30), time(23, 30), 20, False),
+        SlotConfig(time(23, 30), time(23, 57), 100, True),
+        SlotConfig(time(23, 57), time(23, 58), 20, False),
+        SlotConfig(time(23, 58), time(0, 0), 20, False),
+    ]
+    return ProgrammeState(slots=slots, reason_log=[])
+
+
+# -----------------------------------------------------------------------
+# Diff tests - pure logic, no transport needed
+# -----------------------------------------------------------------------
 
 class TestDiffProgramme:
     def test_no_changes_returns_empty(self):
-        current = ProgrammeState(
-            slots=[
-                SlotConfig(time(0, 0), time(5, 30), 100, True),
-                SlotConfig(time(5, 30), time(18, 30), 100, False),
-                SlotConfig(time(18, 30), time(23, 30), 20, False),
-                SlotConfig(time(23, 30), time(23, 57), 100, True),
-                SlotConfig(time(23, 57), time(23, 58), 20, False),
-                SlotConfig(time(23, 58), time(0, 0), 20, False),
-            ],
-            reason_log=[],
-        )
-        new = ProgrammeState(
-            slots=[s.__class__(s.start_time, s.end_time, s.capacity_soc, s.grid_charge)
-                   for s in current.slots],
-            reason_log=[],
-        )
-        writer = MqttWriter(client=MagicMock(), base_topic="solar_assistant")
-        writes = writer.diff(current, new)
-        assert writes == []
+        current = _baseline_programme()
+        new = _baseline_programme()
+        writer = MqttWriter(client=MagicMock())
+        assert writer.diff(current, new) == []
 
     def test_soc_change_detected(self):
-        current = ProgrammeState(
-            slots=[
-                SlotConfig(time(0, 0), time(5, 30), 100, True),
-                SlotConfig(time(5, 30), time(18, 30), 100, False),
-                SlotConfig(time(18, 30), time(23, 30), 20, False),
-                SlotConfig(time(23, 30), time(23, 57), 100, True),
-                SlotConfig(time(23, 57), time(23, 58), 20, False),
-                SlotConfig(time(23, 58), time(0, 0), 20, False),
-            ],
-            reason_log=[],
-        )
-        new = ProgrammeState(
-            slots=[
-                SlotConfig(time(0, 0), time(5, 30), 80, True),
-                SlotConfig(time(5, 30), time(18, 30), 100, False),
-                SlotConfig(time(18, 30), time(23, 30), 20, False),
-                SlotConfig(time(23, 30), time(23, 57), 80, True),
-                SlotConfig(time(23, 57), time(23, 58), 20, False),
-                SlotConfig(time(23, 58), time(0, 0), 20, False),
-            ],
-            reason_log=[],
-        )
-        writer = MqttWriter(client=MagicMock(), base_topic="solar_assistant")
+        current = _baseline_programme()
+        new = _baseline_programme()
+        new.slots[0] = SlotConfig(time(0, 0), time(5, 30), 80, True)
+        writer = MqttWriter(client=MagicMock())
         writes = writer.diff(current, new)
-        soc_writes = [w for w in writes if w.capacity_soc is not None]
-        assert len(soc_writes) == 2
-        assert soc_writes[0].slot_number == 1
-        assert soc_writes[0].capacity_soc == 80
+        assert len(writes) == 1
+        assert writes[0].slot_number == 1
+        assert writes[0].capacity_soc == 80
+        assert writes[0].time_point is None
+        assert writes[0].grid_charge is None
 
     def test_time_change_detected(self):
-        current = ProgrammeState(
-            slots=[
-                SlotConfig(time(0, 0), time(5, 30), 100, True),
-                SlotConfig(time(5, 30), time(18, 30), 100, False),
-                SlotConfig(time(18, 30), time(23, 30), 20, False),
-                SlotConfig(time(23, 30), time(23, 57), 100, True),
-                SlotConfig(time(23, 57), time(23, 58), 20, False),
-                SlotConfig(time(23, 58), time(0, 0), 20, False),
-            ],
-            reason_log=[],
-        )
-        new = ProgrammeState(
-            slots=[
-                SlotConfig(time(0, 0), time(6, 0), 100, True),
-                SlotConfig(time(6, 0), time(18, 30), 100, False),
-                SlotConfig(time(18, 30), time(23, 30), 20, False),
-                SlotConfig(time(23, 30), time(23, 57), 100, True),
-                SlotConfig(time(23, 57), time(23, 58), 20, False),
-                SlotConfig(time(23, 58), time(0, 0), 20, False),
-            ],
-            reason_log=[],
-        )
-        writer = MqttWriter(client=MagicMock(), base_topic="solar_assistant")
+        current = _baseline_programme()
+        new = _baseline_programme()
+        new.slots[1] = SlotConfig(time(5, 30), time(19, 0), 100, False)
+        writer = MqttWriter(client=MagicMock())
         writes = writer.diff(current, new)
-        time_writes = [w for w in writes if w.time_point is not None]
-        assert len(time_writes) >= 1
+        assert len(writes) == 1
+        assert writes[0].slot_number == 2
+        assert writes[0].time_point == "19:00"
+        assert writes[0].capacity_soc is None
 
     def test_grid_charge_change_detected(self):
-        current = ProgrammeState(
-            slots=[
-                SlotConfig(time(0, 0), time(5, 30), 100, True),
-                SlotConfig(time(5, 30), time(18, 30), 100, False),
-                SlotConfig(time(18, 30), time(23, 30), 20, False),
-                SlotConfig(time(23, 30), time(23, 57), 100, True),
-                SlotConfig(time(23, 57), time(23, 58), 20, False),
-                SlotConfig(time(23, 58), time(0, 0), 20, False),
-            ],
-            reason_log=[],
-        )
-        new = ProgrammeState(
-            slots=[
-                SlotConfig(time(0, 0), time(5, 30), 100, True),
-                SlotConfig(time(5, 30), time(18, 30), 100, True),
-                SlotConfig(time(18, 30), time(23, 30), 20, False),
-                SlotConfig(time(23, 30), time(23, 57), 100, True),
-                SlotConfig(time(23, 57), time(23, 58), 20, False),
-                SlotConfig(time(23, 58), time(0, 0), 20, False),
-            ],
-            reason_log=[],
-        )
-        writer = MqttWriter(client=MagicMock(), base_topic="solar_assistant")
+        current = _baseline_programme()
+        new = _baseline_programme()
+        new.slots[2] = SlotConfig(time(18, 30), time(23, 30), 20, True)
+        writer = MqttWriter(client=MagicMock())
         writes = writer.diff(current, new)
-        gc_writes = [w for w in writes if w.grid_charge is not None]
-        assert len(gc_writes) == 1
-        assert gc_writes[0].slot_number == 2
-        assert gc_writes[0].grid_charge is True
+        assert len(writes) == 1
+        assert writes[0].slot_number == 3
+        assert writes[0].grid_charge is True
+        assert writes[0].capacity_soc is None
 
+
+# -----------------------------------------------------------------------
+# Topic generation - SA's real naming scheme
+# -----------------------------------------------------------------------
+
+class TestTopicGeneration:
+    def test_capacity_topic_is_capacity_point_n(self):
+        writer = MqttWriter(client=MagicMock())
+        assert writer._set_topic("capacity", 3) == "solar_assistant/inverter_1/capacity_point_3/set"
+
+    def test_time_topic_is_time_point_n(self):
+        writer = MqttWriter(client=MagicMock())
+        assert writer._set_topic("time", 1) == "solar_assistant/inverter_1/time_point_1/set"
+
+    def test_grid_charge_topic_is_grid_charge_point_n(self):
+        writer = MqttWriter(client=MagicMock())
+        assert writer._set_topic("grid_charge", 6) == "solar_assistant/inverter_1/grid_charge_point_6/set"
+
+    def test_custom_inverter_name(self):
+        """A second SA instance (e.g. for inverter 2 via RS232) could
+        use a different inverter_name. Writer must support that."""
+        writer = MqttWriter(client=MagicMock(), inverter_name="inverter_2")
+        assert writer._set_topic("capacity", 1) == "solar_assistant/inverter_2/capacity_point_1/set"
+
+    def test_response_topic(self):
+        writer = MqttWriter(client=MagicMock())
+        assert writer._response_topic() == "solar_assistant/set/response_message/state"
+
+
+# -----------------------------------------------------------------------
+# Formatters
+# -----------------------------------------------------------------------
+
+class TestFormatters:
+    def test_format_grid_charge_true_is_Enabled(self):
+        assert format_grid_charge(True) == "Enabled"
+
+    def test_format_grid_charge_false_is_Disabled(self):
+        assert format_grid_charge(False) == "Disabled"
+
+    def test_format_time_accepts_time_object(self):
+        assert format_time(time(23, 30)) == "23:30"
+
+    def test_format_time_passes_strings_through(self):
+        assert format_time("05:30") == "05:30"
+
+
+# -----------------------------------------------------------------------
+# parse_response_message - pure function covering SA's actual formats
+# -----------------------------------------------------------------------
+
+class TestParseResponseMessage:
+    def test_saved_returns_success(self):
+        ok, reason = parse_response_message(
+            "Set 'Capacity point 1' to '97': Saved.",
+            "Capacity point 1",
+        )
+        assert ok is True
+        assert reason is None
+
+    def test_saved_without_trailing_period(self):
+        """Defensive - some SA variants may omit the trailing dot."""
+        ok, reason = parse_response_message(
+            "Set 'Capacity point 1' to '97': Saved",
+            "Capacity point 1",
+        )
+        assert ok is True
+
+    def test_error_no_response_is_failure(self):
+        """Live SA log shows this error shape verbatim."""
+        ok, reason = parse_response_message(
+            "Set 'Grid charge' to 'Disabled': Error: No response.",
+            "Grid charge",
+        )
+        assert ok is False
+        assert reason == "No response"
+
+    def test_error_with_explanation_captures_detail(self):
+        ok, reason = parse_response_message(
+            "Set 'Work mode' to 'Selling first': Error: Value rejected by inverter.",
+            "Work mode",
+        )
+        assert ok is False
+        assert "rejected" in reason
+
+    def test_response_for_different_setting_is_failure(self):
+        """If SA responds about something else, don't claim our success."""
+        ok, reason = parse_response_message(
+            "Set 'Energy pattern' to 'Battery first': Saved.",
+            "Capacity point 1",
+        )
+        assert ok is False
+        assert "different setting" in reason
+
+    def test_empty_response_is_failure(self):
+        ok, reason = parse_response_message("", "Capacity point 1")
+        assert ok is False
+
+    def test_malformed_response_is_failure(self):
+        ok, reason = parse_response_message(
+            "something else entirely",
+            "Capacity point 1",
+        )
+        assert ok is False
+        assert "malformed" in reason
+
+
+# -----------------------------------------------------------------------
+# write_registers integration - using FakeTransport
+# -----------------------------------------------------------------------
 
 class TestWriteRegisters:
     @pytest.mark.asyncio
-    async def test_writes_consecutively(self):
-        """Each register write must complete before the next starts."""
-        call_order = []
+    async def test_happy_path_capacity_write_confirmed(self):
+        transport = FakeTransport()
+        transport.script_responses([
+            "Set 'Capacity point 1' to '80': Saved.",
+        ])
+        writer = MqttWriter(transport=transport)
 
-        async def mock_publish(topic, payload):
-            call_order.append(("pub", topic))
-
-        async def mock_wait_readback(topic, expected, timeout):
-            call_order.append(("read", topic))
-            return True
-
-        writer = MqttWriter(client=MagicMock(), base_topic="solar_assistant")
-        writer._publish = mock_publish
-        writer._wait_for_readback = mock_wait_readback
-
-        writes = [
+        result = await writer.write_registers([
             SlotWrite(slot_number=1, capacity_soc=80),
+        ])
+
+        assert result.success is True
+        assert result.writes_attempted == 1
+        assert result.writes_confirmed == 1
+        assert len(transport.published) == 1
+        assert transport.published[0] == (
+            "solar_assistant/inverter_1/capacity_point_1/set",
+            "80",
+        )
+
+    @pytest.mark.asyncio
+    async def test_grid_charge_serialised_as_Enabled_or_Disabled(self):
+        transport = FakeTransport()
+        transport.script_responses([
+            "Set 'Grid charge point 2' to 'Enabled': Saved.",
+        ])
+        writer = MqttWriter(transport=transport)
+
+        await writer.write_registers([
             SlotWrite(slot_number=2, grid_charge=True),
-        ]
+        ])
 
-        result = await writer.write_registers(writes)
-        assert result.success is True
-        assert call_order[0][0] == "pub"
-        assert call_order[1][0] == "read"
-        assert call_order[2][0] == "pub"
-        assert call_order[3][0] == "read"
+        _topic, payload = transport.published[0]
+        assert payload == "Enabled"
 
     @pytest.mark.asyncio
-    async def test_retries_on_readback_failure(self):
-        """Retries up to 3 times on read-back timeout."""
-        attempt_count = 0
+    async def test_multiple_slots_published_in_order(self):
+        transport = FakeTransport()
+        transport.script_responses([
+            "Set 'Capacity point 1' to '80': Saved.",
+            "Set 'Grid charge point 3' to 'Enabled': Saved.",
+        ])
+        writer = MqttWriter(transport=transport)
 
-        async def mock_publish(topic, payload):
-            pass
-
-        async def mock_wait_readback(topic, expected, timeout):
-            nonlocal attempt_count
-            attempt_count += 1
-            return attempt_count >= 3
-
-        writer = MqttWriter(client=MagicMock(), base_topic="solar_assistant")
-        writer._publish = mock_publish
-        writer._wait_for_readback = mock_wait_readback
-
-        writes = [SlotWrite(slot_number=1, capacity_soc=80)]
-        result = await writer.write_registers(writes)
-        assert result.success is True
-        assert attempt_count == 3
-
-    @pytest.mark.asyncio
-    async def test_aborts_on_persistent_failure(self):
-        """After 3 failed retries, abort remaining writes."""
-        async def mock_publish(topic, payload):
-            pass
-
-        async def mock_wait_readback(topic, expected, timeout):
-            return False
-
-        writer = MqttWriter(client=MagicMock(), base_topic="solar_assistant")
-        writer._publish = mock_publish
-        writer._wait_for_readback = mock_wait_readback
-
-        writes = [
+        result = await writer.write_registers([
             SlotWrite(slot_number=1, capacity_soc=80),
-            SlotWrite(slot_number=2, capacity_soc=60),
-        ]
-        result = await writer.write_registers(writes)
+            SlotWrite(slot_number=3, grid_charge=True),
+        ])
+
+        assert result.success is True
+        assert result.writes_confirmed == 2
+        assert len(transport.published) == 2
+        # Writes happen in the order specified
+        assert "capacity_point_1" in transport.published[0][0]
+        assert "grid_charge_point_3" in transport.published[1][0]
+
+
+    @pytest.mark.asyncio
+    async def test_error_response_fails_immediately_no_retry(self):
+        """When SA says 'Error: No response', the inverter already tried
+        and rejected. No point retrying - fail fast."""
+        transport = FakeTransport()
+        transport.script_responses([
+            "Set 'Capacity point 1' to '80': Error: No response.",
+        ])
+        writer = MqttWriter(transport=transport)
+
+        result = await writer.write_registers([
+            SlotWrite(slot_number=1, capacity_soc=80),
+        ])
+
         assert result.success is False
         assert result.failed_slot == 1
+        assert result.failed_param == "capacity"
+        assert result.failed_reason == "No response"
+        # Only one publish happened - no retry on Error
+        assert len(transport.published) == 1
+
+    @pytest.mark.asyncio
+    async def test_timeout_triggers_retry_then_success(self, monkeypatch):
+        """If no response arrives in time, retry up to MQTT_MAX_RETRIES."""
+        # Shorten the timeout so the test finishes quickly
+        monkeypatch.setattr(
+            "heo2.mqtt_writer.MQTT_WRITE_TIMEOUT_SECONDS", 0.05
+        )
+        transport = FakeTransport()
+        transport.script_responses([
+            None,  # first attempt: no response
+            "Set 'Capacity point 1' to '80': Saved.",  # second: success
+        ])
+        writer = MqttWriter(transport=transport)
+
+        result = await writer.write_registers([
+            SlotWrite(slot_number=1, capacity_soc=80),
+        ])
+
+        assert result.success is True
+        # Two publishes: original + one retry
+        assert len(transport.published) == 2
+
+    @pytest.mark.asyncio
+    async def test_all_retries_timeout_is_failure(self, monkeypatch):
+        monkeypatch.setattr(
+            "heo2.mqtt_writer.MQTT_WRITE_TIMEOUT_SECONDS", 0.05
+        )
+        monkeypatch.setattr("heo2.mqtt_writer.MQTT_MAX_RETRIES", 3)
+        transport = FakeTransport()
+        transport.script_responses([None, None, None])  # all silent
+        writer = MqttWriter(transport=transport)
+
+        result = await writer.write_registers([
+            SlotWrite(slot_number=1, capacity_soc=80),
+        ])
+
+        assert result.success is False
+        assert result.failed_slot == 1
+        assert "no response" in (result.failed_reason or "").lower()
+        assert len(transport.published) == 3
+
+
+    @pytest.mark.asyncio
+    async def test_later_slot_not_published_if_earlier_fails(self):
+        """On failure of slot 1, slot 2 must not be attempted.
+        Partial writes would leave the inverter in an inconsistent state."""
+        transport = FakeTransport()
+        transport.script_responses([
+            "Set 'Capacity point 1' to '80': Error: Inverter rejected.",
+            # No second response scripted - we should never get here
+        ])
+        writer = MqttWriter(transport=transport)
+
+        result = await writer.write_registers([
+            SlotWrite(slot_number=1, capacity_soc=80),
+            SlotWrite(slot_number=2, capacity_soc=60),
+        ])
+
+        assert result.success is False
+        assert result.failed_slot == 1
+        # Slot 2 never got published
+        assert len(transport.published) == 1
+        assert "capacity_point_1" in transport.published[0][0]
 
     @pytest.mark.asyncio
     async def test_dry_run_logs_without_publishing(self):
-        """Dry-run mode: log what would be written, don't publish."""
-        published = []
+        transport = FakeTransport()
+        writer = MqttWriter(transport=transport, dry_run=True)
 
-        async def mock_publish(topic, payload):
-            published.append(topic)
+        result = await writer.write_registers([
+            SlotWrite(slot_number=1, capacity_soc=80),
+        ])
 
-        writer = MqttWriter(client=MagicMock(), base_topic="solar_assistant", dry_run=True)
-        writer._publish = mock_publish
-
-        writes = [SlotWrite(slot_number=1, capacity_soc=80)]
-        result = await writer.write_registers(writes)
         assert result.success is True
-        assert len(published) == 0
+        assert result.writes_confirmed == 1
+        assert len(transport.published) == 0
         assert len(result.dry_run_log) == 1
+        assert "Would publish" in result.dry_run_log[0]
+        assert "capacity_point_1" in result.dry_run_log[0]
 
-
-class TestTopicGeneration:
-    def test_capacity_topic(self):
-        writer = MqttWriter(client=MagicMock(), base_topic="solar_assistant")
-        assert writer._topic(3, "capacity") == "solar_assistant/inverter_1/prog3_capacity/set"
-
-    def test_time_topic(self):
-        writer = MqttWriter(client=MagicMock(), base_topic="solar_assistant")
-        assert writer._topic(1, "time") == "solar_assistant/inverter_1/prog1_time/set"
-
-    def test_charge_topic(self):
-        writer = MqttWriter(client=MagicMock(), base_topic="solar_assistant")
-        assert writer._topic(6, "charge") == "solar_assistant/inverter_1/prog6_charge/set"
+    @pytest.mark.asyncio
+    async def test_dry_run_empty_writes_still_succeeds(self):
+        """No diffs means no writes means still a success."""
+        transport = FakeTransport()
+        writer = MqttWriter(transport=transport, dry_run=True)
+        result = await writer.write_registers([])
+        assert result.success is True
+        assert result.writes_attempted == 0


### PR DESCRIPTION
## Summary

Last priority-A blocker before `dry_run=false`. Replaces stub `_wait_for_readback` with a real implementation using Solar Assistant's `response_message/state` topic.

## Also fixes incidentally

The MQTT topic names were wrong (`prog1_capacity` instead of `capacity_point_1`). No publish would have reached SA even with readback implemented.

## Protocol (confirmed by live HEO-13 test earlier today)

- Publish to `solar_assistant/inverter_1/<setting>/set`  
- SA applies over RS485, master replicates to slave  
- SA publishes verdict to `solar_assistant/set/response_message/state`  
- `Saved` = success, `Error` = fail fast, timeout = retry

## Files

- `mqtt_writer.py` rewritten with `MqttTransport` protocol (pure, no HA imports)
- `ha_mqtt_transport.py` new - HA adapter, keeps writer testable
- `test_mqtt_writer.py` full rewrite: 29 tests covering diff, topics, formatters, response parsing, happy path, fail-fast on Error, timeout-retry, abort-on-failure, dry-run

## Tests

208 → 226 pass, 0 fail.

## After merge

Deploy to HA. Verify. Then flip `dry_run=false` via SSH+jq config edit. First real write lands.