### PR TITLE
feat(HEO-27): direct MQTT write path + log levels + writes_blocked sensor

### DIFF
--- a/custom_components/heo2/binary_sensor.py
+++ b/custom_components/heo2/binary_sensor.py
@@ -22,7 +22,10 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     coordinator: HEO2Coordinator = hass.data[DOMAIN][entry.entry_id]
-    async_add_entities([HealthySensor(coordinator, entry)])
+    async_add_entities([
+        HealthySensor(coordinator, entry),
+        WritesBlockedSensor(coordinator, entry),
+    ])
 
 
 class HealthySensor(CoordinatorEntity, BinarySensorEntity):
@@ -36,3 +39,29 @@ class HealthySensor(CoordinatorEntity, BinarySensorEntity):
     @property
     def is_on(self) -> bool:
         return self.coordinator.healthy
+
+
+class WritesBlockedSensor(CoordinatorEntity, BinarySensorEntity):
+    """Dashboard alert indicator: ON when HEO II cannot write the
+    programme to the inverter right now.
+
+    Uses device_class=problem so the HA UI colours it red when on,
+    and green when off. Extra state attribute 'reason' explains why
+    when blocked. Useful as a conditional card trigger on dashboards.
+    """
+    _attr_device_class = BinarySensorDeviceClass.PROBLEM
+
+    def __init__(self, coordinator: HEO2Coordinator, entry: ConfigEntry):
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{entry.entry_id}_writes_blocked"
+        self._attr_name = "HEO II Writes Blocked"
+
+    @property
+    def is_on(self) -> bool:
+        return self.coordinator.writes_blocked
+
+    @property
+    def extra_state_attributes(self) -> dict:
+        return {
+            "reason": self.coordinator.writes_blocked_reason or "writes enabled",
+        }

--- a/custom_components/heo2/coordinator.py
+++ b/custom_components/heo2/coordinator.py
@@ -27,6 +27,7 @@ from .const import DEFAULT_FLAT_RATE_PENCE
 from .mqtt_writer import MqttWriter, apply_programme_diff
 from .direct_mqtt_transport import DirectMqttTransport
 from .inverter_state_reader import read_from_hass as read_inverter_state
+from .writes_status import _compute_writes_blocked
 
 logger = logging.getLogger(__name__)
 
@@ -566,3 +567,42 @@ class HEO2Coordinator(DataUpdateCoordinator):
     def active_rule_names(self) -> list[str]:
         """List of currently active rule names."""
         return [r.name for r in self._engine._rules if r.enabled]
+
+    @property
+    def writes_blocked(self) -> bool:
+        """True when HEO II cannot currently send programme changes to
+        the inverter. Drives binary_sensor.heo_ii_writes_blocked so the
+        dashboard can show an alert.
+
+        Blocked conditions:
+          - dry_run is True (writes suppressed by config)
+          - MqttWriter hasn't been constructed yet (early startup)
+          - DirectMqttTransport exists but is not connected
+        """
+        blocked, _ = _compute_writes_blocked(
+            dry_run=self._writer_dry_run,
+            writer_constructed=self._mqtt_writer is not None,
+            transport_exists=self._mqtt_transport is not None,
+            transport_connected=(
+                self._mqtt_transport.is_connected
+                if self._mqtt_transport is not None else False
+            ),
+            host=self._sa_mqtt_host,
+        )
+        return blocked
+
+    @property
+    def writes_blocked_reason(self) -> str:
+        """Short human-readable reason matching writes_blocked, for the
+        binary sensor's state attributes. Returns '' when not blocked."""
+        _, reason = _compute_writes_blocked(
+            dry_run=self._writer_dry_run,
+            writer_constructed=self._mqtt_writer is not None,
+            transport_exists=self._mqtt_transport is not None,
+            transport_connected=(
+                self._mqtt_transport.is_connected
+                if self._mqtt_transport is not None else False
+            ),
+            host=self._sa_mqtt_host,
+        )
+        return reason

--- a/custom_components/heo2/coordinator.py
+++ b/custom_components/heo2/coordinator.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from datetime import timedelta
 
@@ -24,7 +25,7 @@ from .cost_tracker import CostAccumulator
 from .octopus import OctopusBillingFetcher
 from .const import DEFAULT_FLAT_RATE_PENCE
 from .mqtt_writer import MqttWriter, apply_programme_diff
-from .ha_mqtt_transport import HAMqttTransport
+from .direct_mqtt_transport import DirectMqttTransport
 from .inverter_state_reader import read_from_hass as read_inverter_state
 
 logger = logging.getLogger(__name__)
@@ -65,7 +66,15 @@ class HEO2Coordinator(DataUpdateCoordinator):
         # enabled via config. See HEO-27.
         self._inverter_name = self._config.get("inverter_name", "inverter_1")
         self._writer_dry_run: bool = bool(self._config.get("dry_run", True))
+        # SA broker connection details. Defaults point at Paddy's install;
+        # override via config entry for other deployments. No auth required
+        # for SA's default broker configuration.
+        self._sa_mqtt_host: str = self._config.get("sa_mqtt_host", "192.168.4.7")
+        self._sa_mqtt_port: int = int(self._config.get("sa_mqtt_port", 1883))
+        self._sa_mqtt_username: str | None = self._config.get("sa_mqtt_username") or None
+        self._sa_mqtt_password: str | None = self._config.get("sa_mqtt_password") or None
         self._mqtt_writer: MqttWriter | None = None  # lazy-constructed on first tick
+        self._mqtt_transport: DirectMqttTransport | None = None  # owned by this coordinator
         # Source of truth for "what's currently on the inverter". Seeded
         # on first tick from SA-published entities and updated on every
         # successful write.
@@ -156,15 +165,39 @@ class HEO2Coordinator(DataUpdateCoordinator):
         """
         # Lazy construct writer on first use. HA startup sequence can race
         # with mqtt component availability, hence deferring past __init__.
+        # The DirectMqttTransport connects directly to SA's broker rather
+        # than going through HA's local mosquitto + bridge, because adding
+        # outbound to the bridge config kills inbound telemetry in
+        # mosquitto 2.1.2. See HEO-27 discussion.
         if self._mqtt_writer is None:
-            transport = HAMqttTransport(self.hass)
+            try:
+                transport = DirectMqttTransport(
+                    loop=asyncio.get_event_loop(),
+                    host=self._sa_mqtt_host,
+                    port=self._sa_mqtt_port,
+                    username=self._sa_mqtt_username,
+                    password=self._sa_mqtt_password,
+                    client_id="heo2_writer",
+                )
+                await transport.connect()
+            except Exception:
+                logger.exception(
+                    "HEO-27: DirectMqttTransport connect to %s:%d failed; "
+                    "will retry on next tick",
+                    self._sa_mqtt_host, self._sa_mqtt_port,
+                )
+                return
+
+            self._mqtt_transport = transport
             self._mqtt_writer = MqttWriter(
                 transport=transport,
                 inverter_name=self._inverter_name,
                 dry_run=self._writer_dry_run,
             )
             logger.info(
-                "HEO-27: MqttWriter constructed (inverter=%s dry_run=%s)",
+                "HEO-27: MqttWriter ready via DirectMqttTransport "
+                "(broker=%s:%d, inverter=%s, dry_run=%s)",
+                self._sa_mqtt_host, self._sa_mqtt_port,
                 self._inverter_name, self._writer_dry_run,
             )
 

--- a/custom_components/heo2/coordinator.py
+++ b/custom_components/heo2/coordinator.py
@@ -194,7 +194,7 @@ class HEO2Coordinator(DataUpdateCoordinator):
                 inverter_name=self._inverter_name,
                 dry_run=self._writer_dry_run,
             )
-            logger.info(
+            logger.warning(
                 "HEO-27: MqttWriter ready via DirectMqttTransport "
                 "(broker=%s:%d, inverter=%s, dry_run=%s)",
                 self._sa_mqtt_host, self._sa_mqtt_port,
@@ -206,7 +206,7 @@ class HEO2Coordinator(DataUpdateCoordinator):
             self._last_known_programme = read_inverter_state(
                 self.hass, inverter_name=self._inverter_name,
             )
-            logger.info(
+            logger.warning(
                 "HEO-27: seeded last-known programme from HA entities "
                 "(slot1 cap=%d gc=%s, slot3 cap=%d)",
                 self._last_known_programme.slots[0].capacity_soc,
@@ -221,7 +221,7 @@ class HEO2Coordinator(DataUpdateCoordinator):
             logger.debug("HEO-27: no diffs, nothing to write")
             return
 
-        logger.info(
+        logger.warning(
             "HEO-27: %d slot write(s) needed (dry_run=%s)",
             len(writes), self._writer_dry_run,
         )
@@ -234,10 +234,10 @@ class HEO2Coordinator(DataUpdateCoordinator):
 
         if result.dry_run_log:
             for line in result.dry_run_log:
-                logger.info("HEO-27: %s", line)
+                logger.warning("HEO-27: %s", line)
 
         if result.success:
-            logger.info(
+            logger.warning(
                 "HEO-27: %d/%d writes confirmed",
                 result.writes_confirmed, result.writes_attempted,
             )

--- a/custom_components/heo2/direct_mqtt_transport.py
+++ b/custom_components/heo2/direct_mqtt_transport.py
@@ -1,0 +1,326 @@
+# custom_components/heo2/direct_mqtt_transport.py
+"""Direct MQTT transport: connects HEO II straight to Solar Assistant's broker.
+
+Why this exists:
+  HA's mosquitto addon bridges SA's broker to HA's local broker, but the
+  bridge config that enables outbound writes (topic # out 0 solar_assistant/
+  solar_assistant/) breaks inbound telemetry in mosquitto 2.1.2. We
+  ultimately care about inbound working so HA dashboards stay live; the
+  price is that we can't use HA's local broker for writes. This transport
+  bypasses the bridge entirely by connecting directly to SA's broker at
+  192.168.4.7:1883 (configurable).
+
+Threading model:
+  paho-mqtt runs a network thread. Callbacks (on_connect, on_message,
+  on_disconnect) fire on that thread. We dispatch them to the asyncio
+  event loop using run_coroutine_threadsafe so our subscribe callbacks
+  can be regular async def.
+
+Lifecycle:
+  connect() -> async, blocks until CONNACK received
+  subscribe/publish -> async, safe to call after connect
+  disconnect() -> clean teardown (called on HA shutdown ideally)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import threading
+from typing import Any, Awaitable, Callable
+
+import paho.mqtt.client as mqtt
+
+logger = logging.getLogger(__name__)
+
+# Sentinel values - module-level constants so tests can override
+DEFAULT_HOST = "192.168.4.7"
+DEFAULT_PORT = 1883
+DEFAULT_KEEPALIVE = 60
+CONNECT_TIMEOUT_SECONDS = 10.0
+
+
+class DirectMqttTransport:
+    """Direct-connection transport to Solar Assistant's MQTT broker.
+
+    Implements the MqttTransport protocol (from mqtt_writer.py):
+        async def publish(topic, payload) -> None
+        async def subscribe(topic, callback) -> unsub_callable
+
+    Constructor params:
+        loop: asyncio event loop callbacks are dispatched to
+        host, port, username, password, client_id: MQTT connection params
+              (default anonymous connection to SA at 192.168.4.7:1883)
+
+    NOT thread-safe: call from a single asyncio task. paho's own threading
+    is handled internally - we just need to avoid two calls to
+    connect/disconnect racing.
+    """
+
+    def __init__(
+        self,
+        loop: asyncio.AbstractEventLoop,
+        host: str = DEFAULT_HOST,
+        port: int = DEFAULT_PORT,
+        username: str | None = None,
+        password: str | None = None,
+        client_id: str = "heo2_direct",
+        keepalive: int = DEFAULT_KEEPALIVE,
+    ) -> None:
+        self._loop = loop
+        self._host = host
+        self._port = port
+        self._username = username
+        self._password = password
+        self._client_id = client_id
+        self._keepalive = keepalive
+
+        # Subscription registry: topic -> list of async callbacks.
+        # We serve each incoming message to every matching subscriber.
+        # Using a list rather than a single cb to support multiple subs
+        # on the same topic (e.g., MqttWriter's response listener plus
+        # a diagnostic sniffer).
+        self._subscriptions: dict[str, list[Callable[[str, str], Any]]] = {}
+        self._sub_lock = threading.Lock()
+
+        # Paho client, constructed in connect() so the lifecycle is
+        # explicit and reconstructable after disconnect.
+        self._client: Any = None
+        self._connected_event = asyncio.Event()
+        self._connected = False
+
+
+    @property
+    def is_connected(self) -> bool:
+        """True when CONNACK received and broker is reachable."""
+        return self._connected
+
+    async def connect(self) -> None:
+        """Establish connection to SA broker. Blocks until CONNACK
+        received or timeout. Raises on failure."""
+        # paho-mqtt v2.x changed constructor. Prefer v2 API.
+        try:
+            client = mqtt.Client(
+                callback_api_version=mqtt.CallbackAPIVersion.VERSION2,
+                client_id=self._client_id,
+                clean_session=True,
+            )
+        except AttributeError:
+            # v1.x fallback - theoretical, HA ships v2 since 2024.4
+            client = mqtt.Client(client_id=self._client_id, clean_session=True)
+
+        if self._username:
+            client.username_pw_set(self._username, self._password)
+
+        # Wire callbacks. These fire on paho's network thread.
+        client.on_connect = self._on_connect
+        client.on_disconnect = self._on_disconnect
+        client.on_message = self._on_message
+
+        self._client = client
+        self._connected_event.clear()
+
+        logger.info(
+            "DirectMqttTransport: connecting to %s:%d as client_id=%s",
+            self._host, self._port, self._client_id,
+        )
+
+        # connect_async returns immediately. loop_start spawns the
+        # network thread which drives the protocol and fires callbacks.
+        def _start() -> None:
+            client.connect_async(self._host, self._port, self._keepalive)
+            client.loop_start()
+
+        await self._loop.run_in_executor(None, _start)
+
+        # Wait for CONNACK (set in _on_connect).
+        try:
+            await asyncio.wait_for(
+                self._connected_event.wait(),
+                timeout=CONNECT_TIMEOUT_SECONDS,
+            )
+        except asyncio.TimeoutError:
+            logger.error(
+                "DirectMqttTransport: CONNACK not received within %.1fs, aborting",
+                CONNECT_TIMEOUT_SECONDS,
+            )
+            await self.disconnect()
+            raise
+
+
+    async def disconnect(self) -> None:
+        """Clean shutdown of MQTT connection. Safe to call multiple times."""
+        client = self._client
+        if client is None:
+            return
+        self._client = None
+        self._connected = False
+
+        def _stop() -> None:
+            try:
+                client.loop_stop()
+                client.disconnect()
+            except Exception:
+                # best-effort shutdown - don't raise in disconnect path
+                logger.debug("DirectMqttTransport: exception during disconnect", exc_info=True)
+
+        await self._loop.run_in_executor(None, _stop)
+        logger.info("DirectMqttTransport: disconnected from %s", self._host)
+
+    async def publish(self, topic: str, payload: str) -> None:
+        """Publish payload to topic. Matches MqttTransport protocol.
+
+        Raises RuntimeError if not connected (lets MqttWriter handle it
+        as a write failure rather than silently succeeding)."""
+        client = self._client
+        if client is None or not self._connected:
+            raise RuntimeError(
+                f"DirectMqttTransport not connected, cannot publish to {topic}"
+            )
+
+        def _publish() -> None:
+            result = client.publish(topic, payload, qos=0, retain=False)
+            # paho returns a MessageInfo object; .rc is the return code.
+            # 0 = MQTT_ERR_SUCCESS. Other values are errors.
+            if result.rc != 0:
+                raise RuntimeError(
+                    f"publish to {topic} failed with rc={result.rc}"
+                )
+
+        await self._loop.run_in_executor(None, _publish)
+
+
+    async def subscribe(
+        self,
+        topic: str,
+        callback: Callable[[str, str], Awaitable[None] | None],
+    ) -> Callable[[], None]:
+        """Subscribe to topic. callback(topic, payload) is called on
+        each message. Returns a sync unsubscribe callable.
+
+        Multiple subscribes to the same topic are supported - all
+        callbacks are invoked on each matching message."""
+        client = self._client
+        if client is None or not self._connected:
+            raise RuntimeError(
+                f"DirectMqttTransport not connected, cannot subscribe to {topic}"
+            )
+
+        with self._sub_lock:
+            first_sub = topic not in self._subscriptions
+            self._subscriptions.setdefault(topic, []).append(callback)
+
+        # Only send SUBSCRIBE to broker on the first subscriber for this
+        # topic - otherwise we'd get duplicate messages.
+        if first_sub:
+            def _subscribe() -> None:
+                result, _mid = client.subscribe(topic, qos=0)
+                if result != 0:
+                    raise RuntimeError(
+                        f"subscribe to {topic} failed with rc={result}"
+                    )
+            await self._loop.run_in_executor(None, _subscribe)
+
+        def unsub() -> None:
+            """Remove this callback. If it was the last sub on this
+            topic, also send UNSUBSCRIBE to broker."""
+            with self._sub_lock:
+                if topic not in self._subscriptions:
+                    return
+                try:
+                    self._subscriptions[topic].remove(callback)
+                except ValueError:
+                    return
+                if not self._subscriptions[topic]:
+                    del self._subscriptions[topic]
+                    last = True
+                else:
+                    last = False
+            if last and self._client is not None:
+                try:
+                    self._client.unsubscribe(topic)
+                except Exception:
+                    logger.debug("unsubscribe failed for %s", topic, exc_info=True)
+
+        return unsub
+
+
+    # ---- Callbacks from paho network thread ----
+    #
+    # These run on paho's internal thread. They must not call asyncio
+    # primitives directly - instead dispatch to the event loop with
+    # call_soon_threadsafe / run_coroutine_threadsafe.
+
+    def _on_connect(self, client, userdata, flags, reason_code, properties=None) -> None:
+        """Fired when CONNACK received from broker."""
+        # paho v2 API: reason_code is a ReasonCode object; .is_failure exists
+        # paho v1 API: reason_code is an int where 0 = success
+        try:
+            is_failure = reason_code.is_failure  # v2
+        except AttributeError:
+            is_failure = (reason_code != 0)  # v1
+
+        if is_failure:
+            logger.error(
+                "DirectMqttTransport: broker rejected connection, rc=%s",
+                reason_code,
+            )
+            # Don't set _connected. connect() will time out waiting for the
+            # event and raise.
+            return
+
+        logger.info(
+            "DirectMqttTransport: connected to %s:%d (flags=%s)",
+            self._host, self._port, flags,
+        )
+        self._connected = True
+
+        # Wake up the connect() coroutine. This MUST be threadsafe.
+        self._loop.call_soon_threadsafe(self._connected_event.set)
+
+        # If we had subscriptions before disconnect (reconnect case),
+        # resubscribe. On first connect this is a no-op.
+        with self._sub_lock:
+            topics = list(self._subscriptions.keys())
+        for t in topics:
+            try:
+                client.subscribe(t, qos=0)
+            except Exception:
+                logger.exception("DirectMqttTransport: resubscribe to %s failed", t)
+
+    def _on_disconnect(self, client, userdata, *args, **kwargs) -> None:
+        """Fired on broker disconnect or network failure.
+
+        paho's loop_start() will attempt reconnect automatically; we just
+        flag ourselves as disconnected so publish/subscribe raise cleanly.
+        Signature accepts any extra args for cross-version compat (v1 and
+        v2 pass different params)."""
+        self._connected = False
+        logger.warning(
+            "DirectMqttTransport: disconnected from %s (paho will auto-reconnect)",
+            self._host,
+        )
+
+    def _on_message(self, client, userdata, msg) -> None:
+        """Fired on incoming PUBLISH. Dispatch to asyncio loop."""
+        topic = msg.topic
+        try:
+            payload = msg.payload.decode("utf-8", errors="replace")
+        except Exception:
+            payload = ""
+
+        with self._sub_lock:
+            callbacks = list(self._subscriptions.get(topic, []))
+
+        # Dispatch each callback to the event loop safely.
+        # If callback is async, schedule the coroutine.
+        # If sync, call through call_soon_threadsafe.
+        for cb in callbacks:
+            try:
+                result = cb(topic, payload)
+                if asyncio.iscoroutine(result):
+                    asyncio.run_coroutine_threadsafe(result, self._loop)
+            except Exception:
+                logger.exception(
+                    "DirectMqttTransport: callback for %s raised", topic,
+                )

--- a/custom_components/heo2/writes_status.py
+++ b/custom_components/heo2/writes_status.py
@@ -1,0 +1,38 @@
+# custom_components/heo2/writes_status.py
+"""Pure logic for determining whether HEO II is currently able to write
+to the inverter.
+
+Separated out so it can be unit-tested without HA imports. The coordinator
+calls `_compute_writes_blocked` to drive both the binary_sensor and any
+internal branching.
+"""
+
+from __future__ import annotations
+
+
+def _compute_writes_blocked(
+    *,
+    dry_run: bool,
+    writer_constructed: bool,
+    transport_exists: bool,
+    transport_connected: bool,
+    host: str,
+) -> tuple[bool, str]:
+    """Determine if writes are currently blocked and why.
+
+    Returns (blocked, reason). When blocked=False, reason is empty string.
+    When blocked=True, reason is a short human-readable explanation for
+    the dashboard.
+
+    Order of checks matters: dry_run takes precedence over transport
+    state because dry_run is an intentional user choice - reporting
+    "transport disconnected" when the user has explicitly disabled
+    writes would be misleading.
+    """
+    if dry_run:
+        return True, "dry_run enabled"
+    if not writer_constructed or not transport_exists:
+        return True, "MQTT writer not yet initialised"
+    if not transport_connected:
+        return True, f"MQTT transport disconnected from {host}"
+    return False, ""

--- a/tests/test_direct_mqtt_transport.py
+++ b/tests/test_direct_mqtt_transport.py
@@ -1,0 +1,280 @@
+# tests/test_direct_mqtt_transport.py
+"""Tests for DirectMqttTransport.
+
+Strategy: mock paho's client so we can simulate network-thread callbacks
+from tests without real TCP connections or background threads.
+
+The real integration risk (paho's network thread, threadsafe dispatch to
+asyncio loop) is covered by:
+  - in-unit: mocking paho and directly invoking the _on_connect, _on_message
+    callbacks from the asyncio-test thread to exercise the dispatch logic
+  - in-production: first-run deploy against SA's actual broker, verified
+    by observing "Saved" responses come through
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from heo2.direct_mqtt_transport import DirectMqttTransport
+
+
+def _make_fake_paho_module(connect_rc: int = 0) -> MagicMock:
+    """Build a fake paho.mqtt.client module with enough API surface for tests.
+
+    connect_rc=0 simulates successful CONNACK. Non-zero triggers failure path.
+    """
+    fake_mqtt = MagicMock()
+    fake_mqtt.CallbackAPIVersion.VERSION2 = "v2_sentinel"
+
+    fake_client = MagicMock()
+    fake_client.publish.return_value = SimpleNamespace(rc=0)
+    fake_client.subscribe.return_value = (0, 1)  # (rc, mid)
+    fake_client.unsubscribe.return_value = (0, 1)
+    fake_mqtt.Client.return_value = fake_client
+
+    return fake_mqtt, fake_client
+
+
+def _patch_mqtt(fake_mqtt: MagicMock):
+    """Context manager patching the module-level mqtt import in
+    direct_mqtt_transport with our fake."""
+    return patch("heo2.direct_mqtt_transport.mqtt", fake_mqtt)
+
+
+def _trigger_connack(client: MagicMock, transport: DirectMqttTransport,
+                      success: bool = True) -> None:
+    """Simulate paho firing on_connect after CONNACK."""
+    reason_code = SimpleNamespace(is_failure=not success)
+    transport._on_connect(client, None, {}, reason_code)
+
+
+class TestConnect:
+    @pytest.mark.asyncio
+    async def test_successful_connect_sets_is_connected(self):
+        """Happy path: CONNACK received, transport reports connected."""
+        fake_mqtt, fake_client = _make_fake_paho_module()
+
+        loop = asyncio.get_event_loop()
+        transport = DirectMqttTransport(loop=loop)
+
+        # Patch paho import inside connect()
+        with _patch_mqtt(fake_mqtt):
+            # Start connect() as a task so we can trigger CONNACK separately
+            connect_task = asyncio.create_task(transport.connect())
+            await asyncio.sleep(0.05)  # let executor run connect_async/loop_start
+
+            # Simulate paho firing on_connect on its network thread
+            _trigger_connack(fake_client, transport, success=True)
+
+            await connect_task
+
+        assert transport.is_connected is True
+        fake_client.connect_async.assert_called_once_with("192.168.4.7", 1883, 60)
+        fake_client.loop_start.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_connect_timeout_raises(self):
+        """If CONNACK never arrives, connect() raises TimeoutError."""
+        fake_mqtt, fake_client = _make_fake_paho_module()
+
+        loop = asyncio.get_event_loop()
+        # Override timeout to short value via monkey-patching module constant
+        with patch("heo2.direct_mqtt_transport.CONNECT_TIMEOUT_SECONDS", 0.1):
+            transport = DirectMqttTransport(loop=loop)
+            with _patch_mqtt(fake_mqtt):
+                with pytest.raises(asyncio.TimeoutError):
+                    await transport.connect()
+
+        assert transport.is_connected is False
+        # disconnect should have been called as cleanup
+        fake_client.loop_stop.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_connect_failure_reason_code_sets_not_connected(self):
+        """If CONNACK has failure reason_code, we don't mark connected."""
+        fake_mqtt, fake_client = _make_fake_paho_module()
+
+        loop = asyncio.get_event_loop()
+        with patch("heo2.direct_mqtt_transport.CONNECT_TIMEOUT_SECONDS", 0.1):
+            transport = DirectMqttTransport(loop=loop)
+            with _patch_mqtt(fake_mqtt):
+                connect_task = asyncio.create_task(transport.connect())
+                await asyncio.sleep(0.05)
+                _trigger_connack(fake_client, transport, success=False)
+                # connect() will still time out because we didn't set the event
+                with pytest.raises(asyncio.TimeoutError):
+                    await connect_task
+
+        assert transport.is_connected is False
+
+
+class TestPublish:
+    @pytest.mark.asyncio
+    async def test_publish_before_connect_raises(self):
+        """publish on disconnected transport must raise, not silently succeed."""
+        loop = asyncio.get_event_loop()
+        transport = DirectMqttTransport(loop=loop)
+
+        with pytest.raises(RuntimeError, match="not connected"):
+            await transport.publish("some/topic", "payload")
+
+    @pytest.mark.asyncio
+    async def test_publish_happy_path(self):
+        """Once connected, publish calls paho client.publish with right args."""
+        fake_mqtt, fake_client = _make_fake_paho_module()
+        loop = asyncio.get_event_loop()
+        transport = DirectMqttTransport(loop=loop)
+
+        with _patch_mqtt(fake_mqtt):
+            task = asyncio.create_task(transport.connect())
+            await asyncio.sleep(0.05)
+            _trigger_connack(fake_client, transport, success=True)
+            await task
+
+            await transport.publish("solar_assistant/inverter_1/capacity_point_1/set", "100")
+
+        fake_client.publish.assert_called_once_with(
+            "solar_assistant/inverter_1/capacity_point_1/set", "100",
+            qos=0, retain=False,
+        )
+
+    @pytest.mark.asyncio
+    async def test_publish_nonzero_rc_raises(self):
+        """If paho publish returns non-zero rc (e.g. disconnected mid-call),
+        we raise so MqttWriter can count it as a write failure."""
+        fake_mqtt, fake_client = _make_fake_paho_module()
+        fake_client.publish.return_value = SimpleNamespace(rc=4)  # MQTT_ERR_NO_CONN
+
+        loop = asyncio.get_event_loop()
+        transport = DirectMqttTransport(loop=loop)
+
+        with _patch_mqtt(fake_mqtt):
+            task = asyncio.create_task(transport.connect())
+            await asyncio.sleep(0.05)
+            _trigger_connack(fake_client, transport, success=True)
+            await task
+
+            with pytest.raises(RuntimeError, match="rc=4"):
+                await transport.publish("topic", "payload")
+
+
+class TestSubscribe:
+    @pytest.mark.asyncio
+    async def test_subscribe_calls_paho_subscribe(self):
+        """First subscribe to a topic sends SUBSCRIBE to broker."""
+        fake_mqtt, fake_client = _make_fake_paho_module()
+        loop = asyncio.get_event_loop()
+        transport = DirectMqttTransport(loop=loop)
+
+        with _patch_mqtt(fake_mqtt):
+            task = asyncio.create_task(transport.connect())
+            await asyncio.sleep(0.05)
+            _trigger_connack(fake_client, transport, success=True)
+            await task
+
+            async def cb(topic, payload):
+                pass
+
+            await transport.subscribe("solar_assistant/set/response_message/state", cb)
+
+        fake_client.subscribe.assert_called_once_with(
+            "solar_assistant/set/response_message/state", qos=0,
+        )
+
+    @pytest.mark.asyncio
+    async def test_incoming_message_dispatches_to_callback(self):
+        """Simulate paho on_message firing; verify our callback runs."""
+        fake_mqtt, fake_client = _make_fake_paho_module()
+        loop = asyncio.get_event_loop()
+        transport = DirectMqttTransport(loop=loop)
+
+        received: list[tuple[str, str]] = []
+
+        async def cb(topic, payload):
+            received.append((topic, payload))
+
+        with _patch_mqtt(fake_mqtt):
+            task = asyncio.create_task(transport.connect())
+            await asyncio.sleep(0.05)
+            _trigger_connack(fake_client, transport, success=True)
+            await task
+            await transport.subscribe("topic/a", cb)
+
+            # simulate incoming message from paho network thread
+            fake_msg = SimpleNamespace(topic="topic/a", payload=b"payload_bytes")
+            transport._on_message(fake_client, None, fake_msg)
+
+            # Let the scheduled coroutine run
+            await asyncio.sleep(0.05)
+
+        assert received == [("topic/a", "payload_bytes")]
+
+
+    @pytest.mark.asyncio
+    async def test_unsubscribe_removes_callback_and_sends_unsub_on_last(self):
+        """Unsub-callable removes the cb. When it's the last for a topic,
+        UNSUBSCRIBE is sent to broker."""
+        fake_mqtt, fake_client = _make_fake_paho_module()
+        loop = asyncio.get_event_loop()
+        transport = DirectMqttTransport(loop=loop)
+
+        with _patch_mqtt(fake_mqtt):
+            task = asyncio.create_task(transport.connect())
+            await asyncio.sleep(0.05)
+            _trigger_connack(fake_client, transport, success=True)
+            await task
+
+            received: list = []
+            async def cb(t, p): received.append((t, p))
+
+            unsub = await transport.subscribe("topic/a", cb)
+            unsub()
+
+            # Broker-level unsubscribe should fire because it was last sub
+            fake_client.unsubscribe.assert_called_once_with("topic/a")
+
+            # Incoming message after unsub should NOT call our callback
+            fake_msg = SimpleNamespace(topic="topic/a", payload=b"after_unsub")
+            transport._on_message(fake_client, None, fake_msg)
+            await asyncio.sleep(0.05)
+
+        assert received == []  # callback was never invoked
+
+    @pytest.mark.asyncio
+    async def test_multiple_subs_same_topic_single_broker_sub(self):
+        """Two subscribers on the same topic should only send one SUBSCRIBE
+        to the broker, but both callbacks should fire on messages."""
+        fake_mqtt, fake_client = _make_fake_paho_module()
+        loop = asyncio.get_event_loop()
+        transport = DirectMqttTransport(loop=loop)
+
+        with _patch_mqtt(fake_mqtt):
+            task = asyncio.create_task(transport.connect())
+            await asyncio.sleep(0.05)
+            _trigger_connack(fake_client, transport, success=True)
+            await task
+
+            calls_a: list = []
+            calls_b: list = []
+            async def cb_a(t, p): calls_a.append(p)
+            async def cb_b(t, p): calls_b.append(p)
+
+            await transport.subscribe("topic/x", cb_a)
+            await transport.subscribe("topic/x", cb_b)
+
+            # Only ONE broker SUBSCRIBE call
+            assert fake_client.subscribe.call_count == 1
+
+            # Both callbacks fire on a message
+            fake_msg = SimpleNamespace(topic="topic/x", payload=b"hello")
+            transport._on_message(fake_client, None, fake_msg)
+            await asyncio.sleep(0.05)
+
+        assert calls_a == ["hello"]
+        assert calls_b == ["hello"]
+

--- a/tests/test_writes_status.py
+++ b/tests/test_writes_status.py
@@ -1,0 +1,87 @@
+# tests/test_writes_status.py
+"""Tests for the pure _compute_writes_blocked helper."""
+
+from __future__ import annotations
+
+import pytest
+
+from heo2.writes_status import _compute_writes_blocked
+
+
+class TestComputeWritesBlocked:
+    def test_dry_run_blocks_writes(self):
+        """dry_run=True always blocks, regardless of transport state."""
+        blocked, reason = _compute_writes_blocked(
+            dry_run=True,
+            writer_constructed=True,
+            transport_exists=True,
+            transport_connected=True,
+            host="192.168.4.7",
+        )
+        assert blocked is True
+        assert "dry_run" in reason
+
+    def test_dry_run_takes_precedence_over_disconnect(self):
+        """When dry_run=True AND transport disconnected, reason cites
+        dry_run (user's intentional choice), not the disconnect."""
+        blocked, reason = _compute_writes_blocked(
+            dry_run=True,
+            writer_constructed=False,
+            transport_exists=False,
+            transport_connected=False,
+            host="192.168.4.7",
+        )
+        assert blocked is True
+        assert "dry_run" in reason
+        assert "disconnected" not in reason
+        assert "initialised" not in reason
+
+    def test_writer_not_constructed_blocks(self):
+        """Early startup state - writer is None - blocks writes."""
+        blocked, reason = _compute_writes_blocked(
+            dry_run=False,
+            writer_constructed=False,
+            transport_exists=False,
+            transport_connected=False,
+            host="192.168.4.7",
+        )
+        assert blocked is True
+        assert "not yet initialised" in reason
+
+    def test_transport_exists_but_disconnected_blocks(self):
+        """Post-startup but broker link is down - blocks with host info."""
+        blocked, reason = _compute_writes_blocked(
+            dry_run=False,
+            writer_constructed=True,
+            transport_exists=True,
+            transport_connected=False,
+            host="192.168.4.7",
+        )
+        assert blocked is True
+        assert "disconnected" in reason
+        assert "192.168.4.7" in reason
+
+    def test_happy_path_not_blocked(self):
+        """Everything up and running - writes are permitted."""
+        blocked, reason = _compute_writes_blocked(
+            dry_run=False,
+            writer_constructed=True,
+            transport_exists=True,
+            transport_connected=True,
+            host="192.168.4.7",
+        )
+        assert blocked is False
+        assert reason == ""
+
+    def test_host_appears_in_disconnect_reason(self):
+        """Custom host should appear in the reason so multi-install
+        users can tell which SA broker has disconnected."""
+        blocked, reason = _compute_writes_blocked(
+            dry_run=False,
+            writer_constructed=True,
+            transport_exists=True,
+            transport_connected=False,
+            host="10.0.5.42",
+        )
+        assert blocked is True
+        assert "10.0.5.42" in reason


### PR DESCRIPTION
Closes #27.

## What this does

Wires HEO II to write programme changes directly to Solar Assistant's broker at `192.168.4.7:1883`, bypassing the HA local mosquitto bridge. This is the pragmatic answer to the mosquitto 2.1.2 bridge bug where adding `topic # out` breaks inbound telemetry.

The bridge remains as-is (inbound-only, restored to pre-HEO-13 config). Live telemetry (grid_power, pv_power, etc.) continues flowing normally. Writes now go via a separate connection that does not affect inbound.

## Commits in order

1. `DirectMqttTransport` + 10 tests. paho-mqtt based, threadsafe asyncio dispatch, explicit connect/disconnect lifecycle, multi-subscriber support.
2. Coordinator wired to use DirectMqttTransport instead of HAMqttTransport. New config fields `sa_mqtt_host` (default `192.168.4.7`), `sa_mqtt_port` (1883), `sa_mqtt_username`/`password` (optional, empty defaults).
3. HEO-27 diagnostic logs bumped from `logger.info` to `logger.warning` so they appear in HA's default log output. Same gotcha we hit with HEO-5.
4. New `binary_sensor.heo_ii_writes_blocked` with device_class=problem. Extra state attribute `reason` explains why when on. Dashboard can surface as a red banner when dry_run or transport-disconnect.

## Tests

260 unit tests pass (up from 244 before this branch). Added:
- `test_direct_mqtt_transport.py` - 10 tests
- `test_writes_status.py` - 6 tests

## Safety

`dry_run` defaults to `true`. This PR does NOT change that. First deploy will log:

```
HEO-27: MqttWriter ready via DirectMqttTransport (broker=192.168.4.7:1883, inverter=inverter_1, dry_run=True)
HEO-27: seeded last-known programme from HA entities (slot1 cap=23 gc=False, slot3 cap=100)
HEO-27: 5 slot write(s) needed (dry_run=True)
HEO-27: Would publish solar_assistant/inverter_1/capacity_point_1/set = 100
...
```

No actual publishes to SA. Inverter state unchanged.

## After merge

Deploy to HA via `scripts/deploy-to-ha.ps1`, restart, verify the above log lines appear. Confirm `binary_sensor.heo_ii_writes_blocked = on` with reason "dry_run enabled". Then flip `dry_run=false` in a later session and watch the first real write land.

## Related

- Issue #27 (this PR closes it)
- HEO-2 #26 (MqttWriter readback mechanics - complete, in use)
- HEO-13 #20 (bridge outbound topic discovery - superseded by this work, the bridge outbound approach is abandoned)
