### PR TITLE
fix(HEO-14): support split import/export BottlecapDave meters

### DIFF
--- a/custom_components/heo2/bottlecapdave_client.py
+++ b/custom_components/heo2/bottlecapdave_client.py
@@ -91,6 +91,11 @@ class BottlecapDaveRates:
     Lists are empty and `*_now_pence` are None when the corresponding
     BottlecapDave entity is missing or unavailable - callers must
     handle absence rather than falling back silently.
+
+    `import_meter_key` and `export_meter_key` are tracked separately
+    because UK installs commonly have different MPAN/serials per
+    direction (e.g. an Octopus Outgoing export meter alongside an IGO
+    import meter). Single-meter installs see the same value in both.
     """
 
     import_today: list[RateSlot] = field(default_factory=list)
@@ -99,7 +104,18 @@ class BottlecapDaveRates:
     export_tomorrow: list[RateSlot] = field(default_factory=list)
     import_now_pence: float | None = None
     export_now_pence: float | None = None
-    meter_key: str | None = None
+    import_meter_key: str | None = None
+    export_meter_key: str | None = None
+
+    @property
+    def meter_key(self) -> str | None:
+        """Diagnostic alias - returns import key if set, else export.
+
+        Kept for backward compatibility with callers from before the
+        split-meter fix. New code should read `import_meter_key` or
+        `export_meter_key` directly.
+        """
+        return self.import_meter_key or self.export_meter_key
 
     @property
     def has_any_data(self) -> bool:
@@ -121,7 +137,8 @@ class BottlecapDaveRates:
 
 def discover_meter_keys(entity_ids: Iterable[str]) -> set[str]:
     """Return all unique BottlecapDave meter keys (`{mpan}_{serial}`) found
-    in the given entity ids. Empty set if BottlecapDave isn't installed.
+    in the given entity ids, regardless of direction (import/export).
+    Empty set if BottlecapDave isn't installed.
     """
     keys: set[str] = set()
     for eid in entity_ids:
@@ -134,6 +151,26 @@ def discover_meter_keys(entity_ids: Iterable[str]) -> set[str]:
                 keys.add(m.group("key"))
                 break
     return keys
+
+
+def classify_entity(entity_id: str) -> tuple[str, bool] | None:
+    """Match a BD entity id and return `(meter_key, is_export)`.
+
+    Returns None for non-BD ids. The is_export flag distinguishes
+    `_export_*_rates` and `_export_current_rate` (True) from their
+    import counterparts (False) so callers can build per-direction
+    indices for split-meter installs.
+    """
+    if not isinstance(entity_id, str):
+        return None
+    norm = entity_id.lower()
+    for pattern in (RATES_EVENT_PATTERN, RATE_SENSOR_PATTERN):
+        m = pattern.match(norm)
+        if not m:
+            continue
+        export_grp = m.group("export") or ""
+        return m.group("key"), bool(export_grp)
+    return None
 
 
 def pick_freshest_meter_key(
@@ -156,6 +193,24 @@ def pick_freshest_meter_key(
         return ts if ts is not None else oldest
 
     return max(keys_to_freshness, key=freshness)
+
+
+def pick_meter_keys_per_direction(
+    keys_freshness: Mapping[tuple[str, bool], datetime | None],
+) -> tuple[str | None, str | None]:
+    """Pick the freshest meter key for import and for export independently.
+
+    Input maps `(meter_key, is_export)` tuples to a freshness timestamp
+    (None permitted for missing). Returns `(import_key, export_key)`.
+
+    UK installs frequently publish import on one MPAN/serial and export
+    on a separate one (Outgoing on a dedicated meter, IGO on another).
+    Picking a single key for both directions silently drops one side -
+    this helper avoids that by treating the directions independently.
+    """
+    imports = {k: ts for (k, is_exp), ts in keys_freshness.items() if not is_exp}
+    exports = {k: ts for (k, is_exp), ts in keys_freshness.items() if is_exp}
+    return pick_freshest_meter_key(imports), pick_freshest_meter_key(exports)
 
 
 def parse_event_rates(attr_rates: object) -> list[RateSlot]:
@@ -243,6 +298,11 @@ def merge_rate_sources(
 def read_bottlecapdave_rates(hass) -> BottlecapDaveRates:
     """Read all BottlecapDave rate data from HA into a single snapshot.
 
+    Discovers import and export meter keys *independently* so installs
+    with separate import and export MPAN/serials are read correctly
+    (common with Octopus Outgoing on a dedicated meter alongside IGO).
+    Within each direction, the freshest key wins.
+
     Returns an empty `BottlecapDaveRates` when BottlecapDave isn't
     installed or no entities are populated yet (HA startup race).
     Never raises - always returns a usable structure so the coordinator
@@ -257,30 +317,22 @@ def read_bottlecapdave_rates(hass) -> BottlecapDaveRates:
     except Exception:  # pragma: no cover - defensive for stub envs
         return BottlecapDaveRates()
 
-    # Group states by meter key, tracking max last_updated for freshness.
-    keys_to_freshness: dict[str, datetime | None] = {}
+    # Track freshness per (meter_key, is_export) so we can pick the
+    # active meter for each direction independently.
+    keys_freshness: dict[tuple[str, bool], datetime | None] = {}
     for state in all_states:
         eid = getattr(state, "entity_id", "")
-        if not eid:
+        cls = classify_entity(eid)
+        if cls is None:
             continue
-        norm = eid.lower()
-        match = (
-            RATES_EVENT_PATTERN.match(norm)
-            or RATE_SENSOR_PATTERN.match(norm)
-        )
-        if not match:
-            continue
-        key = match.group("key")
         ts = getattr(state, "last_updated", None)
-        prev = keys_to_freshness.get(key)
+        prev = keys_freshness.get(cls)
         if prev is None or (ts is not None and ts > prev):
-            keys_to_freshness[key] = ts
+            keys_freshness[cls] = ts
 
-    chosen = pick_freshest_meter_key(keys_to_freshness)
-    if chosen is None:
+    import_key, export_key = pick_meter_keys_per_direction(keys_freshness)
+    if import_key is None and export_key is None:
         return BottlecapDaveRates()
-
-    base = f"octopus_energy_electricity_{chosen}"
 
     def _state(entity_id: str):
         st = hass.states.get(entity_id)
@@ -295,18 +347,37 @@ def read_bottlecapdave_rates(hass) -> BottlecapDaveRates:
         attrs = getattr(st, "attributes", None) or {}
         return attrs.get("rates")
 
+    import_today: list[RateSlot] = []
+    import_tomorrow: list[RateSlot] = []
+    import_now_pence: float | None = None
+    if import_key is not None:
+        ibase = f"octopus_energy_electricity_{import_key}"
+        import_today = parse_event_rates(_attr_rates(f"event.{ibase}_current_day_rates"))
+        import_tomorrow = parse_event_rates(_attr_rates(f"event.{ibase}_next_day_rates"))
+        import_now_pence = parse_current_rate_pence(_state(f"sensor.{ibase}_current_rate"))
+
+    export_today: list[RateSlot] = []
+    export_tomorrow: list[RateSlot] = []
+    export_now_pence: float | None = None
+    if export_key is not None:
+        ebase = f"octopus_energy_electricity_{export_key}"
+        export_today = parse_event_rates(
+            _attr_rates(f"event.{ebase}_export_current_day_rates")
+        )
+        export_tomorrow = parse_event_rates(
+            _attr_rates(f"event.{ebase}_export_next_day_rates")
+        )
+        export_now_pence = parse_current_rate_pence(
+            _state(f"sensor.{ebase}_export_current_rate")
+        )
+
     return BottlecapDaveRates(
-        import_today=parse_event_rates(_attr_rates(f"event.{base}_current_day_rates")),
-        import_tomorrow=parse_event_rates(_attr_rates(f"event.{base}_next_day_rates")),
-        export_today=parse_event_rates(
-            _attr_rates(f"event.{base}_export_current_day_rates")
-        ),
-        export_tomorrow=parse_event_rates(
-            _attr_rates(f"event.{base}_export_next_day_rates")
-        ),
-        import_now_pence=parse_current_rate_pence(_state(f"sensor.{base}_current_rate")),
-        export_now_pence=parse_current_rate_pence(
-            _state(f"sensor.{base}_export_current_rate")
-        ),
-        meter_key=chosen,
+        import_today=import_today,
+        import_tomorrow=import_tomorrow,
+        export_today=export_today,
+        export_tomorrow=export_tomorrow,
+        import_now_pence=import_now_pence,
+        export_now_pence=export_now_pence,
+        import_meter_key=import_key,
+        export_meter_key=export_key,
     )

--- a/custom_components/heo2/coordinator.py
+++ b/custom_components/heo2/coordinator.py
@@ -334,21 +334,23 @@ class HEO2Coordinator(DataUpdateCoordinator):
         # data, which violates SPEC H4 once it reaches the inverter.
         prev_present = self._live_rates_present
         self._live_rates_present = bool(live_import_rates) and bool(live_export_rates)
-        self._bottlecapdave_meter_key = bd_rates.meter_key
+        self._bottlecapdave_meter_key = (
+            f"import={bd_rates.import_meter_key} export={bd_rates.export_meter_key}"
+        )
 
         if not self._live_rates_present:
             logger.warning(
-                "HEO-14: BottlecapDave incomplete (import=%d slots, export=%d slots, "
-                "meter_key=%s); blocking writes per SPEC H4",
-                len(live_import_rates), len(live_export_rates),
-                bd_rates.meter_key,
+                "HEO-14: BottlecapDave incomplete (import=%d slots key=%s, "
+                "export=%d slots key=%s); blocking writes per SPEC H4",
+                len(live_import_rates), bd_rates.import_meter_key,
+                len(live_export_rates), bd_rates.export_meter_key,
             )
         elif not prev_present:
             logger.warning(
-                "HEO-14: BottlecapDave rates restored (meter_key=%s, import=%d, "
-                "export=%d slots); writes unblocked",
-                bd_rates.meter_key,
-                len(live_import_rates), len(live_export_rates),
+                "HEO-14: BottlecapDave rates restored (import_key=%s %d slots, "
+                "export_key=%s %d slots); writes unblocked",
+                bd_rates.import_meter_key, len(live_import_rates),
+                bd_rates.export_meter_key, len(live_export_rates),
             )
 
         load_profile = self._load_builder.build()

--- a/tests/test_bottlecapdave_client.py
+++ b/tests/test_bottlecapdave_client.py
@@ -16,11 +16,13 @@ import pytest
 from heo2.bottlecapdave_client import (
     GBP_TO_PENCE,
     BottlecapDaveRates,
+    classify_entity,
     discover_meter_keys,
     merge_rate_sources,
     parse_current_rate_pence,
     parse_event_rates,
     pick_freshest_meter_key,
+    pick_meter_keys_per_direction,
     read_bottlecapdave_rates,
 )
 from heo2.models import RateSlot
@@ -236,6 +238,88 @@ class TestDiscoverMeterKeys:
 # ---------------------------------------------------------------------------
 
 
+class TestClassifyEntity:
+    def test_import_event(self):
+        result = classify_entity(
+            "event.octopus_energy_electricity_meter1_meter1_current_day_rates"
+        )
+        assert result == ("meter1_meter1", False)
+
+    def test_export_event(self):
+        result = classify_entity(
+            "event.octopus_energy_electricity_meter1_meter1_export_current_day_rates"
+        )
+        assert result == ("meter1_meter1", True)
+
+    def test_import_sensor(self):
+        result = classify_entity(
+            "sensor.octopus_energy_electricity_meter1_meter1_current_rate"
+        )
+        assert result == ("meter1_meter1", False)
+
+    def test_export_sensor(self):
+        result = classify_entity(
+            "sensor.octopus_energy_electricity_meter1_meter1_export_current_rate"
+        )
+        assert result == ("meter1_meter1", True)
+
+    def test_non_octopus_returns_none(self):
+        assert classify_entity("sensor.solcast_pv_forecast_today") is None
+        assert classify_entity("binary_sensor.heo_ii_healthy") is None
+
+    def test_non_string_returns_none(self):
+        assert classify_entity(None) is None
+        assert classify_entity(42) is None
+
+
+class TestPickMeterKeysPerDirection:
+    def test_split_meters(self):
+        """Different keys per direction - the typical UK Outgoing+IGO setup."""
+        i_ts = datetime(2026, 4, 30, 4, 0, tzinfo=UTC)
+        e_ts = datetime(2026, 4, 30, 8, 0, tzinfo=UTC)
+        result = pick_meter_keys_per_direction({
+            ("import_meter", False): i_ts,
+            ("export_meter", True): e_ts,
+        })
+        assert result == ("import_meter", "export_meter")
+
+    def test_single_meter_both_directions(self):
+        ts = datetime(2026, 4, 30, 12, 0, tzinfo=UTC)
+        result = pick_meter_keys_per_direction({
+            ("only_meter", False): ts,
+            ("only_meter", True): ts,
+        })
+        assert result == ("only_meter", "only_meter")
+
+    def test_import_only_install(self):
+        ts = datetime(2026, 4, 30, 12, 0, tzinfo=UTC)
+        result = pick_meter_keys_per_direction({
+            ("imp_meter", False): ts,
+        })
+        assert result == ("imp_meter", None)
+
+    def test_export_only_install(self):
+        ts = datetime(2026, 4, 30, 12, 0, tzinfo=UTC)
+        result = pick_meter_keys_per_direction({
+            ("exp_meter", True): ts,
+        })
+        assert result == (None, "exp_meter")
+
+    def test_empty_returns_pair_of_nones(self):
+        assert pick_meter_keys_per_direction({}) == (None, None)
+
+    def test_freshest_wins_within_direction(self):
+        old = datetime(2026, 4, 30, 6, 0, tzinfo=UTC)
+        new = datetime(2026, 4, 30, 16, 0, tzinfo=UTC)
+        result = pick_meter_keys_per_direction({
+            ("imp_old", False): old,
+            ("imp_new", False): new,
+            ("exp_old", True): old,
+            ("exp_new", True): new,
+        })
+        assert result == ("imp_new", "exp_new")
+
+
 class TestPickFreshestMeterKey:
     def test_returns_most_recent(self):
         old = datetime(2026, 4, 30, 12, 0, tzinfo=UTC)
@@ -362,7 +446,9 @@ class TestReadBottlecapDaveRates:
                                              with_tomorrow=True))
         result = read_bottlecapdave_rates(hass)
 
-        assert result.meter_key == "1850009498_2394300396097"
+        assert result.import_meter_key == "1850009498_2394300396097"
+        assert result.export_meter_key == "1850009498_2394300396097"
+        assert result.meter_key == "1850009498_2394300396097"  # legacy alias
         assert result.has_any_data is True
         assert result.import_now_pence == pytest.approx(4.952)
         assert result.export_now_pence == pytest.approx(13.150)
@@ -370,6 +456,43 @@ class TestReadBottlecapDaveRates:
         assert len(result.export_today) == 2
         assert len(result.import_tomorrow) == 2
         assert len(result.export_tomorrow) == 2
+
+    def test_split_meters_import_and_export_have_different_keys(self):
+        """Real-world UK install: Octopus Outgoing on a dedicated export
+        meter, IGO on a separate import meter. Must read both."""
+        import_ts = datetime(2026, 4, 30, 4, 30, tzinfo=UTC)
+        export_ts = datetime(2026, 4, 30, 8, 0, tzinfo=UTC)
+        states = []
+        # Import-only meter: just current_rate sensor + current_day_rates event
+        ibase = "octopus_energy_electricity_18p5009498_2372761090617"
+        states.append(_state(f"sensor.{ibase}_current_rate", "0.04952", import_ts))
+        states.append(_state(
+            f"event.{ibase}_current_day_rates",
+            "today",
+            import_ts,
+            attributes={"rates": SAMPLE_IMPORT_TODAY_RATES},
+        ))
+        # Export-only meter: export_current_rate sensor + export_current_day_rates event
+        ebase = "octopus_energy_electricity_18p5009498_2394300396097"
+        states.append(_state(f"sensor.{ebase}_export_current_rate", "0.13150", export_ts))
+        states.append(_state(
+            f"event.{ebase}_export_current_day_rates",
+            "today",
+            export_ts,
+            attributes={"rates": SAMPLE_EXPORT_TODAY_RATES},
+        ))
+        hass = _make_hass(states)
+
+        result = read_bottlecapdave_rates(hass)
+
+        # Both directions populated with their distinct keys
+        assert result.import_meter_key == "18p5009498_2372761090617"
+        assert result.export_meter_key == "18p5009498_2394300396097"
+        # Both rates reflect their respective sources
+        assert result.import_now_pence == pytest.approx(4.952)
+        assert result.export_now_pence == pytest.approx(13.150)
+        assert len(result.import_today) == 2
+        assert len(result.export_today) == 2
 
     def test_returns_empty_when_bd_not_installed(self):
         # Only non-octopus entities present
@@ -379,7 +502,8 @@ class TestReadBottlecapDaveRates:
         ])
         result = read_bottlecapdave_rates(hass)
         assert result.has_any_data is False
-        assert result.meter_key is None
+        assert result.import_meter_key is None
+        assert result.export_meter_key is None
         assert result.import_today == []
         assert result.export_today == []
         assert result.import_now_pence is None
@@ -387,9 +511,11 @@ class TestReadBottlecapDaveRates:
     def test_returns_empty_when_hass_none(self):
         result = read_bottlecapdave_rates(None)
         assert result.has_any_data is False
-        assert result.meter_key is None
+        assert result.import_meter_key is None
+        assert result.export_meter_key is None
 
-    def test_picks_freshest_meter_when_multiple(self):
+    def test_picks_freshest_meter_when_multiple_per_direction(self):
+        """Same direction with two meter keys - freshest wins."""
         old = datetime(2026, 4, 30, 6, 0, tzinfo=UTC)
         new = datetime(2026, 4, 30, 16, 0, tzinfo=UTC)
         states = (
@@ -398,7 +524,8 @@ class TestReadBottlecapDaveRates:
         )
         hass = _make_hass(states)
         result = read_bottlecapdave_rates(hass)
-        assert result.meter_key == "freshmeter_bbbb"
+        assert result.import_meter_key == "freshmeter_bbbb"
+        assert result.export_meter_key == "freshmeter_bbbb"
 
     def test_partial_data_ok(self):
         """Today's import published, but export tomorrow not yet -
@@ -496,8 +623,20 @@ class TestBottlecapDaveRatesDataclass:
         assert r.export_today == []
         assert r.import_now_pence is None
         assert r.export_now_pence is None
+        assert r.import_meter_key is None
+        assert r.export_meter_key is None
         assert r.meter_key is None
 
     def test_has_any_data_true_with_just_one_field(self):
         r = BottlecapDaveRates(import_now_pence=4.95)
         assert r.has_any_data is True
+
+    def test_meter_key_alias_returns_import_or_export(self):
+        """Backwards-compat: callers reading .meter_key should get
+        a usable identifier whether the install is single or split."""
+        r = BottlecapDaveRates(import_meter_key="imp", export_meter_key="exp")
+        assert r.meter_key == "imp"
+        r2 = BottlecapDaveRates(export_meter_key="exp_only")
+        assert r2.meter_key == "exp_only"
+        r3 = BottlecapDaveRates()
+        assert r3.meter_key is None


### PR DESCRIPTION
## Summary

Follow-up to #33. On the production install, BottlecapDave publishes import and export under different MPAN/serial pairs (a dedicated Outgoing meter alongside IGO). The first PR's discovery picked one freshest key for both directions, so the export meter won and import rates fell through to the IGO fixed-rate fallback. ``sensor.heo_ii_current_import_rate`` showed 27.88 p/kWh instead of BottlecapDave's published value.

## Fix

Per-direction discovery: pick freshest import key independently of freshest export key. Single-meter installs still see the same key for both directions; split installs read both correctly.

## Tests

319 passing (up from 305). 14 new cases:

- ``classify_entity`` for the four entity-shape variants
- ``pick_meter_keys_per_direction`` for split, single, import-only, export-only, and empty inputs
- ``read_bottlecapdave_rates`` integration case asserting both directions are read on a split-meter install

🤖 Generated with [Claude Code](https://claude.com/claude-code)