### PR TITLE
fix(HEO-32): SA bare-Saved response + lowercase grid_charge

### DIFF
--- a/custom_components/heo2/mqtt_writer.py
+++ b/custom_components/heo2/mqtt_writer.py
@@ -85,39 +85,47 @@ def format_time(t: time | str) -> str:
 
 
 def format_grid_charge(enabled: bool) -> str:
-    """SA expects 'Enabled' / 'Disabled' as the setting value."""
-    return "Enabled" if enabled else "Disabled"
+    """SA's grid_charge_point_N set-topic accepts 'true' / 'false'.
+
+    Pre-HEO-32 (2026-04 and earlier) SA used 'Enabled' / 'Disabled' here.
+    The current SA build rejects those with `Error: Invalid value
+    'Enabled' for 'Grid charge point N'. Valid values: true, false.`
+    so any HEO II writer talking to a current SA must emit lowercase
+    booleans.
+    """
+    return "true" if enabled else "false"
 
 
-def parse_response_message(
-    response: str, expected_setting: str,
-) -> tuple[bool, str | None]:
+def parse_response_message(response: str) -> tuple[bool, str | None]:
     """Parse an SA response_message payload.
 
     Returns (success, error_detail_or_none). `success` is True iff the
-    response is for the expected setting and ends with ": Saved."
-    Any other outcome (Error, different setting, malformed) is False.
+    response is "Saved" (with optional trailing punctuation/whitespace).
+    Anything starting "Error:" is an explicit failure with the error
+    text returned as the detail.
 
-    SA format observed in production:
-        Set 'Capacity point 1' to '97': Saved.
-        Set 'Grid charge' to 'Disabled': Error: No response.
+    Current SA format observed 2026-05-02:
+        Saved
+        Error: Invalid value 'Enabled' for 'Grid charge point 1'. ...
+        Error: No response.
+
+    Pre-2026-05 SA prefixed every response with `Set 'Name' to 'Value': `.
+    The payload no longer carries the setting name, so callers must
+    correlate responses to writes by FIFO ordering rather than by
+    parsing the response payload (handled by `_publish_and_confirm`).
     """
-    if not response or "Set '" not in response:
-        return False, f"malformed response: {response!r}"
+    if not response:
+        return False, "empty response"
 
-    if expected_setting not in response:
-        # Response is for some other concurrent write; not ours
-        return False, f"response for different setting: {response!r}"
-
-    if response.rstrip(".").endswith("Saved"):
+    text = response.strip().rstrip(".")
+    if text == "Saved" or text.endswith(": Saved"):
         return True, None
 
-    # Everything else is an error; extract the detail after "Error:"
     marker = "Error:"
-    if marker in response:
-        detail = response[response.index(marker) + len(marker):].strip().rstrip(".")
-        return False, detail
-    return False, f"unknown failure: {response!r}"
+    if marker in text:
+        detail = text[text.index(marker) + len(marker):].strip().rstrip(".")
+        return False, detail or "unspecified error"
+    return False, f"unrecognised response: {response!r}"
 
 
 class MqttWriter:
@@ -231,7 +239,16 @@ class MqttWriter:
     async def write_registers(self, writes: list[SlotWrite]) -> MqttWriteResult:
         """Publish each setting change and wait for SA to confirm each
         one via response_message. Returns on first unrecoverable failure
-        or when all writes are confirmed."""
+        or when all writes are confirmed.
+
+        SA's response payload no longer includes the setting name (just
+        "Saved" or "Error: ..."), so we correlate responses to writes
+        by strict FIFO. We subscribe once per batch, push every incoming
+        response onto an asyncio.Queue, and `_publish_and_confirm` pops
+        exactly one item per publish. Writes are sequential by design
+        (see HEO-32) so the next response is always for the most recent
+        publish.
+        """
         result = MqttWriteResult(writes_attempted=0)
 
         if self._dry_run:
@@ -243,24 +260,20 @@ class MqttWriter:
             result.success = True
             return result
 
-        # Subscribe to the response topic ONCE for the whole batch. Each
-        # write temporarily attaches its own future to the subscription
-        # handler via the shared self._response_futures dict.
-        self._response_futures: dict[str, asyncio.Future[tuple[bool, str | None]]] = {}
+        self._response_queue: asyncio.Queue[str] = asyncio.Queue()
 
         async def _on_response(topic: str, payload: str) -> None:
-            for setting_display, fut in list(self._response_futures.items()):
-                if fut.done():
-                    continue
-                if setting_display in payload:
-                    ok, detail = parse_response_message(payload, setting_display)
-                    if not fut.done():
-                        fut.set_result((ok, detail))
+            await self._response_queue.put(payload)
 
         unsubscribe = await self._transport.subscribe(
             self._response_topic(), _on_response,
         )
         try:
+            # Drain any responses that may have queued up before our
+            # write loop starts (retained messages, slow connect handshake).
+            while not self._response_queue.empty():
+                self._response_queue.get_nowait()
+
             for write in writes:
                 for param, topic, payload, setting_display in self._ops_for_slot(write):
                     result.writes_attempted += 1
@@ -284,48 +297,54 @@ class MqttWriter:
     async def _publish_and_confirm(
         self, topic: str, payload: str, setting_display: str,
     ) -> tuple[bool, str | None]:
-        """Publish once and wait for response. Retry on timeout only
-        (not on Error responses, since SA already tried and reported
-        failure from the inverter end).
+        """Publish once and pop the next response off the FIFO queue.
 
-        Returns (success, reason_if_failed).
+        Retries on timeout (no response) but NOT on explicit Error
+        responses - SA already attempted the write and reported failure
+        from the inverter end.
+
+        Returns (success, reason_if_failed). The setting_display name is
+        included in log lines for diagnosis but is no longer used to
+        match responses to publishes (HEO-32: SA simplified the payload).
         """
         last_reason: str | None = None
 
         for attempt in range(1, MQTT_MAX_RETRIES + 1):
-            fut: asyncio.Future[tuple[bool, str | None]] = asyncio.get_event_loop().create_future()
-            self._response_futures[setting_display] = fut
-
             try:
                 await self._transport.publish(topic, payload)
+            except Exception as exc:
+                last_reason = f"publish failed: {exc}"
+                logger.warning(
+                    "HEO-2: %s attempt %d/%d publish error on %s: %s",
+                    setting_display, attempt, MQTT_MAX_RETRIES, topic, exc,
+                )
+                continue
 
-                try:
-                    ok, detail = await asyncio.wait_for(
-                        fut, timeout=MQTT_WRITE_TIMEOUT_SECONDS,
-                    )
-                except asyncio.TimeoutError:
-                    last_reason = f"no response within {MQTT_WRITE_TIMEOUT_SECONDS}s"
-                    logger.warning(
-                        "HEO-2: %s attempt %d/%d timeout on %s",
-                        setting_display, attempt, MQTT_MAX_RETRIES, topic,
-                    )
-                    continue
+            try:
+                response = await asyncio.wait_for(
+                    self._response_queue.get(),
+                    timeout=MQTT_WRITE_TIMEOUT_SECONDS,
+                )
+            except asyncio.TimeoutError:
+                last_reason = f"no response within {MQTT_WRITE_TIMEOUT_SECONDS}s"
+                logger.warning(
+                    "HEO-2: %s attempt %d/%d timeout on %s",
+                    setting_display, attempt, MQTT_MAX_RETRIES, topic,
+                )
+                continue
 
-                if ok:
-                    logger.info(
-                        "HEO-2: %s confirmed (attempt %d)",
-                        setting_display, attempt,
-                    )
-                    return True, None
-                else:
-                    # Explicit Error from SA. No retry.
-                    logger.warning(
-                        "HEO-2: %s rejected by SA: %s",
-                        setting_display, detail,
-                    )
-                    return False, detail
-            finally:
-                self._response_futures.pop(setting_display, None)
+            ok, detail = parse_response_message(response)
+            if ok:
+                logger.info(
+                    "HEO-2: %s confirmed (attempt %d): %r",
+                    setting_display, attempt, response,
+                )
+                return True, None
+            logger.warning(
+                "HEO-2: %s rejected by SA: %s (raw=%r)",
+                setting_display, detail, response,
+            )
+            return False, detail
 
         return False, last_reason
 

--- a/tests/test_mqtt_writer.py
+++ b/tests/test_mqtt_writer.py
@@ -33,11 +33,14 @@ class FakeTransport:
     Records every publish. After each publish, optionally dispatches a
     scripted response to whoever is subscribed to response_message/state.
 
+    Post-HEO-32 SA payload format: a bare "Saved" or "Error: <reason>"
+    string with no setting prefix. Scripted responses must match.
+
     Usage:
         transport = FakeTransport()
         transport.script_responses([
-            "Set 'Capacity point 1' to '95': Saved.",
-            "Set 'Grid charge point 2' to 'Enabled': Saved.",
+            "Saved",
+            "Error: No response.",
         ])
     """
 
@@ -192,11 +195,14 @@ class TestTopicGeneration:
 # -----------------------------------------------------------------------
 
 class TestFormatters:
-    def test_format_grid_charge_true_is_Enabled(self):
-        assert format_grid_charge(True) == "Enabled"
+    def test_format_grid_charge_true_is_lowercase_true(self):
+        """HEO-32: SA accepts only lowercase 'true'/'false' for
+        grid_charge_point_N. Pre-HEO-32 'Enabled'/'Disabled' is
+        rejected with `Error: Invalid value 'Enabled' for ...`."""
+        assert format_grid_charge(True) == "true"
 
-    def test_format_grid_charge_false_is_Disabled(self):
-        assert format_grid_charge(False) == "Disabled"
+    def test_format_grid_charge_false_is_lowercase_false(self):
+        assert format_grid_charge(False) == "false"
 
     def test_format_time_accepts_time_object(self):
         assert format_time(time(23, 30)) == "23:30"
@@ -206,63 +212,55 @@ class TestFormatters:
 
 
 # -----------------------------------------------------------------------
-# parse_response_message - pure function covering SA's actual formats
+# parse_response_message - pure function covering SA's current format
 # -----------------------------------------------------------------------
 
 class TestParseResponseMessage:
-    def test_saved_returns_success(self):
-        ok, reason = parse_response_message(
-            "Set 'Capacity point 1' to '97': Saved.",
-            "Capacity point 1",
-        )
+    def test_bare_saved_returns_success(self):
+        """HEO-32: post-2026-05 SA payload is just 'Saved' - no
+        'Set <name> to <value>:' prefix."""
+        ok, reason = parse_response_message("Saved")
         assert ok is True
         assert reason is None
 
-    def test_saved_without_trailing_period(self):
-        """Defensive - some SA variants may omit the trailing dot."""
+    def test_legacy_set_prefix_saved_still_recognised(self):
+        """Backward compat with older SA builds that still wrote
+        the verbose `Set 'X' to 'Y': Saved.` format."""
         ok, reason = parse_response_message(
-            "Set 'Capacity point 1' to '97': Saved",
-            "Capacity point 1",
+            "Set 'Capacity point 1' to '97': Saved.",
         )
         assert ok is True
 
     def test_error_no_response_is_failure(self):
-        """Live SA log shows this error shape verbatim."""
+        """Live SA log shape: bare 'Error: No response' with no prefix."""
+        ok, reason = parse_response_message("Error: No response.")
+        assert ok is False
+        assert reason == "No response"
+
+    def test_error_invalid_value_captures_detail(self):
+        """The actual error from SA when sent legacy 'Enabled'."""
+        ok, reason = parse_response_message(
+            "Error: Invalid value 'Enabled' for 'Grid charge point 1'. "
+            "Valid values: true, false."
+        )
+        assert ok is False
+        assert "Invalid value" in reason
+
+    def test_legacy_set_prefix_error_still_recognised(self):
         ok, reason = parse_response_message(
             "Set 'Grid charge' to 'Disabled': Error: No response.",
-            "Grid charge",
         )
         assert ok is False
         assert reason == "No response"
 
-    def test_error_with_explanation_captures_detail(self):
-        ok, reason = parse_response_message(
-            "Set 'Work mode' to 'Selling first': Error: Value rejected by inverter.",
-            "Work mode",
-        )
-        assert ok is False
-        assert "rejected" in reason
-
-    def test_response_for_different_setting_is_failure(self):
-        """If SA responds about something else, don't claim our success."""
-        ok, reason = parse_response_message(
-            "Set 'Energy pattern' to 'Battery first': Saved.",
-            "Capacity point 1",
-        )
-        assert ok is False
-        assert "different setting" in reason
-
     def test_empty_response_is_failure(self):
-        ok, reason = parse_response_message("", "Capacity point 1")
+        ok, reason = parse_response_message("")
         assert ok is False
 
-    def test_malformed_response_is_failure(self):
-        ok, reason = parse_response_message(
-            "something else entirely",
-            "Capacity point 1",
-        )
+    def test_unrecognised_response_is_failure(self):
+        ok, reason = parse_response_message("something else entirely")
         assert ok is False
-        assert "malformed" in reason
+        assert "unrecognised" in reason
 
 
 # -----------------------------------------------------------------------
@@ -273,9 +271,7 @@ class TestWriteRegisters:
     @pytest.mark.asyncio
     async def test_happy_path_capacity_write_confirmed(self):
         transport = FakeTransport()
-        transport.script_responses([
-            "Set 'Capacity point 1' to '80': Saved.",
-        ])
+        transport.script_responses(["Saved"])
         writer = MqttWriter(transport=transport)
 
         result = await writer.write_registers([
@@ -292,11 +288,10 @@ class TestWriteRegisters:
         )
 
     @pytest.mark.asyncio
-    async def test_grid_charge_serialised_as_Enabled_or_Disabled(self):
+    async def test_grid_charge_serialised_as_lowercase_bool(self):
+        """HEO-32: SA's grid_charge_point_N expects 'true'/'false'."""
         transport = FakeTransport()
-        transport.script_responses([
-            "Set 'Grid charge point 2' to 'Enabled': Saved.",
-        ])
+        transport.script_responses(["Saved"])
         writer = MqttWriter(transport=transport)
 
         await writer.write_registers([
@@ -304,15 +299,12 @@ class TestWriteRegisters:
         ])
 
         _topic, payload = transport.published[0]
-        assert payload == "Enabled"
+        assert payload == "true"
 
     @pytest.mark.asyncio
     async def test_multiple_slots_published_in_order(self):
         transport = FakeTransport()
-        transport.script_responses([
-            "Set 'Capacity point 1' to '80': Saved.",
-            "Set 'Grid charge point 3' to 'Enabled': Saved.",
-        ])
+        transport.script_responses(["Saved", "Saved"])
         writer = MqttWriter(transport=transport)
 
         result = await writer.write_registers([
@@ -333,9 +325,7 @@ class TestWriteRegisters:
         """When SA says 'Error: No response', the inverter already tried
         and rejected. No point retrying - fail fast."""
         transport = FakeTransport()
-        transport.script_responses([
-            "Set 'Capacity point 1' to '80': Error: No response.",
-        ])
+        transport.script_responses(["Error: No response."])
         writer = MqttWriter(transport=transport)
 
         result = await writer.write_registers([
@@ -352,14 +342,13 @@ class TestWriteRegisters:
     @pytest.mark.asyncio
     async def test_timeout_triggers_retry_then_success(self, monkeypatch):
         """If no response arrives in time, retry up to MQTT_MAX_RETRIES."""
-        # Shorten the timeout so the test finishes quickly
         monkeypatch.setattr(
             "heo2.mqtt_writer.MQTT_WRITE_TIMEOUT_SECONDS", 0.05
         )
         transport = FakeTransport()
         transport.script_responses([
             None,  # first attempt: no response
-            "Set 'Capacity point 1' to '80': Saved.",  # second: success
+            "Saved",  # second attempt: success
         ])
         writer = MqttWriter(transport=transport)
 
@@ -397,7 +386,7 @@ class TestWriteRegisters:
         Partial writes would leave the inverter in an inconsistent state."""
         transport = FakeTransport()
         transport.script_responses([
-            "Set 'Capacity point 1' to '80': Error: Inverter rejected.",
+            "Error: Inverter rejected.",
             # No second response scripted - we should never get here
         ])
         writer = MqttWriter(transport=transport)
@@ -412,6 +401,25 @@ class TestWriteRegisters:
         # Slot 2 never got published
         assert len(transport.published) == 1
         assert "capacity_point_1" in transport.published[0][0]
+
+    @pytest.mark.asyncio
+    async def test_responses_correlated_by_fifo_order(self):
+        """HEO-32: SA's bare 'Saved'/'Error:' payload doesn't carry the
+        setting name, so writes are sequential and the queue pops one
+        response per publish in order. A delayed first response still
+        attaches to the first publish, not the second.
+        """
+        transport = FakeTransport()
+        # Both succeed - confirms the queue feeds one response per publish.
+        transport.script_responses(["Saved", "Saved"])
+        writer = MqttWriter(transport=transport)
+
+        result = await writer.write_registers([
+            SlotWrite(slot_number=1, capacity_soc=80),
+            SlotWrite(slot_number=2, capacity_soc=70),
+        ])
+        assert result.success is True
+        assert result.writes_confirmed == 2
 
     @pytest.mark.asyncio
     async def test_dry_run_logs_without_publishing(self):
@@ -470,9 +478,7 @@ class TestApplyProgrammeDiff:
         """After a successful write, last_known should reflect the new
         programme so the next tick sees no diff."""
         transport = FakeTransport()
-        transport.script_responses([
-            "Set 'Capacity point 1' to '80': Saved.",
-        ])
+        transport.script_responses(["Saved"])
         writer = MqttWriter(transport=transport)
 
         current = _baseline_programme()
@@ -493,9 +499,7 @@ class TestApplyProgrammeDiff:
         """If SA rejects the write, last_known must NOT advance.
         Next tick should then retry the same diff."""
         transport = FakeTransport()
-        transport.script_responses([
-            "Set 'Capacity point 1' to '80': Error: Inverter unreachable.",
-        ])
+        transport.script_responses(["Error: Inverter unreachable."])
         writer = MqttWriter(transport=transport)
 
         current = _baseline_programme()
@@ -543,8 +547,8 @@ class TestApplyProgrammeDiff:
         retries everything."""
         transport = FakeTransport()
         transport.script_responses([
-            "Set 'Capacity point 1' to '80': Saved.",  # 1 ok
-            "Set 'Capacity point 2' to '60': Error: No response.",  # 2 fails
+            "Saved",  # 1 ok
+            "Error: No response.",  # 2 fails
             # slot 3 never attempted
         ])
         writer = MqttWriter(transport=transport)


### PR DESCRIPTION
## Summary
- `parse_response_message` now accepts SA's current bare `Saved` / `Error: ...` payloads (no setting prefix). Legacy `Set 'X' to 'Y': Saved.` still recognised for backward compat.
- Writer correlates responses to publishes by FIFO queue instead of by parsing setting names from the payload.
- `format_grid_charge` emits lowercase `true` / `false` (SA rejects legacy `Enabled` / `Disabled`).

## Why
HEO-31 deployed at 12:36 BST today. First convergence tick at 12:51:59 timed out after 3 retries on every slot write because the post-HEO-2 SA broker no longer puts the setting name in the response payload, and our parser required it. Probe of the live SA broker confirmed the new payload shapes; commit message has the verbatim mosquitto trace.

## Test plan
- [x] `pytest tests/test_mqtt_writer.py -q` -> 36 pass (one new FIFO test)
- [x] `pytest tests/ --ignore=tests/test_config_flow_dashboard.py -q` -> 346 pass
- [ ] Deploy to PROD, verify next coordinator tick clears the 6 pending writes against the manually edited inverter slots
- [ ] After convergence, slot 1..6 in `sa_inverter_1_*` entities match `sensor.heo_ii_programme_slots`

🤖 Generated with [Claude Code](https://claude.com/claude-code)