### PR TITLE
fix(HEO-31): time_point_N is the START of slot N, not the end

### DIFF
--- a/custom_components/heo2/inverter_state_reader.py
+++ b/custom_components/heo2/inverter_state_reader.py
@@ -81,11 +81,18 @@ def read_programme_state(
     write-back to the "real" value on next tick, which is fine.
 
     Note on slot start/end times:
-      SA's `time_point_N` is the END of slot N (equivalently the START
-      of slot N+1). This mirrors the Sunsynk programme semantics. The
-      returned SlotConfig has:
-        start_time = time_point_{n-1}  (time_point_6 wraps for slot 1)
-        end_time   = time_point_{n}
+      SA's `time_point_N` is the START of slot N (the Sunsynk timer
+      register convention - verified against the SA UI mapping).
+      Slot N covers [time_point_N, time_point_{N+1}), with slot 6
+      wrapping to time_point_1 for its end. So the returned SlotConfig
+      for slot N has:
+        start_time = time_point_{n}
+        end_time   = time_point_{n+1 mod 6}  (= time_point_1 for slot 6)
+
+      Pre-2026-05-02 this module had the convention reversed (treating
+      time_point_N as slot N's END). That bug shifted all SOC and
+      grid_charge writes by one slot relative to their intended time
+      windows - see commit message for HEO-31.
     """
     inv = inverter_name.replace("inverter_", "")
 
@@ -107,11 +114,10 @@ def read_programme_state(
 
         gc = parse_bool(gc_raw) if gc_raw else _FALLBACK_GRID_CHARGE
 
-        # time_point_N is slot N's end; slot N's start is time_point_{N-1},
-        # with slot 1's start being time_point_6 (wraps midnight).
-        start_idx = (n - 2) % 6  # -1 -> 5, 0 -> 0, etc
-        start_time = time_points[start_idx]
-        end_time = time_points[n - 1]
+        # time_point_N is slot N's START. Slot N runs from time_point_N
+        # to time_point_{N+1}, with slot 6 wrapping to time_point_1.
+        start_time = time_points[n - 1]
+        end_time = time_points[n % 6]  # n=6 -> index 0 (wraps midnight)
 
         slots.append(SlotConfig(
             start_time=start_time,

--- a/custom_components/heo2/mqtt_writer.py
+++ b/custom_components/heo2/mqtt_writer.py
@@ -163,7 +163,14 @@ class MqttWriter:
     # --- diff -----------------------------------------------------------
 
     def diff(self, current: ProgrammeState, new: ProgrammeState) -> list[SlotWrite]:
-        """Compare two programmes and return a list of register writes."""
+        """Compare two programmes and return a list of register writes.
+
+        `time_point_N` on the inverter is slot N's START time (Sunsynk
+        timer convention - verified against the SA UI). So we write
+        `slot.start_time` to time_point_N. Pre-2026-05-02 this used
+        `slot.end_time`, which produced an off-by-one shift relative
+        to the intended time windows (HEO-31 fix).
+        """
         writes: list[SlotWrite] = []
 
         for i in range(6):
@@ -172,8 +179,8 @@ class MqttWriter:
             slot_num = i + 1
 
             cap = nw.capacity_soc if nw.capacity_soc != cur.capacity_soc else None
-            cur_time = cur.end_time.strftime("%H:%M")
-            new_time = nw.end_time.strftime("%H:%M")
+            cur_time = cur.start_time.strftime("%H:%M")
+            new_time = nw.start_time.strftime("%H:%M")
             tp = new_time if new_time != cur_time else None
             gc = nw.grid_charge if nw.grid_charge != cur.grid_charge else None
 

--- a/tests/test_inverter_state_reader.py
+++ b/tests/test_inverter_state_reader.py
@@ -88,12 +88,15 @@ class TestReadProgrammeState:
         assert state.slots[4].capacity_soc == 20
         for slot in state.slots:
             assert slot.grid_charge is False
-        # Slot 1 starts at time_point_6 (the previous slot end), ends at time_point_1
-        assert state.slots[0].start_time == time(0, 0)
-        assert state.slots[0].end_time == time(5, 30)
-        # Slot 2 starts at time_point_1, ends at time_point_2
-        assert state.slots[1].start_time == time(5, 30)
-        assert state.slots[1].end_time == time(18, 30)
+        # Slot 1 starts at time_point_1 (Sunsynk timer convention), ends at time_point_2
+        assert state.slots[0].start_time == time(5, 30)
+        assert state.slots[0].end_time == time(18, 30)
+        # Slot 2 starts at time_point_2, ends at time_point_3
+        assert state.slots[1].start_time == time(18, 30)
+        assert state.slots[1].end_time == time(23, 30)
+        # Slot 6 wraps midnight: starts at time_point_6, ends at time_point_1
+        assert state.slots[5].start_time == time(0, 0)
+        assert state.slots[5].end_time == time(5, 30)
 
 
     def test_grid_charge_variants_parsed_correctly(self):

--- a/tests/test_mqtt_writer.py
+++ b/tests/test_mqtt_writer.py
@@ -110,13 +110,19 @@ class TestDiffProgramme:
         assert writes[0].grid_charge is None
 
     def test_time_change_detected(self):
+        """Writer maps slot[i].start_time -> time_point_{i+1} (Sunsynk
+        timer convention). Changing slot 3's start to 19:00 means
+        time_point_3 = 19:00."""
         current = _baseline_programme()
         new = _baseline_programme()
+        # Move slot 3's start earlier - this shifts the boundary
+        # between slot 2 and slot 3 from 18:30 to 19:00.
         new.slots[1] = SlotConfig(time(5, 30), time(19, 0), 100, False)
+        new.slots[2] = SlotConfig(time(19, 0), time(23, 30), 20, False)
         writer = MqttWriter(client=MagicMock())
         writes = writer.diff(current, new)
         assert len(writes) == 1
-        assert writes[0].slot_number == 2
+        assert writes[0].slot_number == 3
         assert writes[0].time_point == "19:00"
         assert writes[0].capacity_soc is None
 
@@ -130,6 +136,27 @@ class TestDiffProgramme:
         assert writes[0].slot_number == 3
         assert writes[0].grid_charge is True
         assert writes[0].capacity_soc is None
+
+    def test_time_point_is_slot_start_not_end(self):
+        """HEO-31: regression guard. The Sunsynk timer convention is
+        time_point_N = start of slot N. If a future refactor flips this
+        back to slot.end_time the bug would silently shift all SOCs and
+        grid_charge flags by one slot relative to their time windows.
+
+        Slot 1 starts at 00:00 -> time_point_1 must be "00:00", NOT
+        the end_time "05:30".
+        """
+        current = _baseline_programme()
+        # Force slot 1's start to differ from current
+        new = _baseline_programme()
+        new.slots[0] = SlotConfig(time(0, 30), time(5, 30), 100, True)
+        writer = MqttWriter(client=MagicMock())
+        writes = writer.diff(current, new)
+        # The diff must pick up the start change as time_point_1 = "00:30",
+        # not "05:30" (which is end_time and unchanged).
+        slot1_writes = [w for w in writes if w.slot_number == 1]
+        assert len(slot1_writes) == 1
+        assert slot1_writes[0].time_point == "00:30"
 
 
 # -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The Sunsynk timer register convention (verified against the SA UI's Work mode timer view) is **\`time_point_N\` = start of slot N**. Our \`inverter_state_reader.read_programme_state\` and \`mqtt_writer.diff\` have been treating \`time_point_N\` as the end of slot N since HEO-27 went live (2026-04-26). Reader + writer were internally consistent, so the diff always agreed with the seed — but every write the inverter received had its SOC and grid_charge values shifted by one slot relative to the time window HEO II intended.

## How we found it

Going live with HEO-30 (rank-based pricing) today produced a plan that flipped two slots' grid_charge from False to True. The SA UI screenshot from the live install showed:

| Time start | Time end | SOC | Grid charge |
|---|---|---|---|
| 05:30 | 05:30 | 10% | OFF |
| 05:30 | 14:00 | 100% | OFF |
| 14:00 | 15:00 | 100% | OFF |
| 15:00 | 18:25 | 100% | OFF |
| 18:25 | 23:30 | 20% | OFF |
| 23:30 | 05:30 | 10% | OFF |

All six slots showed Grid charge = OFF despite HEO II's plan having two grid_charge=True slots. Cross-checking row-by-row against the entity reads (\`time_point_N\`, \`capacity_point_N\`) showed that:

- Row N corresponds to \`time_point_N\` as the start time
- Row N's SOC is \`capacity_point_N\`

If \`time_point_N\` were the end of slot N, the SA UI rows wouldn't line up. They do under the START convention. So **\`time_point_N\` is the start of slot N**.

## Fix

- \`read_programme_state\`: slot[N-1].start_time = time_points[N-1], slot[N-1].end_time = time_points[N % 6] (slot 6 wraps to time_point_1)
- \`MqttWriter.diff\`: writes \`slot.start_time\` to time_point_N instead of \`slot.end_time\`

## Tests (345 passing)

- Updated \`test_reads_all_six_slots_with_live_values\` for the corrected start/end mapping; verifies slot 6 wraps midnight
- Updated \`test_time_change_detected\` to verify a slot-3-start change fires time_point_3 (was testing end_time semantics)
- New \`test_time_point_is_slot_start_not_end\` as an explicit regression guard pinning the Sunsynk convention so a future refactor can't silently flip it back

## Real-world impact

Going back to HEO-27, every "overnight grid charge" slot HEO II thought it was writing was actually landing on a 1-minute window between 23:57-23:58. The battery has been charging from solar during the day, not from cheap-rate IGO at night. The user has been getting away with it through high spring solar production. After this fix lands the next coordinator tick will rewrite all 6 slots with corrected boundaries and grid_charge will land where intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)