### PR TITLE
fix(HEO-27): defer seed when SA entities not yet populated

### DIFF
--- a/custom_components/heo2/coordinator.py
+++ b/custom_components/heo2/coordinator.py
@@ -203,10 +203,21 @@ class HEO2Coordinator(DataUpdateCoordinator):
             )
 
         # Lazy seed last-known state on first tick.
+        # read_inverter_state returns None if SA's MQTT-discovered
+        # entities haven't been populated yet (HA startup race). In that
+        # case we skip seeding and retry next tick. Writing against bogus
+        # seed values would produce spurious SA log entries.
         if self._last_known_programme is None:
-            self._last_known_programme = read_inverter_state(
+            seeded = read_inverter_state(
                 self.hass, inverter_name=self._inverter_name,
             )
+            if seeded is None:
+                logger.warning(
+                    "HEO-27: deferring seed - SA entities not yet populated "
+                    "in HA (discovery still in progress?); retry next tick",
+                )
+                return  # No writer activity until we have a real baseline
+            self._last_known_programme = seeded
             logger.warning(
                 "HEO-27: seeded last-known programme from HA entities "
                 "(slot1 cap=%d gc=%s, slot3 cap=%d)",

--- a/custom_components/heo2/inverter_state_reader.py
+++ b/custom_components/heo2/inverter_state_reader.py
@@ -126,9 +126,20 @@ def read_programme_state(
 def read_from_hass(
     hass,
     inverter_name: str = "inverter_1",
-) -> ProgrammeState:
-    """HA-side adapter. Calls hass.states.get(...).state for each
-    required entity and delegates to read_programme_state.
+) -> ProgrammeState | None:
+    """HA-side adapter. Reads SA-published slot entities into a
+    ProgrammeState.
+
+    Returns None if ANY of the 18 required entities (6 slots x 3 params:
+    capacity_point, time_point, grid_charge_point) is missing or in an
+    unknown/unavailable state. This handles the HA startup race: on the
+    first coordinator tick, HA's MQTT discovery may not have populated
+    the SA entities yet, so we'd fall back to junk values (cap=50 etc.)
+    and compute a bogus diff. Returning None lets the caller defer
+    seeding to the next tick when discovery has completed.
+
+    When all entities are present, returns a valid ProgrammeState built
+    from them (delegates to read_programme_state).
     """
     def _lookup(entity_id: str) -> str | None:
         state = hass.states.get(entity_id) if hass else None
@@ -137,5 +148,29 @@ def read_from_hass(
         if state.state in ("unknown", "unavailable", "none", ""):
             return None
         return state.state
+
+    # Pre-flight: verify all 18 required entities are populated before
+    # building a ProgrammeState. Any missing means HA MQTT discovery
+    # hasn't finished or the bridge is down; either way, don't seed.
+    inv = inverter_name.replace("inverter_", "")
+    required_templates = [
+        "sensor.sa_inverter_{inv}_capacity_point_{n}",
+        "sensor.sa_inverter_{inv}_time_point_{n}",
+        "sensor.sa_inverter_{inv}_grid_charge_point_{n}",
+    ]
+    missing: list[str] = []
+    for n in range(1, 7):
+        for tmpl in required_templates:
+            entity_id = tmpl.format(inv=inv, n=n)
+            if _lookup(entity_id) is None:
+                missing.append(entity_id)
+
+    if missing:
+        logger.info(
+            "inverter_state_reader: %d/%d entities missing/unavailable "
+            "(e.g. %s); deferring seed until next tick",
+            len(missing), 18, missing[0],
+        )
+        return None
 
     return read_programme_state(_lookup, inverter_name=inverter_name)

--- a/tests/test_inverter_state_reader.py
+++ b/tests/test_inverter_state_reader.py
@@ -146,3 +146,88 @@ class TestReadProgrammeState:
             self._make_lookup(values), inverter_name="inverter_2",
         )
         assert state.slots[0].capacity_soc == 42
+
+
+# -----------------------------------------------------------------------
+# read_from_hass - the HA adapter with defer-if-missing behaviour
+# -----------------------------------------------------------------------
+
+from types import SimpleNamespace
+
+from heo2.inverter_state_reader import read_from_hass
+
+
+def _fake_hass(entity_states: dict[str, str]):
+    """Build a minimal hass-like object with a states.get(eid) method.
+
+    entity_states maps entity_id -> state string. Missing entities
+    return None (as HA does for entities that don't exist)."""
+    def _get(entity_id: str):
+        state_val = entity_states.get(entity_id)
+        if state_val is None:
+            return None
+        return SimpleNamespace(state=state_val)
+
+    hass = SimpleNamespace()
+    hass.states = SimpleNamespace(get=_get)
+    return hass
+
+
+def _all_18_entities_populated() -> dict[str, str]:
+    """Build a dict of all 18 SA slot entities with plausible values.
+
+    Matches what Paddy's install had pre-HEO-27-direct-mqtt work."""
+    vals: dict[str, str] = {}
+    caps = [23, 100, 100, 100, 20, 20]
+    times = ["00:00", "05:30", "14:00", "15:00", "18:25", "23:30"]
+    for n in range(1, 7):
+        vals[f"sensor.sa_inverter_1_capacity_point_{n}"] = str(caps[n-1])
+        vals[f"sensor.sa_inverter_1_time_point_{n}"] = times[n-1]
+        vals[f"sensor.sa_inverter_1_grid_charge_point_{n}"] = "false"
+    return vals
+
+
+class TestReadFromHass:
+    def test_all_entities_present_returns_programme_state(self):
+        """Happy path: all 18 entities available, returns a real state."""
+        hass = _fake_hass(_all_18_entities_populated())
+        state = read_from_hass(hass)
+        assert state is not None
+        assert state.slots[0].capacity_soc == 23
+        assert state.slots[1].capacity_soc == 100
+        assert state.slots[4].capacity_soc == 20
+
+    def test_one_entity_missing_returns_none(self):
+        """If even one required entity is missing, defer by returning None.
+        Prevents seeding with fallback values on startup race."""
+        vals = _all_18_entities_populated()
+        del vals["sensor.sa_inverter_1_capacity_point_1"]
+        hass = _fake_hass(vals)
+        assert read_from_hass(hass) is None
+
+    def test_one_entity_unknown_returns_none(self):
+        """State value 'unknown' should be treated as missing."""
+        vals = _all_18_entities_populated()
+        vals["sensor.sa_inverter_1_time_point_3"] = "unknown"
+        hass = _fake_hass(vals)
+        assert read_from_hass(hass) is None
+
+    def test_one_entity_unavailable_returns_none(self):
+        """State 'unavailable' should be treated as missing too."""
+        vals = _all_18_entities_populated()
+        vals["sensor.sa_inverter_1_grid_charge_point_2"] = "unavailable"
+        hass = _fake_hass(vals)
+        assert read_from_hass(hass) is None
+
+    def test_empty_hass_returns_none(self):
+        """Cold-start HA with no entities yet discovered: returns None."""
+        hass = _fake_hass({})
+        assert read_from_hass(hass) is None
+
+    def test_custom_inverter_name_checked(self):
+        """When inverter_name='inverter_2', checks inverter_2 entities
+        (not inverter_1's). inverter_1 entities being present doesn't
+        help satisfy inverter_2 requirements."""
+        vals = _all_18_entities_populated()  # inverter_1 only
+        hass = _fake_hass(vals)
+        assert read_from_hass(hass, inverter_name="inverter_2") is None


### PR DESCRIPTION
Fixes startup race identified during PR #29 production verification. HEO II first tick ran at 21:10:38 and seeded with fallback cap=50 because HA's MQTT discovery hadn't populated sensor.sa_inverter_1_* entities yet. Result: 14-parameter bogus diff on every HA restart. This PR makes read_from_hass return None when any entity is missing, and coordinator defers seeding to next tick. 266 tests pass (up 6).