### PR TITLE
feat(HEO-30): rank-based pricing for ExportWindow + CheapRateCharge

### DIFF
--- a/custom_components/heo2/const.py
+++ b/custom_components/heo2/const.py
@@ -24,6 +24,22 @@ EFFECTIVE_STORED_COST_PENCE = (
     DEFAULT_IGO_NIGHT_RATE_PENCE / ROUND_TRIP_EFFICIENCY
 ) + DEFAULT_DEGRADATION_COST_PER_KWH  # ~7.86
 
+# SPEC-aligned IGO tariff knobs (docs/SPEC.md §1, §10).
+# These are the values quoted in the spec; legacy DEFAULT_IGO_*_RATE_PENCE
+# above are kept for the synthetic fallback path in igo_rates.py and the
+# old EFFECTIVE_STORED_COST_PENCE constant (still used by SolarSurplusRule).
+DEFAULT_IGO_OFF_PEAK_PENCE = 4.9524
+DEFAULT_IGO_PEAK_PENCE = 24.8423
+DEFAULT_PEAK_THRESHOLD_PENCE = 24.0  # H1 detection - covers IGO peak with margin
+
+# SPEC §5a rank-based pricing knobs.
+DEFAULT_SELL_TOP_PCT = 30           # medium SOC, normal tomorrow forecast
+DEFAULT_SELL_TOP_PCT_LOW_SOC = 15   # low SOC OR low tomorrow forecast
+DEFAULT_SELL_TOP_PCT_HIGH_SOC = 50  # high SOC AND high tomorrow forecast
+DEFAULT_CHEAP_CHARGE_BOTTOM_PCT = 25  # bottom-N% of import rates is "cheap"
+DEFAULT_LOW_SOC_THRESHOLD = 50.0
+DEFAULT_HIGH_SOC_THRESHOLD = 80.0
+
 # Load profile
 DEFAULT_LOAD_BASELINE_W = 1900.0
 DEFAULT_LOAD_LOOKBACK_DAYS = 14

--- a/custom_components/heo2/coordinator.py
+++ b/custom_components/heo2/coordinator.py
@@ -307,6 +307,13 @@ class HEO2Coordinator(DataUpdateCoordinator):
         )
 
         solar = self._read_solar_forecast(now)
+        solar_tomorrow = self._read_solar_forecast(
+            now, entity_override=self._config.get(
+                "solcast_tomorrow_entity",
+                "sensor.solcast_pv_forecast_forecast_tomorrow",
+            ),
+            target_offset_days=1,
+        )
 
         # HEO-14: BottlecapDave is the PRIMARY rate source per SPEC H4.
         # AgilePredict (export) and IGO fixed-rate generator (import) are
@@ -375,6 +382,7 @@ class HEO2Coordinator(DataUpdateCoordinator):
             appliance_expected_kwh=0.0,
             live_import_rates=live_import_rates,
             live_export_rates=live_export_rates,
+            solar_forecast_kwh_tomorrow=solar_tomorrow,
         )
 
     def _read_entity_float(self, entity_id: str, default: float) -> float:
@@ -396,26 +404,40 @@ class HEO2Coordinator(DataUpdateCoordinator):
             return default
         return state.state.lower() in ("on", "true", "1")
 
-    def _read_solar_forecast(self, now) -> list[float]:
+    def _read_solar_forecast(
+        self,
+        now,
+        entity_override: str | None = None,
+        target_offset_days: int = 0,
+    ) -> list[float]:
         """Read solar forecast from HACS solcast_solar sensor attributes.
 
-        Returns 24 hourly kWh values, index 0 = 00:00 local time for today.
-        Returns zeros if the sensor is missing or has no detailedHourly
-        attribute. See HEO-4 for the history: HEO II previously made its
-        own Solcast HTTP calls and mis-aggregated the result.
+        Returns 24 hourly kWh values, index 0 = 00:00 local time for the
+        target date. Defaults to today; pass `target_offset_days=1` to
+        read tomorrow's forecast (used by rank-based pricing per SPEC §5a).
+
+        `entity_override` selects a different Solcast sensor, e.g. the
+        tomorrow-specific one. Returns zeros if the sensor is missing or
+        has no detailedHourly attribute. See HEO-4 for the history: HEO II
+        previously made its own Solcast HTTP calls and mis-aggregated the
+        result.
         """
+        from datetime import timedelta
         from zoneinfo import ZoneInfo
         tz_name = (self.hass.config.time_zone
                    if self.hass and self.hass.config.time_zone
                    else "UTC")
         tz = ZoneInfo(tz_name)
-        target_date = now.astimezone(tz).date()
+        target_date = (
+            now.astimezone(tz).date() + timedelta(days=target_offset_days)
+        )
 
-        state = self.hass.states.get(self._solar_entity) if self.hass else None
+        entity = entity_override or self._solar_entity
+        state = self.hass.states.get(entity) if self.hass else None
         if state is None or state.state in ("unknown", "unavailable"):
             logger.warning(
                 "Solar forecast entity %s not available, using zero forecast",
-                self._solar_entity,
+                entity,
             )
             return [0.0] * 24
 
@@ -423,7 +445,7 @@ class HEO2Coordinator(DataUpdateCoordinator):
         if not detailed:
             logger.warning(
                 "Solar forecast entity %s has no detailedHourly attribute",
-                self._solar_entity,
+                entity,
             )
             return [0.0] * 24
 

--- a/custom_components/heo2/models.py
+++ b/custom_components/heo2/models.py
@@ -199,6 +199,11 @@ class ProgrammeInputs:
     appliance_expected_kwh: float
     live_import_rates: list[RateSlot] = field(default_factory=list)
     live_export_rates: list[RateSlot] = field(default_factory=list)
+    # 24 hourly buckets for tomorrow's solar forecast. Defaults empty
+    # so callers from before HEO-30 step 3 (rank-based pricing) keep
+    # working; the rank logic treats an empty list as "no forecast"
+    # which biases towards the conservative top-15% sell window.
+    solar_forecast_kwh_tomorrow: list[float] = field(default_factory=list)
 
     def rate_at(self, dt: datetime) -> float | None:
         """Find the import rate at a specific datetime. Returns None if no rate covers it."""

--- a/custom_components/heo2/rank_pricing.py
+++ b/custom_components/heo2/rank_pricing.py
@@ -1,0 +1,214 @@
+# custom_components/heo2/rank_pricing.py
+"""Rank-based pricing helpers for HEO II rules.
+
+Pure functions, no Home Assistant imports. Unit-testable in isolation.
+
+Implements SPEC §5a: rank within today's published rates rather than
+fixed pence thresholds. Adapts automatically to seasonal Agile shifts
+and tariff changes without code edits.
+
+The fixed 6p / 7.86p thresholds in the legacy rules made decisions
+based on absolute price, which broke whenever winter Agile distributions
+shifted (median ~5p; 6p triggers half the day, draining the reserve)
+versus summer (where 6p is the bottom of the distribution). Rank gives
+us "sell in the top 30% of today's prices" which adapts automatically.
+"""
+
+from __future__ import annotations
+
+import math
+from datetime import datetime
+from typing import Iterable
+
+from .models import RateSlot
+
+
+def filter_today(
+    rates: Iterable[RateSlot],
+    now: datetime,
+    tz=None,
+) -> list[RateSlot]:
+    """Return slots whose START falls on the same LOCAL date as `now`.
+
+    `tz` is the local timezone (ZoneInfo). If None, the now timestamp's
+    own tzinfo is used; if that's also None, naive comparison.
+    """
+    if tz is not None:
+        today_local_date = now.astimezone(tz).date()
+    elif now.tzinfo is not None:
+        today_local_date = now.date()
+    else:
+        today_local_date = now.date()
+
+    out: list[RateSlot] = []
+    for r in rates:
+        start = r.start
+        if tz is not None:
+            start_local = start.astimezone(tz)
+        elif start.tzinfo is not None and now.tzinfo is not None:
+            start_local = start.astimezone(now.tzinfo)
+        else:
+            start_local = start
+        if start_local.date() == today_local_date:
+            out.append(r)
+    return out
+
+
+def top_n_pct(rates: list[RateSlot], n_pct: int | float) -> list[RateSlot]:
+    """Return the top N% of `rates` by rate_pence.
+
+    Sorted descending. Count is rounded UP so n_pct=15 of 48 slots
+    returns 8 slots (`ceil(48 * 0.15)`). Empty input or n_pct<=0
+    returns empty.
+    """
+    if not rates or n_pct <= 0:
+        return []
+    if n_pct >= 100:
+        return sorted(rates, key=lambda r: r.rate_pence, reverse=True)
+    count = max(1, math.ceil(len(rates) * n_pct / 100))
+    return sorted(rates, key=lambda r: r.rate_pence, reverse=True)[:count]
+
+
+def bottom_n_pct(rates: list[RateSlot], n_pct: int | float) -> list[RateSlot]:
+    """Return the bottom N% of `rates` by rate_pence (lowest first).
+
+    Same rounding convention as `top_n_pct`.
+    """
+    if not rates or n_pct <= 0:
+        return []
+    if n_pct >= 100:
+        return sorted(rates, key=lambda r: r.rate_pence)
+    count = max(1, math.ceil(len(rates) * n_pct / 100))
+    return sorted(rates, key=lambda r: r.rate_pence)[:count]
+
+
+def select_export_top_pct(
+    current_soc: float,
+    tomorrow_solar_kwh: float,
+    daily_load_kwh: float,
+    *,
+    low_soc_threshold: float = 50.0,
+    high_soc_threshold: float = 80.0,
+    high_solar_kwh: float | None = None,
+    low_solar_kwh: float | None = None,
+    n_low: int = 15,
+    n_med: int = 30,
+    n_high: int = 50,
+) -> tuple[int, str]:
+    """Choose `N` for top-N% export windows per SPEC §5a.
+
+    - Low SOC OR low tomorrow forecast -> `n_low` (only the very best)
+    - High SOC AND high tomorrow forecast -> `n_high` (sell aggressively)
+    - else -> `n_med`
+
+    Defaults if not supplied: high_solar = daily_load_kwh,
+    low_solar = daily_load_kwh * 0.5. The intuition: if tomorrow's PV
+    will cover today's load, we can sell more of today's stored energy.
+
+    Returns (n_pct, reason_string) so the rule can log which branch fired.
+    """
+    high_solar = high_solar_kwh if high_solar_kwh is not None else daily_load_kwh
+    low_solar = low_solar_kwh if low_solar_kwh is not None else daily_load_kwh * 0.5
+
+    soc_low = current_soc < low_soc_threshold
+    soc_high = current_soc >= high_soc_threshold
+    solar_low = tomorrow_solar_kwh < low_solar
+    solar_high = tomorrow_solar_kwh >= high_solar
+
+    if soc_low or solar_low:
+        return n_low, (
+            f"top {n_low}% (soc={current_soc:.0f}% low={soc_low}, "
+            f"tomorrow_solar={tomorrow_solar_kwh:.1f} kWh low={solar_low})"
+        )
+    if soc_high and solar_high:
+        return n_high, (
+            f"top {n_high}% (soc={current_soc:.0f}% high, "
+            f"tomorrow_solar={tomorrow_solar_kwh:.1f} kWh high)"
+        )
+    return n_med, (
+        f"top {n_med}% (soc={current_soc:.0f}%, "
+        f"tomorrow_solar={tomorrow_solar_kwh:.1f} kWh)"
+    )
+
+
+def is_worth_selling(
+    export_rate_pence: float,
+    replacement_cost_pence: float,
+    round_trip_efficiency: float = 0.9025,
+) -> bool:
+    """SPEC §5a: a window is worth selling in if
+    `export_rate * round_trip_efficiency > replacement_cost`.
+
+    Replacement cost is "the cheapest rate at which we can re-charge",
+    typically the next IGO off-peak slot (~4.95p) or for variable
+    tariffs the next bottom-25% import slot.
+    """
+    return export_rate_pence * round_trip_efficiency > replacement_cost_pence
+
+
+def select_worth_selling_windows(
+    export_rates_today: list[RateSlot],
+    n_pct: int | float,
+    replacement_cost_pence: float,
+    round_trip_efficiency: float = 0.9025,
+) -> list[RateSlot]:
+    """Top-N% AND worth-selling - the actual windows to drain into.
+
+    Sorted by rate_pence DESCENDING (highest revenue first).
+    """
+    top = top_n_pct(export_rates_today, n_pct)
+    return [
+        r for r in top
+        if is_worth_selling(
+            r.rate_pence, replacement_cost_pence, round_trip_efficiency,
+        )
+    ]
+
+
+def hours_covered_by(
+    slots: list[RateSlot],
+    tz,
+) -> set[int]:
+    """Return the set of LOCAL hour indices (0-23) covered by any slot.
+
+    A 30-min slot covers exactly one hour (its starting hour). Two slots
+    in the same hour collapse to one entry. `tz` should be the local
+    timezone (ZoneInfo). Slots without tzinfo are returned by their
+    naive hour.
+    """
+    out: set[int] = set()
+    for s in slots:
+        if tz is not None and s.start.tzinfo is not None:
+            local = s.start.astimezone(tz)
+        else:
+            local = s.start
+        out.add(local.hour)
+    return out
+
+
+def estimate_profitable_export_kwh(
+    worth_selling_windows: list[RateSlot],
+    max_discharge_kw: float = 5.0,
+) -> float:
+    """Estimate kWh we can profitably export today.
+
+    Each worth-selling 30-min slot contributes up to
+    `max_discharge_kw * 0.5` kWh. Assumes the battery has enough capacity
+    and SOC headroom; the caller is responsible for clamping. Used as
+    an upper bound for the cheap-rate-charge target calculation.
+    """
+    return len(worth_selling_windows) * max_discharge_kw * 0.5
+
+
+def select_cheap_charge_windows(
+    import_rates_today: list[RateSlot],
+    n_pct: int | float = 25,
+) -> list[RateSlot]:
+    """SPEC §5a charging-from-grid logic.
+
+    Returns the bottom-N% of today's import rates - the windows where
+    grid_charge=True is justified. For IGO this picks out the off-peak
+    slots (which are the cheapest by construction); for variable tariffs
+    it generalises naturally.
+    """
+    return bottom_n_pct(import_rates_today, n_pct)

--- a/custom_components/heo2/rules/cheap_rate_charge.py
+++ b/custom_components/heo2/rules/cheap_rate_charge.py
@@ -1,56 +1,114 @@
-"""CheapRateChargeRule -- calculates optimal overnight charge target."""
+"""CheapRateChargeRule -- rank-based overnight/cheap-window charge target."""
 
 from __future__ import annotations
 
-from datetime import timedelta
-
-from ..models import ProgrammeState, ProgrammeInputs
+from ..const import (
+    DEFAULT_CHEAP_CHARGE_BOTTOM_PCT,
+    DEFAULT_HIGH_SOC_THRESHOLD,
+    DEFAULT_IGO_OFF_PEAK_PENCE,
+    DEFAULT_LOW_SOC_THRESHOLD,
+    DEFAULT_MAX_DISCHARGE_KW,
+    DEFAULT_SELL_TOP_PCT,
+    DEFAULT_SELL_TOP_PCT_HIGH_SOC,
+    DEFAULT_SELL_TOP_PCT_LOW_SOC,
+    ROUND_TRIP_EFFICIENCY,
+)
+from ..models import ProgrammeInputs, ProgrammeState
+from ..rank_pricing import (
+    estimate_profitable_export_kwh,
+    filter_today,
+    select_export_top_pct,
+    select_worth_selling_windows,
+)
 from ..rule_engine import Rule
-from ..const import EFFECTIVE_STORED_COST_PENCE
 
 
 class CheapRateChargeRule(Rule):
-    """Calculate worth-charging target SOC for overnight cheap-rate slots.
+    """Set the SOC target on grid_charge slots based on expected demand,
+    expected solar, and rank-based profitable-export volume.
 
-    Only charge what we'll consume or profitably export -- avoids wasting
-    cycles on battery that will sit unused.
+    Implements SPEC §5a charging-from-grid logic generalised:
+    `worth_charging_kwh = expected_demand - expected_solar + expected_export`,
+    where `expected_export` is derived from today's published export rates
+    and the rank-based "worth selling" filter rather than a fixed
+    pence threshold.
+
+    Replaces the legacy version's `>7.86p effective stored cost` test.
+    The legacy version over-charged when winter Agile distributions sat
+    above 7.86p (looked profitable everywhere) and under-charged when
+    summer distributions stayed below.
     """
 
     name = "cheap_rate_charge"
-    description = "Calculate overnight charge target based on expected demand and export"
+    description = "Calculate cheap-window charge target from expected demand and rank-worthy export"
 
-    def __init__(self, max_target_soc: int = 100):
+    def __init__(
+        self,
+        max_target_soc: int = 100,
+        *,
+        replacement_cost_pence: float = DEFAULT_IGO_OFF_PEAK_PENCE,
+        round_trip_efficiency: float = ROUND_TRIP_EFFICIENCY,
+        max_discharge_kw: float = DEFAULT_MAX_DISCHARGE_KW,
+        low_soc_threshold: float = DEFAULT_LOW_SOC_THRESHOLD,
+        high_soc_threshold: float = DEFAULT_HIGH_SOC_THRESHOLD,
+        n_low: int = DEFAULT_SELL_TOP_PCT_LOW_SOC,
+        n_med: int = DEFAULT_SELL_TOP_PCT,
+        n_high: int = DEFAULT_SELL_TOP_PCT_HIGH_SOC,
+        cheap_bottom_pct: int = DEFAULT_CHEAP_CHARGE_BOTTOM_PCT,
+    ):
         self.max_target_soc = max_target_soc
+        self.replacement_cost_pence = replacement_cost_pence
+        self.round_trip_efficiency = round_trip_efficiency
+        self.max_discharge_kw = max_discharge_kw
+        self.low_soc_threshold = low_soc_threshold
+        self.high_soc_threshold = high_soc_threshold
+        self.n_low = n_low
+        self.n_med = n_med
+        self.n_high = n_high
+        self.cheap_bottom_pct = cheap_bottom_pct
 
     def apply(self, state: ProgrammeState, inputs: ProgrammeInputs) -> ProgrammeState:
-        # Expected demand: sum of load forecast for full day
         expected_demand_kwh = sum(inputs.load_forecast_kwh)
-
-        # Expected solar generation
         expected_solar_kwh = sum(inputs.solar_forecast_kwh)
+        daily_load_kwh = expected_demand_kwh or 1.0
 
-        # Expected profitable export: hours where export rate > effective stored cost
-        expected_profitable_export_kwh = 0.0
-        for hour in range(24):
-            hour_start = inputs.now.replace(
-                hour=hour, minute=0, second=0, microsecond=0
-            )
-            export_rate = inputs.export_rate_at(hour_start)
-            if export_rate is not None and export_rate > EFFECTIVE_STORED_COST_PENCE:
-                # We can profitably export up to max_discharge_kw per hour
-                # but cap at what the battery can deliver (simplified to 5 kWh/hr)
-                expected_profitable_export_kwh += min(
-                    5.0, inputs.battery_capacity_kwh * 0.25
-                )
+        # Rank-based estimate of how much we can profitably sell today.
+        # Driven by today's live export rates; falls back to zero when
+        # BD hasn't returned anything (writes are H4-blocked anyway).
+        today_export_rates = filter_today(inputs.export_rates, inputs.now)
 
-        # Worth-charging calculation from spec
+        tomorrow_solar_kwh = sum(inputs.solar_forecast_kwh_tomorrow) if (
+            inputs.solar_forecast_kwh_tomorrow
+        ) else expected_solar_kwh
+
+        n_pct, n_reason = select_export_top_pct(
+            current_soc=inputs.current_soc,
+            tomorrow_solar_kwh=tomorrow_solar_kwh,
+            daily_load_kwh=daily_load_kwh,
+            low_soc_threshold=self.low_soc_threshold,
+            high_soc_threshold=self.high_soc_threshold,
+            n_low=self.n_low,
+            n_med=self.n_med,
+            n_high=self.n_high,
+        )
+
+        worth_windows = select_worth_selling_windows(
+            today_export_rates,
+            n_pct=n_pct,
+            replacement_cost_pence=self.replacement_cost_pence,
+            round_trip_efficiency=self.round_trip_efficiency,
+        )
+        expected_profitable_export_kwh = estimate_profitable_export_kwh(
+            worth_windows,
+            max_discharge_kw=self.max_discharge_kw,
+        )
+
         worth_charging_kwh = (
             expected_demand_kwh
             + expected_profitable_export_kwh
             - expected_solar_kwh
         )
 
-        # Convert to SOC percentage
         if worth_charging_kwh <= 0:
             target_soc = int(inputs.min_soc)
         else:
@@ -58,20 +116,18 @@ class CheapRateChargeRule(Rule):
                 inputs.min_soc
                 + (worth_charging_kwh / inputs.battery_capacity_kwh * 100)
             )
-
-        # Clamp to valid range
         target_soc = max(int(inputs.min_soc), min(self.max_target_soc, target_soc))
 
-        # Apply to overnight charge slots (grid_charge=True slots)
         for slot in state.slots:
             if slot.grid_charge:
                 slot.capacity_soc = target_soc
 
         state.reason_log.append(
-            f"CheapRateCharge: target {target_soc}% "
+            f"CheapRateCharge: target {target_soc}% via {n_reason} "
             f"(demand {expected_demand_kwh:.1f} kWh, "
             f"solar {expected_solar_kwh:.1f} kWh, "
-            f"export {expected_profitable_export_kwh:.1f} kWh, "
+            f"profitable export {expected_profitable_export_kwh:.1f} kWh "
+            f"from {len(worth_windows)} slots, "
             f"worth charging {worth_charging_kwh:.1f} kWh)"
         )
         return state

--- a/custom_components/heo2/rules/export_window.py
+++ b/custom_components/heo2/rules/export_window.py
@@ -1,65 +1,162 @@
-"""ExportWindowRule -- drain battery during profitable export windows."""
+"""ExportWindowRule -- drain battery during top-ranked export windows."""
 
 from __future__ import annotations
 
-from datetime import time as dt_time
-
-from ..models import ProgrammeState, ProgrammeInputs
+from ..const import (
+    DEFAULT_HIGH_SOC_THRESHOLD,
+    DEFAULT_IGO_OFF_PEAK_PENCE,
+    DEFAULT_LOW_SOC_THRESHOLD,
+    DEFAULT_SELL_TOP_PCT,
+    DEFAULT_SELL_TOP_PCT_HIGH_SOC,
+    DEFAULT_SELL_TOP_PCT_LOW_SOC,
+    ROUND_TRIP_EFFICIENCY,
+)
+from ..models import ProgrammeInputs, ProgrammeState
+from ..rank_pricing import (
+    filter_today,
+    hours_covered_by,
+    select_export_top_pct,
+    select_worth_selling_windows,
+)
 from ..rule_engine import Rule
-from ..const import EFFECTIVE_STORED_COST_PENCE
 
 
 class ExportWindowRule(Rule):
-    """During profitable export windows, set low SOC targets to drain battery.
+    """Drain the battery during the top-ranked export windows of today.
 
-    The drain target is floored at enough SOC to cover evening demand.
+    Implements SPEC §5a:
+      - Pick top-N% of today's export rates by p/kWh, where N depends on
+        SOC + tomorrow forecast (15 / 30 / 50).
+      - Filter to windows that are *worth* selling in: rate * round-trip
+        efficiency > replacement cost (next IGO off-peak, ~5p).
+      - Drain to `min_soc` during those windows. EveningProtect raises
+        the floor if evening demand requires it; SafetyRule clamps to
+        min_soc finally.
+
+    Replaces the legacy fixed-threshold version (>7.86p effective stored
+    cost) which broke whenever Agile distributions shifted seasonally.
     """
 
     name = "export_window"
-    description = "Drain battery during profitable Agile Outgoing windows"
+    description = "Drain battery during top-ranked Agile Outgoing windows"
+
+    def __init__(
+        self,
+        *,
+        replacement_cost_pence: float = DEFAULT_IGO_OFF_PEAK_PENCE,
+        round_trip_efficiency: float = ROUND_TRIP_EFFICIENCY,
+        low_soc_threshold: float = DEFAULT_LOW_SOC_THRESHOLD,
+        high_soc_threshold: float = DEFAULT_HIGH_SOC_THRESHOLD,
+        n_low: int = DEFAULT_SELL_TOP_PCT_LOW_SOC,
+        n_med: int = DEFAULT_SELL_TOP_PCT,
+        n_high: int = DEFAULT_SELL_TOP_PCT_HIGH_SOC,
+    ):
+        self.replacement_cost_pence = replacement_cost_pence
+        self.round_trip_efficiency = round_trip_efficiency
+        self.low_soc_threshold = low_soc_threshold
+        self.high_soc_threshold = high_soc_threshold
+        self.n_low = n_low
+        self.n_med = n_med
+        self.n_high = n_high
 
     def apply(self, state: ProgrammeState, inputs: ProgrammeInputs) -> ProgrammeState:
         if not inputs.export_rates:
             return state
 
-        # Find profitable export hours
-        profitable_hours: list[int] = []
-        for hour in range(24):
-            from datetime import datetime, timezone
-            hour_start = inputs.now.replace(
-                hour=hour, minute=0, second=0, microsecond=0
-            )
-            export_rate = inputs.export_rate_at(hour_start)
-            if export_rate is not None and export_rate > EFFECTIVE_STORED_COST_PENCE:
-                profitable_hours.append(hour)
-
-        if not profitable_hours:
+        # Today only. Tomorrow's rates are out of scope for the drain
+        # decision in the current programme.
+        today_rates = filter_today(inputs.export_rates, inputs.now)
+        if not today_rates:
             return state
 
-        # Calculate evening demand reserve (18:30-23:30 ~ hours 18-24)
-        evening_demand_kwh = inputs.load_kwh_between(18, 24)
-        export_floor_soc = int(
-            inputs.min_soc + (evening_demand_kwh / inputs.battery_capacity_kwh * 100)
+        daily_load_kwh = sum(inputs.load_forecast_kwh) or 1.0
+        # Tomorrow's solar feeds the rank decision (high-SOC + high-solar
+        # -> sell aggressively; low-solar -> conservative). Falls back to
+        # today's forecast when tomorrow isn't available so the rule
+        # still produces a reasonable answer.
+        tomorrow_solar_kwh = sum(inputs.solar_forecast_kwh_tomorrow) if (
+            inputs.solar_forecast_kwh_tomorrow
+        ) else sum(inputs.solar_forecast_kwh)
+
+        n_pct, n_reason = select_export_top_pct(
+            current_soc=inputs.current_soc,
+            tomorrow_solar_kwh=tomorrow_solar_kwh,
+            daily_load_kwh=daily_load_kwh,
+            low_soc_threshold=self.low_soc_threshold,
+            high_soc_threshold=self.high_soc_threshold,
+            n_low=self.n_low,
+            n_med=self.n_med,
+            n_high=self.n_high,
         )
-        export_floor_soc = min(export_floor_soc, 100)
 
-        drain_target = max(export_floor_soc, int(inputs.min_soc))
+        worth_windows = select_worth_selling_windows(
+            today_rates,
+            n_pct=n_pct,
+            replacement_cost_pence=self.replacement_cost_pence,
+            round_trip_efficiency=self.round_trip_efficiency,
+        )
 
-        # Apply to slots that overlap with profitable hours
+        if not worth_windows:
+            state.reason_log.append(
+                f"ExportWindow: nothing worth selling in {n_reason} "
+                f"(replacement cost {self.replacement_cost_pence:.2f}p)"
+            )
+            return state
+
+        # Local-hour view of which slots overlap a worth-selling window.
+        # SlotConfig stores time-of-day; we render the worth-selling
+        # windows' UTC starts back to local hour using inputs.now's tz.
+        tz = inputs.now.tzinfo
+        worth_hours = hours_covered_by(worth_windows, tz=tz)
+
+        # Per SPEC §5 priority 1 (avoid peak import) DOMINATES priority 3
+        # (sell during top windows). A naive drain-to-min_soc could leave
+        # the battery empty going into the 18:30-23:30 evening window
+        # and force grid imports at peak rates. So the drain target is
+        # floored at min_soc + (evening_demand / capacity), matching the
+        # legacy rule's behaviour. EveningProtectRule (next in the chain)
+        # only protects pre-evening slots; this floor handles overlap
+        # cases like a 12:00-18:30 day slot that EveningProtect skips.
+        evening_demand_kwh = inputs.load_kwh_between(18, 24)
+        if inputs.battery_capacity_kwh > 0:
+            evening_floor_soc = int(
+                inputs.min_soc
+                + (evening_demand_kwh / inputs.battery_capacity_kwh * 100)
+            )
+        else:
+            evening_floor_soc = int(inputs.min_soc)
+        evening_floor_soc = min(evening_floor_soc, 100)
+        drain_target = max(evening_floor_soc, int(inputs.min_soc))
+
         modified = False
         for slot in state.slots:
             start_hour = slot.start_time.hour
             end_hour = slot.end_time.hour if slot.end_time > slot.start_time else 24
             slot_hours = set(range(start_hour, end_hour))
 
-            if slot_hours & set(profitable_hours) and not slot.grid_charge:
+            if slot_hours & worth_hours and not slot.grid_charge:
                 if slot.capacity_soc > drain_target:
                     slot.capacity_soc = drain_target
                     modified = True
 
+        sorted_hours = sorted(worth_hours)
+        rate_summary = (
+            f"{worth_windows[0].rate_pence:.2f}-"
+            f"{worth_windows[-1].rate_pence:.2f}p"
+            if len(worth_windows) > 1
+            else f"{worth_windows[0].rate_pence:.2f}p"
+        )
+
         if modified:
             state.reason_log.append(
-                f"ExportWindow: drain to {drain_target}% during profitable export "
-                f"(hours {profitable_hours}, floor from {evening_demand_kwh:.1f} kWh evening demand)"
+                f"ExportWindow: drain to {drain_target}% in {n_reason}, "
+                f"{len(worth_windows)} slots @ {rate_summary} "
+                f"covering hours {sorted_hours} "
+                f"(evening floor from {evening_demand_kwh:.1f} kWh demand)"
+            )
+        else:
+            state.reason_log.append(
+                f"ExportWindow: {n_reason}, {len(worth_windows)} worth-selling "
+                f"slots @ {rate_summary} but no slot SOC needed lowering"
             )
         return state

--- a/tests/test_rank_pricing.py
+++ b/tests/test_rank_pricing.py
@@ -1,0 +1,265 @@
+# tests/test_rank_pricing.py
+"""Tests for the rank-based pricing helpers (HEO-30 step 3)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from heo2.models import RateSlot
+from heo2.rank_pricing import (
+    bottom_n_pct,
+    estimate_profitable_export_kwh,
+    filter_today,
+    hours_covered_by,
+    is_worth_selling,
+    select_cheap_charge_windows,
+    select_export_top_pct,
+    select_worth_selling_windows,
+    top_n_pct,
+)
+
+UTC = timezone.utc
+
+
+def _slot(start_h: float, pence: float, day: int = 30, month: int = 4) -> RateSlot:
+    """Build a 30-min UTC slot. Hours past 23.5 wrap to subsequent days."""
+    from datetime import timedelta
+    base = datetime(2026, month, day, 0, 0, tzinfo=UTC)
+    start = base + timedelta(minutes=int(round(start_h * 60)))
+    end = start + timedelta(minutes=30)
+    return RateSlot(start=start, end=end, rate_pence=pence)
+
+
+# ---------------------------------------------------------------------------
+# top_n_pct / bottom_n_pct
+# ---------------------------------------------------------------------------
+
+
+class TestTopNPct:
+    def test_returns_top_by_rate_descending(self):
+        rates = [_slot(0, 5.0), _slot(1, 20.0), _slot(2, 10.0), _slot(3, 15.0)]
+        result = top_n_pct(rates, 50)
+        assert [r.rate_pence for r in result] == [20.0, 15.0]
+
+    def test_rounds_count_up(self):
+        # 48 slots, top 15% -> ceil(48*0.15) = ceil(7.2) = 8 slots
+        rates = [_slot(i / 2, float(i)) for i in range(48)]
+        result = top_n_pct(rates, 15)
+        assert len(result) == 8
+        # Highest 8 are slots 40..47 with values 40..47
+        assert min(r.rate_pence for r in result) == 40.0
+
+    def test_returns_at_least_one_when_pct_tiny(self):
+        rates = [_slot(0, 5.0), _slot(1, 10.0)]
+        # 1% of 2 = 0.02, ceil -> 1. Always at least one.
+        result = top_n_pct(rates, 1)
+        assert len(result) == 1
+        assert result[0].rate_pence == 10.0
+
+    def test_empty_returns_empty(self):
+        assert top_n_pct([], 30) == []
+
+    def test_zero_pct_returns_empty(self):
+        rates = [_slot(0, 5.0)]
+        assert top_n_pct(rates, 0) == []
+        assert top_n_pct(rates, -10) == []
+
+    def test_pct_over_100_returns_all(self):
+        rates = [_slot(0, 5.0), _slot(1, 10.0)]
+        result = top_n_pct(rates, 200)
+        assert len(result) == 2
+
+
+class TestBottomNPct:
+    def test_returns_bottom_by_rate_ascending(self):
+        rates = [_slot(0, 5.0), _slot(1, 20.0), _slot(2, 10.0), _slot(3, 15.0)]
+        result = bottom_n_pct(rates, 50)
+        assert [r.rate_pence for r in result] == [5.0, 10.0]
+
+    def test_igo_off_peak_is_bottom_25(self):
+        """For an IGO-shaped distribution (mostly day rate 28p, 12 slots
+        at 5p) the bottom 25% picks all the off-peak slots."""
+        # 36 day-rate slots + 12 off-peak slots = 48 half-hour slots
+        rates = (
+            [_slot(i / 2, 28.0) for i in range(36)]
+            + [_slot(36 + i / 2, 5.0) for i in range(12)]
+        )
+        result = bottom_n_pct(rates, 25)
+        assert len(result) == 12
+        assert all(r.rate_pence == 5.0 for r in result)
+
+
+# ---------------------------------------------------------------------------
+# select_export_top_pct
+# ---------------------------------------------------------------------------
+
+
+class TestSelectExportTopPct:
+    def test_low_soc_uses_n_low(self):
+        n, reason = select_export_top_pct(
+            current_soc=30.0, tomorrow_solar_kwh=50.0, daily_load_kwh=20.0,
+        )
+        assert n == 15
+        assert "low" in reason.lower()
+
+    def test_low_tomorrow_solar_uses_n_low(self):
+        # high SOC but solar < daily_load * 0.5 -> n_low
+        n, _ = select_export_top_pct(
+            current_soc=90.0, tomorrow_solar_kwh=5.0, daily_load_kwh=20.0,
+        )
+        assert n == 15
+
+    def test_high_soc_and_high_solar_uses_n_high(self):
+        n, reason = select_export_top_pct(
+            current_soc=85.0, tomorrow_solar_kwh=30.0, daily_load_kwh=20.0,
+        )
+        assert n == 50
+        assert "high" in reason.lower()
+
+    def test_medium_uses_n_med(self):
+        n, _ = select_export_top_pct(
+            current_soc=60.0, tomorrow_solar_kwh=20.0, daily_load_kwh=20.0,
+        )
+        assert n == 30
+
+    def test_custom_thresholds(self):
+        n, _ = select_export_top_pct(
+            current_soc=45.0,
+            tomorrow_solar_kwh=20.0,
+            daily_load_kwh=20.0,
+            low_soc_threshold=40.0,  # 45 is no longer "low"
+            high_soc_threshold=60.0,  # 45 is "medium"
+        )
+        assert n == 30
+
+
+# ---------------------------------------------------------------------------
+# is_worth_selling
+# ---------------------------------------------------------------------------
+
+
+class TestIsWorthSelling:
+    def test_above_breakeven_is_worth(self):
+        # 10p × 0.9025 = 9.025 > 4.95
+        assert is_worth_selling(10.0, 4.95, 0.9025) is True
+
+    def test_below_breakeven_is_not_worth(self):
+        # 5p × 0.9025 = 4.5125 < 4.95
+        assert is_worth_selling(5.0, 4.95, 0.9025) is False
+
+    def test_breakeven_returns_false(self):
+        # exact breakeven returns False (strict greater-than)
+        assert is_worth_selling(4.95 / 0.9025, 4.95, 0.9025) is False
+
+
+# ---------------------------------------------------------------------------
+# select_worth_selling_windows
+# ---------------------------------------------------------------------------
+
+
+class TestSelectWorthSellingWindows:
+    def test_combines_top_pct_and_worth_filter(self):
+        # 10 slots, top 30% -> 3 slots. Of those 3, 2 are above breakeven.
+        rates = [
+            _slot(0, 1.0), _slot(1, 2.0), _slot(2, 3.0), _slot(3, 4.0),
+            _slot(4, 5.5), _slot(5, 6.0),  # breakeven ~5.49
+            _slot(6, 7.0), _slot(7, 8.0), _slot(8, 9.0), _slot(9, 10.0),
+        ]
+        result = select_worth_selling_windows(
+            rates, n_pct=30, replacement_cost_pence=4.95,
+        )
+        # Top 3 by rate: 10, 9, 8 - all above breakeven
+        assert len(result) == 3
+        assert [r.rate_pence for r in result] == [10.0, 9.0, 8.0]
+
+    def test_drops_top_n_slots_that_fail_worth_test(self):
+        # All 10 slots in narrow band around breakeven
+        rates = [_slot(i, 5.0 + i * 0.1) for i in range(10)]
+        # Top 30% = 3 slots: 5.9, 5.8, 5.7. Breakeven for replacement
+        # cost 5.49 would be 5.49/0.9025 = 6.083p. So none are worth.
+        result = select_worth_selling_windows(
+            rates, n_pct=30, replacement_cost_pence=5.49,
+        )
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# filter_today
+# ---------------------------------------------------------------------------
+
+
+class TestFilterToday:
+    def test_keeps_slots_starting_today_local(self):
+        london = ZoneInfo("Europe/London")
+        # now = 2026-05-01 12:00 UTC = 13:00 BST
+        now = datetime(2026, 5, 1, 12, 0, tzinfo=UTC)
+        rates = [
+            # 2026-05-01 23:30 BST (today) = 22:30 UTC
+            RateSlot(
+                start=datetime(2026, 5, 1, 22, 30, tzinfo=UTC),
+                end=datetime(2026, 5, 1, 23, 0, tzinfo=UTC),
+                rate_pence=10.0,
+            ),
+            # 2026-05-02 00:30 BST (tomorrow) = 23:30 UTC on 5/1
+            RateSlot(
+                start=datetime(2026, 5, 1, 23, 30, tzinfo=UTC),
+                end=datetime(2026, 5, 2, 0, 0, tzinfo=UTC),
+                rate_pence=5.0,
+            ),
+        ]
+        result = filter_today(rates, now, tz=london)
+        assert len(result) == 1
+        assert result[0].rate_pence == 10.0
+
+
+# ---------------------------------------------------------------------------
+# hours_covered_by
+# ---------------------------------------------------------------------------
+
+
+class TestHoursCoveredBy:
+    def test_30min_slots_collapse_to_starting_hour(self):
+        slots = [
+            _slot(14.0, 5.0),  # 14:00
+            _slot(14.5, 6.0),  # 14:30
+            _slot(15.0, 7.0),  # 15:00
+        ]
+        result = hours_covered_by(slots, tz=UTC)
+        assert result == {14, 15}
+
+
+# ---------------------------------------------------------------------------
+# estimate_profitable_export_kwh
+# ---------------------------------------------------------------------------
+
+
+class TestEstimateProfitableExportKwh:
+    def test_max_discharge_per_slot(self):
+        """Each slot contributes max_discharge_kw * 0.5 hours = 2.5 kWh
+        at the default 5 kW max discharge."""
+        slots = [_slot(i, 10.0) for i in range(4)]
+        result = estimate_profitable_export_kwh(slots, max_discharge_kw=5.0)
+        assert result == pytest.approx(10.0)  # 4 * 2.5
+
+    def test_empty_returns_zero(self):
+        assert estimate_profitable_export_kwh([]) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# select_cheap_charge_windows
+# ---------------------------------------------------------------------------
+
+
+class TestSelectCheapChargeWindows:
+    def test_picks_off_peak_slots(self):
+        # IGO-shaped: 36 at day rate, 12 at off-peak
+        rates = (
+            [_slot(i / 2, 28.0) for i in range(36)]
+            + [_slot(36 + i / 2, 5.0) for i in range(12)]
+        )
+        result = select_cheap_charge_windows(rates, n_pct=25)
+        assert len(result) == 12
+        assert all(r.rate_pence == 5.0 for r in result)

--- a/tests/test_rules/test_export_window.py
+++ b/tests/test_rules/test_export_window.py
@@ -1,4 +1,4 @@
-"""Tests for ExportWindowRule."""
+"""Tests for the rank-based ExportWindowRule."""
 
 from datetime import time, datetime, timezone
 
@@ -11,6 +11,24 @@ def _make_baseline(inputs: ProgrammeInputs) -> ProgrammeState:
     return BaselineRule().apply(ProgrammeState.default(min_soc=20), inputs)
 
 
+def _today_export_distribution(values_pence: list[float]) -> list[RateSlot]:
+    """Build a series of consecutive 30-min slots starting at 00:00 today.
+
+    Hour `i // 2` for index `i`. Conftest's `now` fixture is 2026-04-13.
+    """
+    base = datetime(2026, 4, 13, 0, 0, tzinfo=timezone.utc)
+    out = []
+    for i, p in enumerate(values_pence):
+        h, m = divmod(i * 30, 60)
+        if h >= 24:
+            break
+        start = base.replace(hour=h, minute=m)
+        end = start + (datetime(2026, 4, 13, 0, 30, tzinfo=timezone.utc)
+                       - datetime(2026, 4, 13, 0, 0, tzinfo=timezone.utc))
+        out.append(RateSlot(start=start, end=end, rate_pence=p))
+    return out
+
+
 class TestExportWindowRule:
     def test_no_change_when_no_export_rates(self, default_inputs):
         """No export rate data -> no modifications."""
@@ -21,69 +39,91 @@ class TestExportWindowRule:
         result = rule.apply(state, default_inputs)
         assert [s.capacity_soc for s in result.slots] == original_socs
 
-    def test_no_change_when_export_unprofitable(self, default_inputs):
-        """Export rate below effective stored cost -> no drain."""
-        default_inputs.export_rates = [
-            RateSlot(
-                start=datetime(2026, 4, 13, 12, 0, tzinfo=timezone.utc),
-                end=datetime(2026, 4, 13, 16, 0, tzinfo=timezone.utc),
-                rate_pence=5.0,  # below 7.86p
-            ),
-        ]
+    def test_no_change_when_top_pct_below_breakeven(self, default_inputs):
+        """All today's rates are flat and below the worth-selling
+        breakeven (replacement_cost / efficiency ~5.49p) - nothing
+        ranks as worth selling."""
+        # 48 half-hour slots all at 4p (below breakeven of ~5.49p)
+        default_inputs.export_rates = _today_export_distribution([4.0] * 48)
         state = _make_baseline(default_inputs)
         rule = ExportWindowRule()
         original_socs = [s.capacity_soc for s in state.slots]
         result = rule.apply(state, default_inputs)
         assert [s.capacity_soc for s in result.slots] == original_socs
+        assert any("nothing worth selling" in r.lower() for r in result.reason_log)
 
-    def test_sets_drain_target_for_profitable_export(self, default_inputs):
-        """High export rate -> drain battery during that window."""
-        default_inputs.export_rates = [
-            RateSlot(
-                start=datetime(2026, 4, 13, 12, 0, tzinfo=timezone.utc),
-                end=datetime(2026, 4, 13, 16, 0, tzinfo=timezone.utc),
-                rate_pence=20.0,  # well above 7.86p
-            ),
-        ]
-        default_inputs.load_forecast_kwh = [1.0] * 24  # modest load
+    def test_drains_to_min_soc_when_no_evening_demand(self, default_inputs):
+        """A clearly profitable slot drains to min_soc when there's no
+        evening demand to reserve for (priority 1 doesn't apply)."""
+        rates = [3.0] * 48
+        rates[28] = 25.0  # 14:00 spike
+        default_inputs.export_rates = _today_export_distribution(rates)
+        # Zero evening demand -> no priority-1 reserve needed
+        default_inputs.load_forecast_kwh = [1.0] * 18 + [0.0] * 6
         state = _make_baseline(default_inputs)
         rule = ExportWindowRule()
         result = rule.apply(state, default_inputs)
-        # A slot overlapping 12:00-16:00 should have a reduced SOC target
         for slot in result.slots:
-            if slot.contains_time(time(14, 0)):
-                assert slot.capacity_soc < 100
+            if slot.contains_time(time(14, 0)) and not slot.grid_charge:
+                assert slot.capacity_soc == int(default_inputs.min_soc)
                 break
+        else:
+            raise AssertionError("no slot covers 14:00 - test fixture wrong")
 
-    def test_floor_protects_evening_demand(self, default_inputs):
-        """Drain target never goes below evening demand reserve."""
-        default_inputs.export_rates = [
-            RateSlot(
-                start=datetime(2026, 4, 13, 12, 0, tzinfo=timezone.utc),
-                end=datetime(2026, 4, 13, 16, 0, tzinfo=timezone.utc),
-                rate_pence=25.0,
-            ),
-        ]
-        # High evening load: 18:30-23:30 = 5 hours x 2 kWh = 10 kWh
+    def test_evening_demand_floors_drain_target(self, default_inputs):
+        """Per SPEC §5 priority 1 (avoid peak import) the rule floors
+        the drain target at min_soc + (evening_demand / capacity)."""
+        rates = [3.0] * 48
+        rates[28] = 25.0  # 14:00 spike
+        default_inputs.export_rates = _today_export_distribution(rates)
+        # 18:30-23:30 evening demand: 5h × 2 kWh = 10 kWh.
+        # required_soc = 20 + (10/20*100) = 70%
         default_inputs.load_forecast_kwh = [1.0] * 18 + [2.0] * 5 + [1.0]
         state = _make_baseline(default_inputs)
         rule = ExportWindowRule()
         result = rule.apply(state, default_inputs)
-        # Export floor SOC = min_soc + (evening_demand / capacity x 100)
-        # = 20 + (10 / 20 x 100) = 70%
         for slot in result.slots:
-            if slot.contains_time(time(14, 0)):
+            if slot.contains_time(time(14, 0)) and not slot.grid_charge:
                 assert slot.capacity_soc >= 70
                 break
 
+    def test_low_soc_uses_n_low(self, default_inputs):
+        """Low SOC + low tomorrow forecast picks top 15%, which excludes
+        marginal slots that the medium 30% would include."""
+        # 48 slots ascending 1..48. Top 15% (8 slots) is 41..48p.
+        # Top 30% (15 slots) starts at 34p. So a slot at 36p is in top-30
+        # but not top-15.
+        rates = [float(i + 1) for i in range(48)]
+        default_inputs.export_rates = _today_export_distribution(rates)
+        # Force low-SOC + low-solar branch
+        default_inputs.current_soc = 30.0
+        default_inputs.solar_forecast_kwh_tomorrow = [0.0] * 24
+        state = _make_baseline(default_inputs)
+        rule = ExportWindowRule()
+        result = rule.apply(state, default_inputs)
+        # The 36p slot (index 35) is at hour 17 (35*30/60 = 17.5).
+        # Not in top-15%, so its slot shouldn't be drained.
+        # The 48p slot (index 47) is hour 23. It IS in top-15%.
+        # SafetyRule isn't run here so min_soc=20 is the drain target.
+        # We just verify the n_low branch fired.
+        assert any("top 15%" in r for r in result.reason_log)
+
+    def test_high_soc_high_solar_uses_n_high(self, default_inputs):
+        rates = [float(i + 1) for i in range(48)]
+        default_inputs.export_rates = _today_export_distribution(rates)
+        default_inputs.current_soc = 90.0
+        # Tomorrow forecast > daily load -> high-solar branch
+        default_inputs.solar_forecast_kwh_tomorrow = [3.0] * 24
+        default_inputs.load_forecast_kwh = [1.0] * 24  # 24 kWh
+        state = _make_baseline(default_inputs)
+        rule = ExportWindowRule()
+        result = rule.apply(state, default_inputs)
+        assert any("top 50%" in r for r in result.reason_log)
+
     def test_reason_log_entry(self, default_inputs):
-        default_inputs.export_rates = [
-            RateSlot(
-                start=datetime(2026, 4, 13, 12, 0, tzinfo=timezone.utc),
-                end=datetime(2026, 4, 13, 16, 0, tzinfo=timezone.utc),
-                rate_pence=20.0,
-            ),
-        ]
+        rates = [3.0] * 48
+        rates[28] = 25.0
+        default_inputs.export_rates = _today_export_distribution(rates)
         state = _make_baseline(default_inputs)
         rule = ExportWindowRule()
         result = rule.apply(state, default_inputs)


### PR DESCRIPTION
## Summary

PR 1 of 3 in the rules-engine redesign tracked in #31. Replaces the fixed-threshold pricing in ExportWindowRule and CheapRateChargeRule with rank-based decisions per [docs/SPEC.md §5a](docs/SPEC.md). Closes the rule-replacement piece of the breakdown — the planning-lifecycle and pre/post-write validation pieces are PR 2.

## Why

The legacy rules used \`> 7.86p effective stored cost\` (CheapRateCharge) and \`> 7.86p\` (ExportWindow) as the \"profitable\" boundary. This breaks whenever Agile distributions shift:
- Winter median ~5p → 6p triggers half the day, drains the reserve
- Summer 6p is the bottom of the distribution → nothing triggers, no exports

Rank adapts: \"sell during the top 30% of today's published rates\" calibrates itself across season, day-of-week, and tariff changes without code edits.

## Changes

### New module: \`rank_pricing.py\` (pure, HA-free)

\`top_n_pct\` / \`bottom_n_pct\` (with ceil() rounding so \"top 15% of 48 slots\" yields 8), \`select_export_top_pct\` (SPEC §5a 15/30/50 selection from SOC + tomorrow forecast), \`is_worth_selling\` (rate × efficiency > replacement_cost), \`select_worth_selling_windows\`, \`estimate_profitable_export_kwh\`, \`select_cheap_charge_windows\`, \`filter_today\`, \`hours_covered_by\`.

### \`ExportWindowRule\` — rank-based selection + priority-1 floor

- N from SOC + tomorrow forecast (15 if either low; 50 if both high; 30 otherwise)
- Worth-selling filter: \`rate × 0.9025 > 4.95p\` (next IGO off-peak as replacement cost)
- Drain target = \`min_soc + (evening_demand_kwh / capacity_kwh × 100)\` — SPEC §5 priority 1 (\"avoid peak import\") dominates priority 3 (\"sell during top windows\"), so we don't drain so low that we hit peak grid in the evening

### \`CheapRateChargeRule\` — same formula, rank-derived inputs

\`worth_charging = demand + profitable_export - solar\`, but \`profitable_export\` now comes from the rank-based worth-selling slot count × max-discharge-per-slot, not a count of profitable hours by fixed threshold.

### Plumbing

- \`ProgrammeInputs.solar_forecast_kwh_tomorrow\` added (24 hourly floats, default empty)
- Coordinator reads it from \`sensor.solcast_pv_forecast_forecast_tomorrow\` via the existing \`_read_solar_forecast\` helper, now generalised with \`entity_override\` and \`target_offset_days\` parameters
- SPEC-aligned config knobs added to \`const.py\` (legacy constants kept for backward compat)

## Tests (344 passing, +25)

- \`tests/test_rank_pricing.py\` (24 cases): ranking, ceil rounding, N-selection branches, worth-selling combined filter, IGO-shaped bottom-25% picks the off-peak slots, hours_covered_by, today filter with London BST/UTC boundary
- \`tests/test_rules/test_export_window.py\` rewritten for rank semantics: no-change when nothing ranks worth selling, drain-to-min_soc with no evening demand, evening-floor when demand high, n_low / n_high branch selection
- All existing CheapRateChargeRule tests still pass — same formula structure, just rank-derived inputs

## Risk + recommended deploy approach

This PR changes the actual programme written to your inverter. The HEO-14 H4 gate already catches \"no live prices\", but a bug here could still produce a bad plan within that gate. **Recommended**: deploy with \`dry_run=true\` for the first day so you can eyeball:
- \`sensor.heo_ii_programme_reason\` references rank decisions (\"top 15% / 30% / 50%\")
- \`sensor.heo_ii_programme_slots\` 14:00 SOC reflects the evening-floor calc, not the legacy 75%
- Worth-selling slot count seems sensible vs today's actual Agile rates

If the projection looks right, flip \`dry_run=false\`.

## Not in scope (PR 2 of 3 in #31)

- 18:00 daily-plan vs 15-min tick separation (SPEC §8)
- Pre-write validator: peak-window check, IGO cheap-window check, projection report sensor (H1, H5)
- Post-write verification: read back 6 slots, flag mismatch (H6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)