### PR TITLE
fix(HEO-27): wire MqttWriter into coordinator tick path

### DIFF
--- a/custom_components/heo2/coordinator.py
+++ b/custom_components/heo2/coordinator.py
@@ -23,6 +23,9 @@ from .soc_trajectory import calculate_soc_trajectory
 from .cost_tracker import CostAccumulator
 from .octopus import OctopusBillingFetcher
 from .const import DEFAULT_FLAT_RATE_PENCE
+from .mqtt_writer import MqttWriter, apply_programme_diff
+from .ha_mqtt_transport import HAMqttTransport
+from .inverter_state_reader import read_from_hass as read_inverter_state
 
 logger = logging.getLogger(__name__)
 
@@ -56,6 +59,17 @@ class HEO2Coordinator(DataUpdateCoordinator):
             region=self._config.get("agilepredict_region", "M"),
         ) if self._config.get("agilepredict_url") else None
         self._appliance_calc = ApplianceTimingCalculator()
+
+        # MQTT writer for applying programme changes to the inverter.
+        # dry_run defaults to True so nothing is written until explicitly
+        # enabled via config. See HEO-27.
+        self._inverter_name = self._config.get("inverter_name", "inverter_1")
+        self._writer_dry_run: bool = bool(self._config.get("dry_run", True))
+        self._mqtt_writer: MqttWriter | None = None  # lazy-constructed on first tick
+        # Source of truth for "what's currently on the inverter". Seeded
+        # on first tick from SA-published entities and updated on every
+        # successful write.
+        self._last_known_programme: ProgrammeState | None = None
 
         # State
         self.current_programme: ProgrammeState | None = None
@@ -121,7 +135,87 @@ class HEO2Coordinator(DataUpdateCoordinator):
         flat_rate = self._config.get("flat_rate_pence", DEFAULT_FLAT_RATE_PENCE)
         self.cost_accumulator.calculate_savings_vs_flat(flat_rate)
 
+        # Apply programme to inverter via MQTT if enabled.
+        # Any failure is logged but does NOT abort the tick - the coordinator
+        # still returns a valid programme and the next tick will retry
+        # the diff against the un-updated _last_known_programme.
+        try:
+            await self._apply_programme_to_inverter(programme)
+        except Exception:
+            logger.exception("HEO-27: apply_programme failed")
+
         return programme
+
+    async def _apply_programme_to_inverter(
+        self, new_programme: ProgrammeState,
+    ) -> None:
+        """Diff new_programme vs last-known inverter state and write changes.
+
+        Lazy-seeds the writer and last-known state on the first call after
+        HA startup, when SA's MQTT discovery has populated the entities.
+        """
+        # Lazy construct writer on first use. HA startup sequence can race
+        # with mqtt component availability, hence deferring past __init__.
+        if self._mqtt_writer is None:
+            transport = HAMqttTransport(self.hass)
+            self._mqtt_writer = MqttWriter(
+                transport=transport,
+                inverter_name=self._inverter_name,
+                dry_run=self._writer_dry_run,
+            )
+            logger.info(
+                "HEO-27: MqttWriter constructed (inverter=%s dry_run=%s)",
+                self._inverter_name, self._writer_dry_run,
+            )
+
+        # Lazy seed last-known state on first tick.
+        if self._last_known_programme is None:
+            self._last_known_programme = read_inverter_state(
+                self.hass, inverter_name=self._inverter_name,
+            )
+            logger.info(
+                "HEO-27: seeded last-known programme from HA entities "
+                "(slot1 cap=%d gc=%s, slot3 cap=%d)",
+                self._last_known_programme.slots[0].capacity_soc,
+                self._last_known_programme.slots[0].grid_charge,
+                self._last_known_programme.slots[2].capacity_soc,
+            )
+
+        writes = self._mqtt_writer.diff(
+            self._last_known_programme, new_programme,
+        )
+        if not writes:
+            logger.debug("HEO-27: no diffs, nothing to write")
+            return
+
+        logger.info(
+            "HEO-27: %d slot write(s) needed (dry_run=%s)",
+            len(writes), self._writer_dry_run,
+        )
+
+        result, self._last_known_programme = await apply_programme_diff(
+            self._mqtt_writer,
+            self._last_known_programme,
+            new_programme,
+        )
+
+        if result.dry_run_log:
+            for line in result.dry_run_log:
+                logger.info("HEO-27: %s", line)
+
+        if result.success:
+            logger.info(
+                "HEO-27: %d/%d writes confirmed",
+                result.writes_confirmed, result.writes_attempted,
+            )
+        else:
+            logger.warning(
+                "HEO-27: write failed at slot %s param %s: %s "
+                "(%d/%d confirmed before failure); will retry next tick",
+                result.failed_slot, result.failed_param,
+                result.failed_reason,
+                result.writes_confirmed, result.writes_attempted,
+            )
 
     async def _gather_inputs(self) -> ProgrammeInputs:
         """Build ProgrammeInputs from HA entities and external APIs."""

--- a/custom_components/heo2/inverter_state_reader.py
+++ b/custom_components/heo2/inverter_state_reader.py
@@ -1,0 +1,141 @@
+# custom_components/heo2/inverter_state_reader.py
+"""Read the currently programmed 6-slot state from HA entities that
+Solar Assistant publishes via MQTT discovery.
+
+Pure logic layer takes a `state_lookup` callable so it can be unit
+tested without HA. The HA-side helper `read_from_hass` is a thin
+adapter that supplies a real lookup.
+
+This module is the source of truth for "what's on the inverter right
+now" and is used by the coordinator to seed and maintain its tracked
+``last_known_programme`` against which diffs are computed.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import time
+from typing import Callable
+
+from .models import ProgrammeState, SlotConfig
+
+logger = logging.getLogger(__name__)
+
+# SA publishes these as snake_case in MQTT; HA mirrors them as entity IDs
+# under the sa_inverter_{N} prefix after discovery.
+_CAPACITY_FMT = "sensor.sa_inverter_{inv}_capacity_point_{n}"
+_GRID_CHARGE_FMT = "sensor.sa_inverter_{inv}_grid_charge_point_{n}"
+_TIME_FMT = "sensor.sa_inverter_{inv}_time_point_{n}"
+
+
+# Fallback defaults when an entity is missing or unparseable. Chosen to
+# be recognisable as "we don't know" placeholders rather than realistic
+# values: SOC at 50 and grid_charge False and a 04:00 time stamp.
+_FALLBACK_SOC = 50
+_FALLBACK_GRID_CHARGE = False
+_FALLBACK_TIME = time(4, 0)
+
+
+def parse_bool(raw: str) -> bool:
+    """SA publishes grid_charge as 'true'/'false' strings. Be lenient."""
+    return str(raw).strip().lower() in ("true", "on", "enabled", "yes", "1")
+
+
+def parse_time(raw: str) -> time | None:
+    """SA publishes time_point as 'HH:MM'. Return None on unparseable."""
+    if not raw:
+        return None
+    text = str(raw).strip()
+    if ":" not in text:
+        return None
+    try:
+        h, m = text.split(":", 1)
+        return time(int(h), int(m))
+    except (ValueError, TypeError):
+        return None
+
+
+def parse_soc(raw: str) -> int | None:
+    """SA publishes capacity_point as an integer 0-100. Return None if
+    unparseable or out of range."""
+    try:
+        v = int(float(str(raw).strip()))
+    except (ValueError, TypeError):
+        return None
+    if not (0 <= v <= 100):
+        return None
+    return v
+
+
+def read_programme_state(
+    state_lookup: Callable[[str], str | None],
+    inverter_name: str = "inverter_1",
+) -> ProgrammeState:
+    """Build a ProgrammeState from live HA entity values.
+
+    `state_lookup(entity_id)` must return the state string or None if
+    the entity is missing/unavailable.
+
+    Any unparseable slot value is replaced with a fallback. The coordinator
+    still computes a valid diff against this; worst case is a spurious
+    write-back to the "real" value on next tick, which is fine.
+
+    Note on slot start/end times:
+      SA's `time_point_N` is the END of slot N (equivalently the START
+      of slot N+1). This mirrors the Sunsynk programme semantics. The
+      returned SlotConfig has:
+        start_time = time_point_{n-1}  (time_point_6 wraps for slot 1)
+        end_time   = time_point_{n}
+    """
+    inv = inverter_name.replace("inverter_", "")
+
+    # Read all 6 time_points first so we can pair them
+    time_points: list[time] = []
+    for n in range(1, 7):
+        raw = state_lookup(_TIME_FMT.format(inv=inv, n=n))
+        parsed = parse_time(raw) if raw else None
+        time_points.append(parsed if parsed is not None else _FALLBACK_TIME)
+
+    slots: list[SlotConfig] = []
+    for n in range(1, 7):
+        cap_raw = state_lookup(_CAPACITY_FMT.format(inv=inv, n=n))
+        gc_raw = state_lookup(_GRID_CHARGE_FMT.format(inv=inv, n=n))
+
+        cap = parse_soc(cap_raw) if cap_raw else None
+        if cap is None:
+            cap = _FALLBACK_SOC
+
+        gc = parse_bool(gc_raw) if gc_raw else _FALLBACK_GRID_CHARGE
+
+        # time_point_N is slot N's end; slot N's start is time_point_{N-1},
+        # with slot 1's start being time_point_6 (wraps midnight).
+        start_idx = (n - 2) % 6  # -1 -> 5, 0 -> 0, etc
+        start_time = time_points[start_idx]
+        end_time = time_points[n - 1]
+
+        slots.append(SlotConfig(
+            start_time=start_time,
+            end_time=end_time,
+            capacity_soc=cap,
+            grid_charge=gc,
+        ))
+
+    return ProgrammeState(slots=slots, reason_log=[])
+
+
+def read_from_hass(
+    hass,
+    inverter_name: str = "inverter_1",
+) -> ProgrammeState:
+    """HA-side adapter. Calls hass.states.get(...).state for each
+    required entity and delegates to read_programme_state.
+    """
+    def _lookup(entity_id: str) -> str | None:
+        state = hass.states.get(entity_id) if hass else None
+        if state is None:
+            return None
+        if state.state in ("unknown", "unavailable", "none", ""):
+            return None
+        return state.state
+
+    return read_programme_state(_lookup, inverter_name=inverter_name)

--- a/custom_components/heo2/mqtt_writer.py
+++ b/custom_components/heo2/mqtt_writer.py
@@ -321,3 +321,36 @@ class MqttWriter:
                 self._response_futures.pop(setting_display, None)
 
         return False, last_reason
+
+
+async def apply_programme_diff(
+    writer: "MqttWriter",
+    last_known: "ProgrammeState",
+    new_programme: "ProgrammeState",
+) -> tuple["MqttWriteResult", "ProgrammeState"]:
+    """Diff new_programme against last_known and apply via writer.
+
+    Returns (result, effective_last_known) where effective_last_known is:
+      - new_programme if the write succeeded (or was dry-run)
+      - last_known unchanged if the write failed (caller should retry
+        on next tick; partial successes are NOT committed)
+
+    Behaviour on dry_run: writer reports success with writes_confirmed == N
+    and dry_run_log populated. We still advance last_known because in
+    dry_run mode we're simulating a world where the writes happened, so
+    the next tick should see no diff. This prevents re-logging the same
+    "Would publish" lines every 15 minutes.
+
+    Pure async, no HA imports. Callable from the coordinator with real
+    HAMqttTransport-backed writer, or from tests with FakeTransport.
+    """
+    writes = writer.diff(last_known, new_programme)
+    if not writes:
+        # Fabricate a success result for the "no work" case
+        result = MqttWriteResult(success=True, writes_attempted=0, writes_confirmed=0)
+        return result, last_known
+
+    result = await writer.write_registers(writes)
+    if result.success:
+        return result, new_programme
+    return result, last_known

--- a/tests/test_inverter_state_reader.py
+++ b/tests/test_inverter_state_reader.py
@@ -1,0 +1,148 @@
+# tests/test_inverter_state_reader.py
+"""Tests for reading live inverter state from HA-mirrored SA entities."""
+
+from datetime import time
+
+import pytest
+
+from heo2.inverter_state_reader import (
+    parse_bool,
+    parse_time,
+    parse_soc,
+    read_programme_state,
+)
+
+
+class TestParsers:
+    def test_parse_bool_true_variants(self):
+        for v in ["true", "True", "TRUE", "on", "enabled", "Enabled", "yes", "1"]:
+            assert parse_bool(v) is True, f"expected True for {v!r}"
+
+    def test_parse_bool_false_variants(self):
+        for v in ["false", "False", "off", "disabled", "Disabled", "no", "0", "", "bogus"]:
+            assert parse_bool(v) is False, f"expected False for {v!r}"
+
+    def test_parse_time_hhmm(self):
+        assert parse_time("05:30") == time(5, 30)
+        assert parse_time("23:57") == time(23, 57)
+        assert parse_time("00:00") == time(0, 0)
+
+    def test_parse_time_garbage_returns_none(self):
+        assert parse_time("") is None
+        assert parse_time("not-a-time") is None
+        assert parse_time("25:00") is None
+        assert parse_time(None) is None
+
+    def test_parse_soc_integer_strings(self):
+        assert parse_soc("0") == 0
+        assert parse_soc("100") == 100
+        assert parse_soc("23") == 23
+
+    def test_parse_soc_float_strings_are_rounded(self):
+        """SA may publish '20.0' even for an integer setting."""
+        assert parse_soc("20.0") == 20
+        assert parse_soc("75.9") == 75  # truncates, consistent with int()
+
+    def test_parse_soc_out_of_range_returns_none(self):
+        assert parse_soc("-1") is None
+        assert parse_soc("101") is None
+
+    def test_parse_soc_garbage_returns_none(self):
+        assert parse_soc("unknown") is None
+        assert parse_soc("") is None
+
+
+class TestReadProgrammeState:
+    def _make_lookup(self, values: dict[str, str | None]):
+        def lookup(entity_id: str) -> str | None:
+            return values.get(entity_id)
+        return lookup
+
+    def test_reads_all_six_slots_with_live_values(self):
+        """Happy path - matches what HEO II saw on Paddy's install today."""
+        values = {
+            "sensor.sa_inverter_1_time_point_1": "05:30",
+            "sensor.sa_inverter_1_time_point_2": "18:30",
+            "sensor.sa_inverter_1_time_point_3": "23:30",
+            "sensor.sa_inverter_1_time_point_4": "23:57",
+            "sensor.sa_inverter_1_time_point_5": "23:58",
+            "sensor.sa_inverter_1_time_point_6": "00:00",
+            "sensor.sa_inverter_1_capacity_point_1": "23",
+            "sensor.sa_inverter_1_capacity_point_2": "100",
+            "sensor.sa_inverter_1_capacity_point_3": "100",
+            "sensor.sa_inverter_1_capacity_point_4": "100",
+            "sensor.sa_inverter_1_capacity_point_5": "20",
+            "sensor.sa_inverter_1_capacity_point_6": "20",
+            "sensor.sa_inverter_1_grid_charge_point_1": "false",
+            "sensor.sa_inverter_1_grid_charge_point_2": "false",
+            "sensor.sa_inverter_1_grid_charge_point_3": "false",
+            "sensor.sa_inverter_1_grid_charge_point_4": "false",
+            "sensor.sa_inverter_1_grid_charge_point_5": "false",
+            "sensor.sa_inverter_1_grid_charge_point_6": "false",
+        }
+        state = read_programme_state(self._make_lookup(values))
+
+        assert len(state.slots) == 6
+        assert state.slots[0].capacity_soc == 23
+        assert state.slots[1].capacity_soc == 100
+        assert state.slots[4].capacity_soc == 20
+        for slot in state.slots:
+            assert slot.grid_charge is False
+        # Slot 1 starts at time_point_6 (the previous slot end), ends at time_point_1
+        assert state.slots[0].start_time == time(0, 0)
+        assert state.slots[0].end_time == time(5, 30)
+        # Slot 2 starts at time_point_1, ends at time_point_2
+        assert state.slots[1].start_time == time(5, 30)
+        assert state.slots[1].end_time == time(18, 30)
+
+
+    def test_grid_charge_variants_parsed_correctly(self):
+        values = {
+            "sensor.sa_inverter_1_grid_charge_point_1": "true",
+            "sensor.sa_inverter_1_grid_charge_point_2": "Enabled",
+            "sensor.sa_inverter_1_grid_charge_point_3": "on",
+            "sensor.sa_inverter_1_grid_charge_point_4": "false",
+            "sensor.sa_inverter_1_grid_charge_point_5": "Disabled",
+            "sensor.sa_inverter_1_grid_charge_point_6": "off",
+        }
+        state = read_programme_state(self._make_lookup(values))
+        assert state.slots[0].grid_charge is True
+        assert state.slots[1].grid_charge is True
+        assert state.slots[2].grid_charge is True
+        assert state.slots[3].grid_charge is False
+        assert state.slots[4].grid_charge is False
+        assert state.slots[5].grid_charge is False
+
+    def test_missing_entities_use_fallbacks(self):
+        """If SA entities haven't been discovered yet, return a valid but
+        obviously-fallback ProgrammeState. Diff will probably produce
+        writes against this, which is harmless and self-correcting."""
+        state = read_programme_state(self._make_lookup({}))
+        assert len(state.slots) == 6
+        for slot in state.slots:
+            assert slot.capacity_soc == 50  # fallback
+            assert slot.grid_charge is False  # fallback
+
+    def test_unknown_state_treated_as_missing(self):
+        values = {
+            "sensor.sa_inverter_1_capacity_point_1": "unknown",
+            "sensor.sa_inverter_1_capacity_point_2": "100",
+        }
+        # Lookup should return None for unknown - we simulate that at caller.
+        # (HA adapter does it; pure reader just sees None.)
+        def lookup(eid):
+            v = values.get(eid)
+            if v == "unknown":
+                return None
+            return v
+        state = read_programme_state(lookup)
+        assert state.slots[0].capacity_soc == 50  # fallback
+        assert state.slots[1].capacity_soc == 100
+
+    def test_custom_inverter_name(self):
+        """A future inverter 2 over RS232 would use inverter_2."""
+        values = {"sensor.sa_inverter_2_capacity_point_1": "42"}
+        state = read_programme_state(
+            self._make_lookup(values), inverter_name="inverter_2",
+        )
+        assert state.slots[0].capacity_soc == 42

--- a/tests/test_mqtt_writer.py
+++ b/tests/test_mqtt_writer.py
@@ -410,3 +410,131 @@ class TestWriteRegisters:
         result = await writer.write_registers([])
         assert result.success is True
         assert result.writes_attempted == 0
+
+
+# -----------------------------------------------------------------------
+# apply_programme_diff - the pure helper used by the coordinator
+# -----------------------------------------------------------------------
+
+from heo2.mqtt_writer import apply_programme_diff
+
+
+class TestApplyProgrammeDiff:
+    @pytest.mark.asyncio
+    async def test_no_diff_returns_last_known_unchanged(self):
+        """When new matches last_known, no writes are attempted and
+        last_known is returned as-is (not replaced with a new object)."""
+        transport = FakeTransport()
+        writer = MqttWriter(transport=transport)
+        programme = _baseline_programme()
+
+        result, returned_last_known = await apply_programme_diff(
+            writer, programme, programme,
+        )
+
+        assert result.success is True
+        assert result.writes_attempted == 0
+        assert result.writes_confirmed == 0
+        assert len(transport.published) == 0
+        assert returned_last_known is programme
+
+    @pytest.mark.asyncio
+    async def test_success_advances_last_known_to_new(self):
+        """After a successful write, last_known should reflect the new
+        programme so the next tick sees no diff."""
+        transport = FakeTransport()
+        transport.script_responses([
+            "Set 'Capacity point 1' to '80': Saved.",
+        ])
+        writer = MqttWriter(transport=transport)
+
+        current = _baseline_programme()
+        new = _baseline_programme()
+        new.slots[0] = SlotConfig(time(0, 0), time(5, 30), 80, True)
+
+        result, returned_last_known = await apply_programme_diff(
+            writer, current, new,
+        )
+
+        assert result.success is True
+        assert returned_last_known is new
+        assert returned_last_known.slots[0].capacity_soc == 80
+
+
+    @pytest.mark.asyncio
+    async def test_failure_keeps_last_known_unchanged(self):
+        """If SA rejects the write, last_known must NOT advance.
+        Next tick should then retry the same diff."""
+        transport = FakeTransport()
+        transport.script_responses([
+            "Set 'Capacity point 1' to '80': Error: Inverter unreachable.",
+        ])
+        writer = MqttWriter(transport=transport)
+
+        current = _baseline_programme()
+        new = _baseline_programme()
+        new.slots[0] = SlotConfig(time(0, 0), time(5, 30), 80, True)
+
+        result, returned_last_known = await apply_programme_diff(
+            writer, current, new,
+        )
+
+        assert result.success is False
+        assert returned_last_known is current
+        # Caller still has the OLD programme; next tick will re-diff.
+        assert returned_last_known.slots[0].capacity_soc == 100
+
+    @pytest.mark.asyncio
+    async def test_dry_run_advances_last_known(self):
+        """In dry_run mode, advance last_known anyway so we don't spam
+        the log with 'Would publish' lines every tick. The coordinator
+        is simulating the world where the writes happened."""
+        transport = FakeTransport()
+        writer = MqttWriter(transport=transport, dry_run=True)
+
+        current = _baseline_programme()
+        new = _baseline_programme()
+        new.slots[0] = SlotConfig(time(0, 0), time(5, 30), 80, True)
+
+        result, returned_last_known = await apply_programme_diff(
+            writer, current, new,
+        )
+
+        assert result.success is True
+        assert len(result.dry_run_log) >= 1
+        assert len(transport.published) == 0
+        # dry_run advances last_known to simulate the writes
+        assert returned_last_known is new
+
+
+    @pytest.mark.asyncio
+    async def test_partial_failure_does_not_partially_commit(self):
+        """If write 2 of 3 fails, last_known stays at the pre-write state.
+        This is conservative but correct: there's no safe way to represent
+        'slot 1 updated, slot 2 failed, slot 3 never tried' as a single
+        ProgrammeState. Next tick re-diffs from the original state and
+        retries everything."""
+        transport = FakeTransport()
+        transport.script_responses([
+            "Set 'Capacity point 1' to '80': Saved.",  # 1 ok
+            "Set 'Capacity point 2' to '60': Error: No response.",  # 2 fails
+            # slot 3 never attempted
+        ])
+        writer = MqttWriter(transport=transport)
+
+        current = _baseline_programme()
+        new = _baseline_programme()
+        new.slots[0] = SlotConfig(time(0, 0), time(5, 30), 80, True)
+        new.slots[1] = SlotConfig(time(5, 30), time(18, 30), 60, False)
+        new.slots[2] = SlotConfig(time(18, 30), time(23, 30), 40, False)
+
+        result, returned_last_known = await apply_programme_diff(
+            writer, current, new,
+        )
+
+        assert result.success is False
+        assert result.failed_slot == 2
+        assert result.writes_confirmed == 1
+        # last_known still reflects the PRE-write world
+        assert returned_last_known is current
+        assert returned_last_known.slots[0].capacity_soc == 100  # unchanged


### PR DESCRIPTION
Closes #27. See commit message for full detail. 244 tests pass, 0 fail. Safe to merge — dry_run defaults to true, no live writes. Flipping dry_run afterwards via SSH+jq will cause writes to land on the next tick.