### PR TITLE
feat(HEO-14): BottlecapDave primary for live rates

### DIFF
--- a/custom_components/heo2/bottlecapdave_client.py
+++ b/custom_components/heo2/bottlecapdave_client.py
@@ -1,0 +1,312 @@
+# custom_components/heo2/bottlecapdave_client.py
+"""BottlecapDave Octopus Energy integration adapter.
+
+Reads live, published Octopus rates from BottlecapDave's `octopus_energy`
+HACS integration entities. This is HEO II's PRIMARY source for rates;
+AgilePredict is fallback only for prices beyond what BottlecapDave
+currently knows (typically tomorrow-after-tomorrow on Agile Outgoing).
+
+Defined in docs/SPEC.md hard rule H4 (Live-prices-only writes): the
+inverter is only ever programmed using prices Octopus has actually
+published. Predictions are for INTERNAL planning ONLY.
+
+## Entity patterns
+
+BottlecapDave creates entities of the form:
+
+    sensor.octopus_energy_electricity_{mpan}_{serial}_current_rate
+    sensor.octopus_energy_electricity_{mpan}_{serial}_export_current_rate
+    event.octopus_energy_electricity_{mpan}_{serial}_current_day_rates
+    event.octopus_energy_electricity_{mpan}_{serial}_next_day_rates
+    event.octopus_energy_electricity_{mpan}_{serial}_export_current_day_rates
+    event.octopus_energy_electricity_{mpan}_{serial}_export_next_day_rates
+
+State of `*_current_rate` sensors is the rate in GBP/kWh (so 0.132 = 13.2p).
+The `event.*_current_day_rates` entities expose all 30-min slots in their
+`attributes.rates`. Each rate dict has shape:
+
+    {
+      "start": "2026-04-30T23:30:00+01:00",
+      "end":   "2026-04-31T00:00:00+01:00",
+      "value_inc_vat": 0.04952,
+      "is_capped": False,
+      "is_intelligent_adjusted": False,
+    }
+
+We convert GBP/kWh to pence (x100) at the boundary because HEO II
+internally works in pence.
+
+## Auto-discovery
+
+The MPAN/serial varies per install, so we don't hard-code. The discovery
+helpers below scan entity ids for the {mpan}_{serial} key chunk and pick
+the meter whose entities were most recently updated. A multi-MPAN install
+will prefer the active meter automatically.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Iterable, Mapping
+
+from .models import RateSlot
+
+logger = logging.getLogger(__name__)
+
+# Conversion factor: BottlecapDave publishes GBP/kWh, HEO II uses p/kWh.
+GBP_TO_PENCE = 100.0
+
+# Single regex for both `_current_day_rates` and `_next_day_rates`,
+# import (no `_export_`) and export (with `_export_`).
+#
+# The non-greedy `(?P<key>.+?)` lets the engine pin the suffix first.
+# For an export entity id, the optional `(?P<export>export_)?` group
+# captures `export_` and `key` ends just before it. For an import entity
+# id the engine extends `key` further until the suffix matches without
+# `export_`. This is why a single combined regex works where two greedy
+# patterns would both match an export entity.
+RATES_EVENT_PATTERN = re.compile(
+    r"^event\.octopus_energy_electricity_"
+    r"(?P<key>.+?)"
+    r"_(?P<export>export_)?(?P<period>current|next)_day_rates$",
+    re.IGNORECASE,
+)
+
+RATE_SENSOR_PATTERN = re.compile(
+    r"^sensor\.octopus_energy_electricity_"
+    r"(?P<key>.+?)"
+    r"_(?P<export>export_)?current_rate$",
+    re.IGNORECASE,
+)
+
+
+@dataclass
+class BottlecapDaveRates:
+    """Snapshot of all rates HEO II reads from BottlecapDave.
+
+    Every rate is in pence/kWh (already converted from GBP).
+    Lists are empty and `*_now_pence` are None when the corresponding
+    BottlecapDave entity is missing or unavailable - callers must
+    handle absence rather than falling back silently.
+    """
+
+    import_today: list[RateSlot] = field(default_factory=list)
+    import_tomorrow: list[RateSlot] = field(default_factory=list)
+    export_today: list[RateSlot] = field(default_factory=list)
+    export_tomorrow: list[RateSlot] = field(default_factory=list)
+    import_now_pence: float | None = None
+    export_now_pence: float | None = None
+    meter_key: str | None = None
+
+    @property
+    def has_any_data(self) -> bool:
+        """True if at least one BD entity returned usable data."""
+        return bool(
+            self.import_today
+            or self.import_tomorrow
+            or self.export_today
+            or self.export_tomorrow
+            or self.import_now_pence is not None
+            or self.export_now_pence is not None
+        )
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers (no Home Assistant imports) - unit-testable in isolation
+# ---------------------------------------------------------------------------
+
+
+def discover_meter_keys(entity_ids: Iterable[str]) -> set[str]:
+    """Return all unique BottlecapDave meter keys (`{mpan}_{serial}`) found
+    in the given entity ids. Empty set if BottlecapDave isn't installed.
+    """
+    keys: set[str] = set()
+    for eid in entity_ids:
+        if not isinstance(eid, str):
+            continue
+        norm = eid.lower()
+        for pattern in (RATES_EVENT_PATTERN, RATE_SENSOR_PATTERN):
+            m = pattern.match(norm)
+            if m:
+                keys.add(m.group("key"))
+                break
+    return keys
+
+
+def pick_freshest_meter_key(
+    keys_to_freshness: Mapping[str, datetime | None],
+) -> str | None:
+    """Pick the meter key with the most recent freshness timestamp.
+
+    Multi-MPAN installs publish entities for each meter. Picking the one
+    whose entities updated most recently selects the active meter without
+    any per-install configuration.
+
+    `None` freshness sorts oldest. Returns None if input is empty.
+    """
+    if not keys_to_freshness:
+        return None
+    oldest = datetime.min.replace(tzinfo=timezone.utc)
+
+    def freshness(key: str) -> datetime:
+        ts = keys_to_freshness.get(key)
+        return ts if ts is not None else oldest
+
+    return max(keys_to_freshness, key=freshness)
+
+
+def parse_event_rates(attr_rates: object) -> list[RateSlot]:
+    """Convert BottlecapDave's `event.*_day_rates.attributes.rates` list
+    into RateSlots, applying GBP -> pence conversion.
+
+    Tolerates malformed individual entries (skips), missing keys, and
+    non-list inputs (returns empty). Returned slots are UTC-aware and
+    sorted by start time.
+    """
+    if not isinstance(attr_rates, list) or not attr_rates:
+        return []
+
+    out: list[RateSlot] = []
+    for entry in attr_rates:
+        if not isinstance(entry, dict):
+            continue
+        start_raw = entry.get("start")
+        end_raw = entry.get("end")
+        value_raw = entry.get("value_inc_vat")
+        if start_raw is None or end_raw is None or value_raw is None:
+            continue
+        try:
+            start = datetime.fromisoformat(str(start_raw)).astimezone(timezone.utc)
+            end = datetime.fromisoformat(str(end_raw)).astimezone(timezone.utc)
+            pence = float(value_raw) * GBP_TO_PENCE
+        except (ValueError, TypeError):
+            continue
+        out.append(RateSlot(start=start, end=end, rate_pence=pence))
+
+    out.sort(key=lambda r: r.start)
+    return out
+
+
+def parse_current_rate_pence(state: object) -> float | None:
+    """Convert a BottlecapDave `*_current_rate` sensor state to pence.
+
+    BD publishes the value as a string-typed float in GBP/kWh. Returns
+    None when the entity is missing or in an unknown/unavailable state.
+    """
+    if state is None:
+        return None
+    text = str(state).strip().lower()
+    if text in ("", "unknown", "unavailable", "none"):
+        return None
+    try:
+        return float(state) * GBP_TO_PENCE
+    except (ValueError, TypeError):
+        return None
+
+
+def merge_rate_sources(
+    live: list[RateSlot],
+    fallback: list[RateSlot],
+) -> list[RateSlot]:
+    """Merge a primary `live` rates list with a `fallback` list.
+
+    Used to extend BD's published rates (live) with AgilePredict / IGO
+    fixed slots (fallback) for windows BD doesn't yet cover. A fallback
+    slot is dropped if it overlaps any live slot - live always wins.
+
+    Result is sorted by start time. Either input may be empty.
+    """
+    if not fallback:
+        return list(live)
+    if not live:
+        return list(fallback)
+
+    def overlaps(a: RateSlot, b: RateSlot) -> bool:
+        return a.start < b.end and b.start < a.end
+
+    out = list(live)
+    for f in fallback:
+        if not any(overlaps(f, l) for l in live):
+            out.append(f)
+    out.sort(key=lambda r: r.start)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Home Assistant adapter
+# ---------------------------------------------------------------------------
+
+
+def read_bottlecapdave_rates(hass) -> BottlecapDaveRates:
+    """Read all BottlecapDave rate data from HA into a single snapshot.
+
+    Returns an empty `BottlecapDaveRates` when BottlecapDave isn't
+    installed or no entities are populated yet (HA startup race).
+    Never raises - always returns a usable structure so the coordinator
+    can keep ticking. Caller checks `has_any_data` to decide whether to
+    proceed with writes (H4) or fall back.
+    """
+    if hass is None or getattr(hass, "states", None) is None:
+        return BottlecapDaveRates()
+
+    try:
+        all_states = list(hass.states.async_all())
+    except Exception:  # pragma: no cover - defensive for stub envs
+        return BottlecapDaveRates()
+
+    # Group states by meter key, tracking max last_updated for freshness.
+    keys_to_freshness: dict[str, datetime | None] = {}
+    for state in all_states:
+        eid = getattr(state, "entity_id", "")
+        if not eid:
+            continue
+        norm = eid.lower()
+        match = (
+            RATES_EVENT_PATTERN.match(norm)
+            or RATE_SENSOR_PATTERN.match(norm)
+        )
+        if not match:
+            continue
+        key = match.group("key")
+        ts = getattr(state, "last_updated", None)
+        prev = keys_to_freshness.get(key)
+        if prev is None or (ts is not None and ts > prev):
+            keys_to_freshness[key] = ts
+
+    chosen = pick_freshest_meter_key(keys_to_freshness)
+    if chosen is None:
+        return BottlecapDaveRates()
+
+    base = f"octopus_energy_electricity_{chosen}"
+
+    def _state(entity_id: str):
+        st = hass.states.get(entity_id)
+        if st is None:
+            return None
+        return st.state
+
+    def _attr_rates(entity_id: str):
+        st = hass.states.get(entity_id)
+        if st is None:
+            return None
+        attrs = getattr(st, "attributes", None) or {}
+        return attrs.get("rates")
+
+    return BottlecapDaveRates(
+        import_today=parse_event_rates(_attr_rates(f"event.{base}_current_day_rates")),
+        import_tomorrow=parse_event_rates(_attr_rates(f"event.{base}_next_day_rates")),
+        export_today=parse_event_rates(
+            _attr_rates(f"event.{base}_export_current_day_rates")
+        ),
+        export_tomorrow=parse_event_rates(
+            _attr_rates(f"event.{base}_export_next_day_rates")
+        ),
+        import_now_pence=parse_current_rate_pence(_state(f"sensor.{base}_current_rate")),
+        export_now_pence=parse_current_rate_pence(
+            _state(f"sensor.{base}_export_current_rate")
+        ),
+        meter_key=chosen,
+    )

--- a/custom_components/heo2/coordinator.py
+++ b/custom_components/heo2/coordinator.py
@@ -18,6 +18,11 @@ from .rules import default_rules
 from .load_profile import LoadProfileBuilder
 from .solar_forecast import solar_forecast_from_hacs
 from .agilepredict_client import AgilePredictClient
+from .bottlecapdave_client import (
+    BottlecapDaveRates,
+    merge_rate_sources,
+    read_bottlecapdave_rates,
+)
 from .appliance_timing import ApplianceTimingCalculator, ApplianceSuggestion
 from .const import DEFAULT_APPLIANCES
 from .soc_trajectory import calculate_soc_trajectory
@@ -87,6 +92,13 @@ class HEO2Coordinator(DataUpdateCoordinator):
         self.appliance_suggestions: dict[str, ApplianceSuggestion] = {}
         self.enabled: bool = True
         self.healthy: bool = True
+        # H4 (live-prices-only writes): cleared when BottlecapDave returns
+        # no live rate data for the current tick. Used by writes_blocked
+        # property and as a guard before MQTT writes go out. Defaults True
+        # so the first tick (before _gather_inputs) doesn't spuriously
+        # block; the subsequent tick with real data sets the actual value.
+        self._live_rates_present: bool = True
+        self._bottlecapdave_meter_key: str | None = None
 
         # Dashboard state
         self.soc_trajectory: list[float] = [0.0] * 24
@@ -164,6 +176,19 @@ class HEO2Coordinator(DataUpdateCoordinator):
         Lazy-seeds the writer and last-known state on the first call after
         HA startup, when SA's MQTT discovery has populated the entities.
         """
+        # SPEC H4 (Live-prices-only writes): if BottlecapDave returned no
+        # live rates this tick the programme may have been driven by
+        # AgilePredict (forecast) or IGO fixed-rate slots, not by prices
+        # Octopus has actually published. Skip the write entirely - the
+        # next tick will retry once BD is back. The writes_blocked sensor
+        # already reflects this state for the dashboard.
+        if not self._live_rates_present:
+            logger.warning(
+                "HEO-14: skipping inverter write - no live BottlecapDave "
+                "rates (SPEC H4); will retry next tick",
+            )
+            return
+
         # Lazy construct writer on first use. HA startup sequence can race
         # with mqtt component availability, hence deferring past __init__.
         # The DirectMqttTransport connects directly to SA's broker rather
@@ -283,14 +308,51 @@ class HEO2Coordinator(DataUpdateCoordinator):
 
         solar = self._read_solar_forecast(now)
 
-        export_rates = []
+        # HEO-14: BottlecapDave is the PRIMARY rate source per SPEC H4.
+        # AgilePredict (export) and IGO fixed-rate generator (import) are
+        # fallback only - to extend coverage past BD's horizon, or as a
+        # backstop when BD's entities aren't yet populated. Writes are
+        # blocked when BD returns nothing (see _live_rates_present).
+        bd_rates = read_bottlecapdave_rates(self.hass)
+        live_import_rates = list(bd_rates.import_today) + list(bd_rates.import_tomorrow)
+        live_export_rates = list(bd_rates.export_today) + list(bd_rates.export_tomorrow)
+
+        forecast_export_rates: list = []
         if self._agilepredict:
-            export_rates = await self._agilepredict.fetch_export_rates()
+            forecast_export_rates = await self._agilepredict.fetch_export_rates()
+
+        igo_import_rates = self._build_import_rates(now)
+
+        # Merged "best available" set: BD wins for any window it covers,
+        # forecast/IGO-fixed fills the tail. Rules and dashboard sensors
+        # consume these; the live_* subsets are reserved for H4 enforcement.
+        import_rates = merge_rate_sources(live_import_rates, igo_import_rates)
+        export_rates = merge_rate_sources(live_export_rates, forecast_export_rates)
+
+        # H4 gate. Conservative AND: writes need both directions live.
+        # Either being empty means a rule could be acting on forecast
+        # data, which violates SPEC H4 once it reaches the inverter.
+        prev_present = self._live_rates_present
+        self._live_rates_present = bool(live_import_rates) and bool(live_export_rates)
+        self._bottlecapdave_meter_key = bd_rates.meter_key
+
+        if not self._live_rates_present:
+            logger.warning(
+                "HEO-14: BottlecapDave incomplete (import=%d slots, export=%d slots, "
+                "meter_key=%s); blocking writes per SPEC H4",
+                len(live_import_rates), len(live_export_rates),
+                bd_rates.meter_key,
+            )
+        elif not prev_present:
+            logger.warning(
+                "HEO-14: BottlecapDave rates restored (meter_key=%s, import=%d, "
+                "export=%d slots); writes unblocked",
+                bd_rates.meter_key,
+                len(live_import_rates), len(live_export_rates),
+            )
 
         load_profile = self._load_builder.build()
         load_forecast = load_profile.for_datetime(now)
-
-        import_rates = self._build_import_rates(now)
 
         return ProgrammeInputs(
             now=now,
@@ -309,6 +371,8 @@ class HEO2Coordinator(DataUpdateCoordinator):
             grid_connected=True,
             active_appliances=[],
             appliance_expected_kwh=0.0,
+            live_import_rates=live_import_rates,
+            live_export_rates=live_export_rates,
         )
 
     def _read_entity_float(self, entity_id: str, default: float) -> float:
@@ -589,6 +653,7 @@ class HEO2Coordinator(DataUpdateCoordinator):
           - dry_run is True (writes suppressed by config)
           - MqttWriter hasn't been constructed yet (early startup)
           - DirectMqttTransport exists but is not connected
+          - HEO-14: BottlecapDave returned no live rates (SPEC H4)
         """
         blocked, _ = _compute_writes_blocked(
             dry_run=self._writer_dry_run,
@@ -599,6 +664,7 @@ class HEO2Coordinator(DataUpdateCoordinator):
                 if self._mqtt_transport is not None else False
             ),
             host=self._sa_mqtt_host,
+            live_rates_present=self._live_rates_present,
         )
         return blocked
 
@@ -615,5 +681,6 @@ class HEO2Coordinator(DataUpdateCoordinator):
                 if self._mqtt_transport is not None else False
             ),
             host=self._sa_mqtt_host,
+            live_rates_present=self._live_rates_present,
         )
         return reason

--- a/custom_components/heo2/models.py
+++ b/custom_components/heo2/models.py
@@ -169,7 +169,18 @@ class ProgrammeState:
 
 @dataclass
 class ProgrammeInputs:
-    """All inputs gathered by the coordinator for a programme calculation."""
+    """All inputs gathered by the coordinator for a programme calculation.
+
+    `import_rates` and `export_rates` are the merged "best available"
+    schedules: BottlecapDave's published Octopus rates first, with
+    AgilePredict (export) and IGO fixed-rate slots (import) filling any
+    gaps beyond BD's horizon. Rules and dashboard sensors read these.
+
+    `live_import_rates` and `live_export_rates` are the BottlecapDave-only
+    subset, used to enforce SPEC hard rule H4 (Live-prices-only writes).
+    Empty when BD is unavailable; the coordinator blocks inverter writes
+    in that state. Predictions never reach the inverter.
+    """
     now: datetime
     current_soc: float
     battery_capacity_kwh: float
@@ -186,6 +197,8 @@ class ProgrammeInputs:
     grid_connected: bool
     active_appliances: list[str]
     appliance_expected_kwh: float
+    live_import_rates: list[RateSlot] = field(default_factory=list)
+    live_export_rates: list[RateSlot] = field(default_factory=list)
 
     def rate_at(self, dt: datetime) -> float | None:
         """Find the import rate at a specific datetime. Returns None if no rate covers it."""

--- a/custom_components/heo2/writes_status.py
+++ b/custom_components/heo2/writes_status.py
@@ -17,6 +17,7 @@ def _compute_writes_blocked(
     transport_exists: bool,
     transport_connected: bool,
     host: str,
+    live_rates_present: bool = True,
 ) -> tuple[bool, str]:
     """Determine if writes are currently blocked and why.
 
@@ -24,10 +25,16 @@ def _compute_writes_blocked(
     When blocked=True, reason is a short human-readable explanation for
     the dashboard.
 
-    Order of checks matters: dry_run takes precedence over transport
-    state because dry_run is an intentional user choice - reporting
-    "transport disconnected" when the user has explicitly disabled
-    writes would be misleading.
+    Order of checks matters:
+      1. dry_run takes precedence over everything else - it's an
+         intentional user choice; reporting any other reason would be
+         misleading.
+      2. Transport readiness comes next so early-startup state is
+         described accurately.
+      3. SPEC H4 (live-prices-only writes) is checked last: by this
+         point the transport is up, so the only remaining reason to
+         block is missing live BottlecapDave rates. The default True
+         keeps backward compatibility for callers that pre-date HEO-14.
     """
     if dry_run:
         return True, "dry_run enabled"
@@ -35,4 +42,6 @@ def _compute_writes_blocked(
         return True, "MQTT writer not yet initialised"
     if not transport_connected:
         return True, f"MQTT transport disconnected from {host}"
+    if not live_rates_present:
+        return True, "HEO-14: no live BottlecapDave rates (SPEC H4)"
     return False, ""

--- a/tests/test_bottlecapdave_client.py
+++ b/tests/test_bottlecapdave_client.py
@@ -1,0 +1,503 @@
+# tests/test_bottlecapdave_client.py
+"""Tests for the BottlecapDave Octopus Energy adapter (HEO-14).
+
+The pure helpers (parsing, discovery, merging) are tested in isolation.
+The HA-side `read_bottlecapdave_rates` is exercised through a minimal
+mock-hass that mimics `hass.states.async_all()` and `hass.states.get()`.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+
+import pytest
+
+from heo2.bottlecapdave_client import (
+    GBP_TO_PENCE,
+    BottlecapDaveRates,
+    discover_meter_keys,
+    merge_rate_sources,
+    parse_current_rate_pence,
+    parse_event_rates,
+    pick_freshest_meter_key,
+    read_bottlecapdave_rates,
+)
+from heo2.models import RateSlot
+
+UTC = timezone.utc
+
+
+# ---------------------------------------------------------------------------
+# Fixtures: realistic BottlecapDave shapes
+# ---------------------------------------------------------------------------
+
+# Real-world example shape from BottlecapDave's `event.*_day_rates`. Values
+# in GBP/kWh, 30-min slots, ISO-formatted local time.
+SAMPLE_EXPORT_TODAY_RATES = [
+    {
+        "start": "2026-04-30T23:00:00+01:00",
+        "end": "2026-04-30T23:30:00+01:00",
+        "value_inc_vat": 0.04952,
+        "is_capped": False,
+        "is_intelligent_adjusted": False,
+    },
+    {
+        "start": "2026-04-30T23:30:00+01:00",
+        "end": "2026-05-01T00:00:00+01:00",
+        "value_inc_vat": 0.13150,
+        "is_capped": False,
+        "is_intelligent_adjusted": False,
+    },
+]
+
+SAMPLE_IMPORT_TODAY_RATES = [
+    {
+        "start": "2026-04-30T23:30:00+01:00",
+        "end": "2026-05-01T00:00:00+01:00",
+        "value_inc_vat": 0.04952,  # IGO off-peak
+        "is_capped": False,
+    },
+    {
+        "start": "2026-05-01T05:30:00+01:00",
+        "end": "2026-05-01T06:00:00+01:00",
+        "value_inc_vat": 0.24842,  # IGO peak
+        "is_capped": False,
+    },
+]
+
+
+def _state(entity_id: str, value: object, last_updated: datetime | None = None,
+           attributes: dict | None = None):
+    """Build a State-like object suitable for hass.states.get() / async_all()."""
+    return SimpleNamespace(
+        entity_id=entity_id,
+        state=value,
+        last_updated=last_updated,
+        attributes=attributes or {},
+    )
+
+
+def _make_hass(states: list):
+    """Mock hass with `states.get()` and `states.async_all()`."""
+    by_id = {s.entity_id: s for s in states}
+
+    class _States:
+        def get(self, entity_id):
+            return by_id.get(entity_id)
+
+        def async_all(self):
+            return list(by_id.values())
+
+    return SimpleNamespace(states=_States())
+
+
+# ---------------------------------------------------------------------------
+# parse_event_rates
+# ---------------------------------------------------------------------------
+
+
+class TestParseEventRates:
+    def test_converts_gbp_to_pence(self):
+        rates = parse_event_rates(SAMPLE_EXPORT_TODAY_RATES)
+        # 0.04952 GBP/kWh * 100 = 4.952 p/kWh
+        assert rates[0].rate_pence == pytest.approx(4.952)
+        # 0.13150 * 100 = 13.150
+        assert rates[1].rate_pence == pytest.approx(13.150)
+
+    def test_returns_utc_aware_slots(self):
+        rates = parse_event_rates(SAMPLE_EXPORT_TODAY_RATES)
+        # 23:00 +01:00 == 22:00 UTC
+        assert rates[0].start == datetime(2026, 4, 30, 22, 0, tzinfo=UTC)
+        assert rates[0].end == datetime(2026, 4, 30, 22, 30, tzinfo=UTC)
+        assert rates[0].start.tzinfo is not None
+
+    def test_sorts_by_start_time(self):
+        unsorted = [
+            SAMPLE_EXPORT_TODAY_RATES[1],  # 23:30
+            SAMPLE_EXPORT_TODAY_RATES[0],  # 23:00
+        ]
+        rates = parse_event_rates(unsorted)
+        assert rates[0].start < rates[1].start
+
+    def test_empty_input_returns_empty(self):
+        assert parse_event_rates([]) == []
+        assert parse_event_rates(None) == []
+
+    def test_non_list_input_returns_empty(self):
+        assert parse_event_rates("not a list") == []
+        assert parse_event_rates({"rates": []}) == []
+
+    def test_skips_malformed_entries(self):
+        bad = [
+            {"start": "2026-04-30T23:00:00+01:00",
+             "end": "2026-04-30T23:30:00+01:00",
+             "value_inc_vat": 0.05},
+            {"start": "broken", "end": "broken", "value_inc_vat": 0.10},
+            None,
+            {"start": "2026-04-30T23:30:00+01:00",
+             "end": "2026-05-01T00:00:00+01:00",
+             "value_inc_vat": 0.06},
+            {"value_inc_vat": 0.99},  # missing start/end
+        ]
+        rates = parse_event_rates(bad)
+        assert len(rates) == 2
+        assert rates[0].rate_pence == pytest.approx(5.0)
+        assert rates[1].rate_pence == pytest.approx(6.0)
+
+
+# ---------------------------------------------------------------------------
+# parse_current_rate_pence
+# ---------------------------------------------------------------------------
+
+
+class TestParseCurrentRatePence:
+    def test_converts_gbp_string_to_pence(self):
+        # 0.132 GBP/kWh -> 13.2 p/kWh
+        assert parse_current_rate_pence("0.132") == pytest.approx(13.2)
+
+    def test_handles_float_input(self):
+        assert parse_current_rate_pence(0.04952) == pytest.approx(4.952)
+
+    def test_returns_none_for_unavailable(self):
+        assert parse_current_rate_pence("unavailable") is None
+        assert parse_current_rate_pence("unknown") is None
+        assert parse_current_rate_pence("") is None
+        assert parse_current_rate_pence("none") is None
+        assert parse_current_rate_pence(None) is None
+
+    def test_returns_none_for_garbage(self):
+        assert parse_current_rate_pence("not a number") is None
+        assert parse_current_rate_pence("x") is None
+
+
+# ---------------------------------------------------------------------------
+# discover_meter_keys
+# ---------------------------------------------------------------------------
+
+
+class TestDiscoverMeterKeys:
+    def test_finds_event_pattern(self):
+        keys = discover_meter_keys([
+            "event.octopus_energy_electricity_1850009498_2394300396097_current_day_rates",
+        ])
+        assert keys == {"1850009498_2394300396097"}
+
+    def test_finds_sensor_pattern(self):
+        keys = discover_meter_keys([
+            "sensor.octopus_energy_electricity_1850009498_2394300396097_current_rate",
+        ])
+        assert keys == {"1850009498_2394300396097"}
+
+    def test_distinguishes_import_export_suffix(self):
+        """Critical: `_export_current_day_rates` must not match the
+        import pattern with `_export` swallowed into the meter key."""
+        keys = discover_meter_keys([
+            "event.octopus_energy_electricity_18p5009498_2394300396097_current_day_rates",
+            "event.octopus_energy_electricity_18p5009498_2394300396097_export_current_day_rates",
+            "event.octopus_energy_electricity_18p5009498_2394300396097_next_day_rates",
+            "event.octopus_energy_electricity_18p5009498_2394300396097_export_next_day_rates",
+        ])
+        # All four must collapse to the same key - if export bled into
+        # the key we'd get a second key like "..._export".
+        assert keys == {"18p5009498_2394300396097"}
+
+    def test_handles_mpan_with_letter(self):
+        """Real-world example from #16 has 'p' in MPAN."""
+        keys = discover_meter_keys([
+            "sensor.octopus_energy_electricity_18p5009498_2394300396097_current_rate",
+        ])
+        assert keys == {"18p5009498_2394300396097"}
+
+    def test_ignores_non_octopus_entities(self):
+        keys = discover_meter_keys([
+            "sensor.solcast_pv_forecast_forecast_today",
+            "sensor.sa_inverter_1_capacity_point_1",
+            "binary_sensor.heo_ii_writes_blocked",
+        ])
+        assert keys == set()
+
+    def test_finds_multiple_meters(self):
+        keys = discover_meter_keys([
+            "sensor.octopus_energy_electricity_1234567890_aaa1_current_rate",
+            "sensor.octopus_energy_electricity_9999999999_bbb2_current_rate",
+        ])
+        assert keys == {"1234567890_aaa1", "9999999999_bbb2"}
+
+    def test_handles_non_string_inputs(self):
+        # Defensive: hass.states.async_all() should yield strings, but
+        # protect against garbage just in case.
+        keys = discover_meter_keys([None, 42, "not_an_octopus_entity"])
+        assert keys == set()
+
+
+# ---------------------------------------------------------------------------
+# pick_freshest_meter_key
+# ---------------------------------------------------------------------------
+
+
+class TestPickFreshestMeterKey:
+    def test_returns_most_recent(self):
+        old = datetime(2026, 4, 30, 12, 0, tzinfo=UTC)
+        new = datetime(2026, 4, 30, 13, 0, tzinfo=UTC)
+        result = pick_freshest_meter_key({
+            "old_meter": old,
+            "new_meter": new,
+        })
+        assert result == "new_meter"
+
+    def test_empty_returns_none(self):
+        assert pick_freshest_meter_key({}) is None
+
+    def test_single_key_returned(self):
+        ts = datetime(2026, 4, 30, 12, 0, tzinfo=UTC)
+        assert pick_freshest_meter_key({"only": ts}) == "only"
+
+    def test_none_freshness_sorts_oldest(self):
+        ts = datetime(2026, 4, 30, 12, 0, tzinfo=UTC)
+        result = pick_freshest_meter_key({
+            "missing_ts": None,
+            "with_ts": ts,
+        })
+        assert result == "with_ts"
+
+
+# ---------------------------------------------------------------------------
+# merge_rate_sources
+# ---------------------------------------------------------------------------
+
+
+def _slot(start_h: int, end_h: int, pence: float, day: int = 30) -> RateSlot:
+    return RateSlot(
+        start=datetime(2026, 4, day, start_h, 0, tzinfo=UTC),
+        end=datetime(2026, 4, day, end_h, 0, tzinfo=UTC),
+        rate_pence=pence,
+    )
+
+
+class TestMergeRateSources:
+    def test_empty_live_returns_fallback(self):
+        fb = [_slot(0, 1, 5.0)]
+        assert merge_rate_sources([], fb) == fb
+
+    def test_empty_fallback_returns_live(self):
+        live = [_slot(0, 1, 5.0)]
+        assert merge_rate_sources(live, []) == live
+
+    def test_live_wins_over_fallback_at_same_window(self):
+        live = [_slot(10, 11, 5.0)]
+        fb = [_slot(10, 11, 99.0)]
+        merged = merge_rate_sources(live, fb)
+        assert len(merged) == 1
+        assert merged[0].rate_pence == 5.0
+
+    def test_fallback_extends_past_live_horizon(self):
+        live = [_slot(10, 11, 5.0)]
+        fb = [_slot(11, 12, 6.0), _slot(12, 13, 7.0)]
+        merged = merge_rate_sources(live, fb)
+        assert [s.rate_pence for s in merged] == [5.0, 6.0, 7.0]
+
+    def test_overlap_drops_fallback_slot(self):
+        live = [_slot(10, 12, 5.0)]
+        fb = [_slot(11, 13, 99.0)]  # partial overlap
+        merged = merge_rate_sources(live, fb)
+        assert merged == [_slot(10, 12, 5.0)]
+
+    def test_result_sorted_by_start(self):
+        live = [_slot(15, 16, 5.0)]
+        fb = [_slot(10, 11, 6.0), _slot(20, 21, 7.0)]
+        merged = merge_rate_sources(live, fb)
+        assert [s.start.hour for s in merged] == [10, 15, 20]
+
+
+# ---------------------------------------------------------------------------
+# read_bottlecapdave_rates (HA adapter)
+# ---------------------------------------------------------------------------
+
+
+def _make_meter_states(meter_key: str, last_updated: datetime,
+                       *, with_export: bool = True,
+                       with_tomorrow: bool = False) -> list:
+    base = f"octopus_energy_electricity_{meter_key}"
+    states = [
+        _state(f"sensor.{base}_current_rate", "0.04952", last_updated),
+        _state(
+            f"event.{base}_current_day_rates",
+            "today",
+            last_updated,
+            attributes={"rates": SAMPLE_IMPORT_TODAY_RATES},
+        ),
+    ]
+    if with_export:
+        states.append(_state(
+            f"sensor.{base}_export_current_rate", "0.13150", last_updated,
+        ))
+        states.append(_state(
+            f"event.{base}_export_current_day_rates",
+            "today",
+            last_updated,
+            attributes={"rates": SAMPLE_EXPORT_TODAY_RATES},
+        ))
+    if with_tomorrow:
+        states.append(_state(
+            f"event.{base}_next_day_rates",
+            "tomorrow",
+            last_updated,
+            attributes={"rates": SAMPLE_IMPORT_TODAY_RATES},
+        ))
+        if with_export:
+            states.append(_state(
+                f"event.{base}_export_next_day_rates",
+                "tomorrow",
+                last_updated,
+                attributes={"rates": SAMPLE_EXPORT_TODAY_RATES},
+            ))
+    return states
+
+
+class TestReadBottlecapDaveRates:
+    def test_happy_path(self):
+        ts = datetime(2026, 4, 30, 12, 0, tzinfo=UTC)
+        hass = _make_hass(_make_meter_states("1850009498_2394300396097", ts,
+                                             with_tomorrow=True))
+        result = read_bottlecapdave_rates(hass)
+
+        assert result.meter_key == "1850009498_2394300396097"
+        assert result.has_any_data is True
+        assert result.import_now_pence == pytest.approx(4.952)
+        assert result.export_now_pence == pytest.approx(13.150)
+        assert len(result.import_today) == 2
+        assert len(result.export_today) == 2
+        assert len(result.import_tomorrow) == 2
+        assert len(result.export_tomorrow) == 2
+
+    def test_returns_empty_when_bd_not_installed(self):
+        # Only non-octopus entities present
+        hass = _make_hass([
+            _state("sensor.solcast_pv_forecast_forecast_today", "10.5"),
+            _state("binary_sensor.heo_ii_writes_blocked", "off"),
+        ])
+        result = read_bottlecapdave_rates(hass)
+        assert result.has_any_data is False
+        assert result.meter_key is None
+        assert result.import_today == []
+        assert result.export_today == []
+        assert result.import_now_pence is None
+
+    def test_returns_empty_when_hass_none(self):
+        result = read_bottlecapdave_rates(None)
+        assert result.has_any_data is False
+        assert result.meter_key is None
+
+    def test_picks_freshest_meter_when_multiple(self):
+        old = datetime(2026, 4, 30, 6, 0, tzinfo=UTC)
+        new = datetime(2026, 4, 30, 16, 0, tzinfo=UTC)
+        states = (
+            _make_meter_states("oldmeter_aaaa", old)
+            + _make_meter_states("freshmeter_bbbb", new)
+        )
+        hass = _make_hass(states)
+        result = read_bottlecapdave_rates(hass)
+        assert result.meter_key == "freshmeter_bbbb"
+
+    def test_partial_data_ok(self):
+        """Today's import published, but export tomorrow not yet -
+        the missing entity simply yields an empty list, not a crash."""
+        ts = datetime(2026, 4, 30, 12, 0, tzinfo=UTC)
+        # Only the import current_rate sensor and current_day_rates event
+        states = [
+            _state(
+                "sensor.octopus_energy_electricity_meter1_meter1_current_rate",
+                "0.04952", ts,
+            ),
+            _state(
+                "event.octopus_energy_electricity_meter1_meter1_current_day_rates",
+                "today",
+                ts,
+                attributes={"rates": SAMPLE_IMPORT_TODAY_RATES},
+            ),
+        ]
+        hass = _make_hass(states)
+        result = read_bottlecapdave_rates(hass)
+        assert result.import_now_pence == pytest.approx(4.952)
+        assert result.export_now_pence is None
+        assert len(result.import_today) == 2
+        assert result.export_today == []
+        assert result.import_tomorrow == []
+
+    def test_unavailable_state_yields_none(self):
+        ts = datetime(2026, 4, 30, 12, 0, tzinfo=UTC)
+        states = [
+            _state(
+                "sensor.octopus_energy_electricity_meter1_meter1_current_rate",
+                "unavailable", ts,
+            ),
+            _state(
+                "event.octopus_energy_electricity_meter1_meter1_current_day_rates",
+                "today",
+                ts,
+                attributes={"rates": []},
+            ),
+        ]
+        hass = _make_hass(states)
+        result = read_bottlecapdave_rates(hass)
+        assert result.import_now_pence is None
+        assert result.import_today == []
+
+    def test_rate_now_matches_30min_slot_from_event_attribute(self):
+        """Defensive: BD's `current_rate` sensor and the active 30-min
+        slot in `current_day_rates` should agree. Test that we return
+        both faithfully so callers can verify."""
+        ts = datetime(2026, 4, 30, 12, 0, tzinfo=UTC)
+        # current_rate matches the second slot's value
+        bespoke_rates = [
+            {"start": "2026-04-30T11:00:00+00:00",
+             "end": "2026-04-30T11:30:00+00:00",
+             "value_inc_vat": 0.06000},
+            {"start": "2026-04-30T11:30:00+00:00",
+             "end": "2026-04-30T12:00:00+00:00",
+             "value_inc_vat": 0.07000},
+            {"start": "2026-04-30T12:00:00+00:00",
+             "end": "2026-04-30T12:30:00+00:00",
+             "value_inc_vat": 0.08000},
+        ]
+        states = [
+            _state(
+                "sensor.octopus_energy_electricity_meter1_meter1_current_rate",
+                "0.08000", ts,
+            ),
+            _state(
+                "event.octopus_energy_electricity_meter1_meter1_current_day_rates",
+                "today",
+                ts,
+                attributes={"rates": bespoke_rates},
+            ),
+        ]
+        hass = _make_hass(states)
+        result = read_bottlecapdave_rates(hass)
+        assert result.import_now_pence == pytest.approx(8.0)
+        # The slot covering 12:00 UTC is the third one (8.0p)
+        now = datetime(2026, 4, 30, 12, 15, tzinfo=UTC)
+        match = [s for s in result.import_today if s.start <= now < s.end]
+        assert len(match) == 1
+        assert match[0].rate_pence == pytest.approx(8.0)
+
+
+# ---------------------------------------------------------------------------
+# BottlecapDaveRates dataclass
+# ---------------------------------------------------------------------------
+
+
+class TestBottlecapDaveRatesDataclass:
+    def test_default_is_empty(self):
+        r = BottlecapDaveRates()
+        assert r.has_any_data is False
+        assert r.import_today == []
+        assert r.export_today == []
+        assert r.import_now_pence is None
+        assert r.export_now_pence is None
+        assert r.meter_key is None
+
+    def test_has_any_data_true_with_just_one_field(self):
+        r = BottlecapDaveRates(import_now_pence=4.95)
+        assert r.has_any_data is True

--- a/tests/test_writes_status.py
+++ b/tests/test_writes_status.py
@@ -73,6 +73,48 @@ class TestComputeWritesBlocked:
         assert blocked is False
         assert reason == ""
 
+    def test_no_live_rates_blocks_writes(self):
+        """HEO-14: SPEC H4 forbids inverter writes without live BD rates."""
+        blocked, reason = _compute_writes_blocked(
+            dry_run=False,
+            writer_constructed=True,
+            transport_exists=True,
+            transport_connected=True,
+            host="192.168.4.7",
+            live_rates_present=False,
+        )
+        assert blocked is True
+        assert "BottlecapDave" in reason or "HEO-14" in reason
+        assert "H4" in reason
+
+    def test_dry_run_takes_precedence_over_no_live_rates(self):
+        """If user has explicitly disabled writes, that's the reason
+        reported - not a downstream H4 reason that's also true."""
+        blocked, reason = _compute_writes_blocked(
+            dry_run=True,
+            writer_constructed=True,
+            transport_exists=True,
+            transport_connected=True,
+            host="192.168.4.7",
+            live_rates_present=False,
+        )
+        assert blocked is True
+        assert "dry_run" in reason
+        assert "H4" not in reason
+
+    def test_default_live_rates_present_is_true(self):
+        """Backward-compat: callers from before HEO-14 don't pass the
+        flag, so the default must not silently start blocking."""
+        blocked, reason = _compute_writes_blocked(
+            dry_run=False,
+            writer_constructed=True,
+            transport_exists=True,
+            transport_connected=True,
+            host="192.168.4.7",
+        )
+        assert blocked is False
+        assert reason == ""
+
     def test_host_appears_in_disconnect_reason(self):
         """Custom host should appear in the reason so multi-install
         users can tell which SA broker has disconnected."""


### PR DESCRIPTION
## Summary

- Promotes BottlecapDave's `octopus_energy` integration to the primary source for current and scheduled Octopus rates. AgilePredict (export) and the IGO fixed-rate generator (import) become fallback only.
- New `custom_components/heo2/bottlecapdave_client` reads `event.octopus_energy_electricity_*_*_day_rates` and `sensor.octopus_energy_electricity_*_current_rate` entities, auto-discovering the MPAN/serial. £/kWh values are converted to p/kWh at the boundary.
- `ProgrammeInputs` gains `live_import_rates` and `live_export_rates` (BD-only). The coordinator blocks inverter writes when these are missing for a tick (SPEC H4 *Live-prices-only writes*).
- Sensor `heo_ii_current_export_rate` will now reflect BD's published rate instead of AgilePredict's inflated forecast (the ~33p vs ~13p mismatch behind the bug).

Closes #16. Foundation for the rules redesign tracked in #31 — without correct prices, none of the rank-based pricing in [docs/SPEC.md](docs/SPEC.md) §5a can produce sensible decisions.

## Spec alignment

- **§3 Inputs HEO II reads, Rates** — BD is now the source for `import_rate_now`, `export_rate_now`, `*_rates_today[]`, `*_rates_tomorrow[]`.
- **H4 Live-prices-only writes** — enforced via `_live_rates_present` gate in coordinator. When BD returns nothing, the writer is short-circuited and `binary_sensor.heo_ii_writes_blocked` reports the reason.

## What this does *not* change

- Rules engine still consumes the merged `import_rates`/`export_rates`. Pre-write validation (sub-task 2 of #31) is the next piece and not in scope here.
- `agilepredict_client` is unchanged.
- No new config entries; the BD entities are auto-discovered. Multi-MPAN installs pick the meter whose entities updated most recently.

## Test plan

- [x] `pytest tests/ --ignore=tests/test_config_flow_dashboard.py` — **305 passed (266 baseline + 39 new)**
- [ ] Deploy via `scripts/deploy-to-ha.ps1` and restart HA on `homeassistant2.local`. Verify post-deploy:
  - [ ] `sensor.heo_ii_current_export_rate` matches BD's `*_export_current_rate * 100` (within 0.1p)
  - [ ] `sensor.heo_ii_current_import_rate` matches BD's `*_current_rate * 100`
  - [ ] `sensor.heo_ii_programme_reason` references real prices, not 24-33p inflated values
  - [ ] HA log shows BD warnings only when expected (`HEO-14:` prefixed lines)
  - [ ] `binary_sensor.heo_ii_writes_blocked` is OFF when BD healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)
