### PR TITLE
feat(HEO-31 PR2): planning lifecycle + pre-write H5 + post-write H6

### DIFF
--- a/custom_components/heo2/const.py
+++ b/custom_components/heo2/const.py
@@ -55,6 +55,20 @@ SLOT_COUNT = 6
 UPDATE_INTERVAL_MINUTES = 15
 SOC_DEVIATION_THRESHOLD_PCT = 10.0
 
+# SPEC §8 planning cadence: full re-plan once per day at this local time.
+# Tomorrow's Octopus rates are published after 16:00; 18:00 gives a
+# two-hour safety margin.
+DEFAULT_DAILY_PLAN_TIME = "18:00"
+DEFAULT_REPLAN_SOLAR_PCT = 25
+DEFAULT_REPLAN_LOAD_PCT = 25
+DEFAULT_REPLAN_SOC_PCT = 10
+
+# SPEC §7 post-write verify: how long to wait for SA's polling cadence
+# to reflect a successful publish in the discovered HA entities. SA
+# polls the inverter every ~5s; 10s is conservative without bloating
+# the tick.
+POST_WRITE_VERIFY_DELAY_SECONDS = 10
+
 # Appliance defaults (draw_kw, duration_hours)
 DEFAULT_APPLIANCES = {
     "wash": {"draw_kw": 2.0, "duration_hours": 1.0},

--- a/custom_components/heo2/coordinator.py
+++ b/custom_components/heo2/coordinator.py
@@ -5,14 +5,30 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from datetime import timedelta
+from datetime import timedelta, time
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
-from .const import DOMAIN, UPDATE_INTERVAL_MINUTES, DEFAULT_MIN_SOC
-from .models import ProgrammeInputs, ProgrammeState
+from .const import (
+    DOMAIN,
+    UPDATE_INTERVAL_MINUTES,
+    DEFAULT_MIN_SOC,
+    DEFAULT_DAILY_PLAN_TIME,
+    DEFAULT_REPLAN_SOLAR_PCT,
+    DEFAULT_REPLAN_LOAD_PCT,
+    DEFAULT_REPLAN_SOC_PCT,
+    DEFAULT_PEAK_THRESHOLD_PENCE,
+    DEFAULT_SELL_TOP_PCT,
+    DEFAULT_CHEAP_CHARGE_BOTTOM_PCT,
+    DEFAULT_MAX_CHARGE_KW,
+    DEFAULT_MAX_DISCHARGE_KW,
+    DEFAULT_CHARGE_EFFICIENCY,
+    DEFAULT_DISCHARGE_EFFICIENCY,
+    POST_WRITE_VERIFY_DELAY_SECONDS,
+)
+from .models import ProgrammeInputs, ProgrammeState, SlotConfig
 from .rule_engine import RuleEngine
 from .rules import default_rules
 from .load_profile import LoadProfileBuilder
@@ -33,6 +49,13 @@ from .mqtt_writer import MqttWriter, apply_programme_diff
 from .direct_mqtt_transport import DirectMqttTransport
 from .inverter_state_reader import read_from_hass as read_inverter_state
 from .writes_status import _compute_writes_blocked
+from .plan_validator import ValidationResult, validate_plan
+from .projection import Projection
+from .replan_triggers import (
+    BaselineSnapshot,
+    capture_baseline,
+    should_commit_replan,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -100,6 +123,61 @@ class HEO2Coordinator(DataUpdateCoordinator):
         self._live_rates_present: bool = True
         self._bottlecapdave_meter_key: str | None = None
 
+        # SPEC §8 planning lifecycle. The baseline is the programme
+        # currently being driven into the inverter; the rule engine
+        # runs every tick for sensors/diagnostics but only swaps the
+        # baseline when the daily 18:00 window fires or a trigger
+        # condition deviates the world from the baseline-time snapshot.
+        self._baseline: BaselineSnapshot | None = None
+        # SPEC §6 H5 / §7 H6: pre-write validation + post-write verify
+        # state. Reasons surface via writes_blocked_reason; the
+        # projection feeds sensor.heo_ii_projection_today.
+        self._plan_rejected_reason: str | None = None
+        self._verify_mismatch_reason: str | None = None
+        self._validation_warnings: list[str] = []
+        self._last_projection: Projection | None = None
+        # The programme currently on the inverter that the next tick
+        # should verify. Set after a successful write; cleared after
+        # verify completes. Only ever holds a programme that we
+        # actively pushed (never the lazy seed).
+        self._pending_verification: ProgrammeState | None = None
+
+        # SPEC §10 tunable knobs. Defaults match the SPEC table; any
+        # of these will become HA UI number entities under HEO-11.
+        self._daily_plan_time: time = self._parse_time_config(
+            "daily_plan_time", DEFAULT_DAILY_PLAN_TIME,
+        )
+        self._replan_solar_pct: float = self._config.get(
+            "replan_solar_pct", DEFAULT_REPLAN_SOLAR_PCT,
+        )
+        self._replan_load_pct: float = self._config.get(
+            "replan_load_pct", DEFAULT_REPLAN_LOAD_PCT,
+        )
+        self._replan_soc_pct: float = self._config.get(
+            "replan_soc_pct", DEFAULT_REPLAN_SOC_PCT,
+        )
+        self._peak_threshold_p: float = self._config.get(
+            "peak_threshold_p", DEFAULT_PEAK_THRESHOLD_PENCE,
+        )
+        self._sell_top_pct_default: int = self._config.get(
+            "sell_top_pct_default", DEFAULT_SELL_TOP_PCT,
+        )
+        self._cheap_bottom_pct: int = self._config.get(
+            "cheap_charge_bottom_pct", DEFAULT_CHEAP_CHARGE_BOTTOM_PCT,
+        )
+        self._max_charge_kw: float = self._config.get(
+            "max_charge_kw", DEFAULT_MAX_CHARGE_KW,
+        )
+        self._max_discharge_kw: float = self._config.get(
+            "max_discharge_kw", DEFAULT_MAX_DISCHARGE_KW,
+        )
+        self._charge_efficiency: float = self._config.get(
+            "charge_efficiency", DEFAULT_CHARGE_EFFICIENCY,
+        )
+        self._discharge_efficiency: float = self._config.get(
+            "discharge_efficiency", DEFAULT_DISCHARGE_EFFICIENCY,
+        )
+
         # Dashboard state
         self.soc_trajectory: list[float] = [0.0] * 24
         self.cost_accumulator = CostAccumulator()
@@ -120,14 +198,102 @@ class HEO2Coordinator(DataUpdateCoordinator):
             )
 
     async def _async_update_data(self) -> ProgrammeState:
-        """Gather inputs, run rules, return new programme."""
+        """Gather inputs, run rules, decide whether to commit a fresh
+        plan or hold the baseline, validate, write, verify."""
         inputs = await self._gather_inputs()
         self.last_inputs = inputs
 
-        programme = self._engine.calculate(inputs)
-        self.current_programme = programme
+        # Verify the previously-written programme BEFORE running new
+        # rules: SA's polling will have caught up by now (15-min tick
+        # spacing) so a mismatch is real rather than a timing artefact.
+        await self._verify_pending_programme()
 
-        # Calculate appliance timing suggestions
+        # Always run the rule engine for sensors and diagnostics. The
+        # 15-min cadence updates dashboard signals every tick even
+        # when the inverter programme stays on the baseline.
+        fresh = self._engine.calculate(inputs)
+        self.current_programme = fresh
+
+        # SPEC §8: decide whether this tick commits a new baseline or
+        # holds the previous one. The trigger logic considers daily-
+        # plan-time, IGO/saving session/grid restore transitions, and
+        # quantitative deviations vs the captured baseline forecasts.
+        tz = self._local_tz()
+        decision = should_commit_replan(
+            new_programme=fresh,
+            inputs=inputs,
+            baseline=self._baseline,
+            tz=tz,
+            daily_plan_time=self._daily_plan_time,
+            replan_solar_pct=self._replan_solar_pct,
+            replan_load_pct=self._replan_load_pct,
+            replan_soc_pct=self._replan_soc_pct,
+        )
+        is_daily_plan = "daily plan" in decision.reason
+
+        if decision.commit:
+            effective = fresh
+            logger.warning("HEO-31 PR2: committing new plan: %s", decision.reason)
+        else:
+            effective = self._baseline.programme if self._baseline else fresh
+            logger.debug("HEO-31 PR2: %s", decision.reason)
+
+        # SPEC §6 H5: pre-write validate the EFFECTIVE programme (the
+        # one that will be diffed against the inverter). If it fails,
+        # the baseline stays unchanged and writes_blocked surfaces the
+        # rejection reason.
+        validation = validate_plan(
+            effective, inputs,
+            peak_threshold_p=self._peak_threshold_p,
+            cheap_bottom_pct=self._cheap_bottom_pct,
+            max_charge_kw=self._max_charge_kw,
+            max_discharge_kw=self._max_discharge_kw,
+            charge_efficiency=self._charge_efficiency,
+            discharge_efficiency=self._discharge_efficiency,
+        )
+        self._validation_warnings = validation.warnings
+        self._last_projection = validation.projection
+
+        for w in validation.warnings:
+            logger.warning("HEO-31 PR2 H5 warning: %s", w)
+
+        if not validation.passed:
+            self._plan_rejected_reason = validation.reason()[len("plan rejected: "):]
+            for e in validation.errors:
+                logger.warning("HEO-31 PR2 H5 reject: %s", e)
+            # Don't update baseline, don't write. Sensors still reflect
+            # the fresh rule output for dashboard transparency.
+            self._update_dashboard_secondary(inputs, fresh)
+            return fresh
+
+        self._plan_rejected_reason = None
+
+        # Validation passed. Promote the candidate baseline only when
+        # the trigger said "commit"; otherwise we stay on the existing
+        # baseline (which is what we just successfully validated).
+        if decision.commit:
+            self._baseline = capture_baseline(
+                fresh, inputs, tz=tz, is_daily_plan=is_daily_plan,
+            )
+
+        # Apply programme to inverter via MQTT if enabled.
+        # Any failure is logged but does NOT abort the tick - the
+        # coordinator still returns a valid programme and the next
+        # tick will retry the diff against the un-updated
+        # _last_known_programme.
+        try:
+            await self._apply_programme_to_inverter(effective)
+        except Exception:
+            logger.exception("HEO-27: apply_programme failed")
+
+        self._update_dashboard_secondary(inputs, fresh)
+        return fresh
+
+    def _update_dashboard_secondary(
+        self, inputs: ProgrammeInputs, fresh: ProgrammeState,
+    ) -> None:
+        """Calculate appliance suggestions, SOC trajectory and savings
+        from the fresh rule output regardless of write outcome."""
         for name, spec in DEFAULT_APPLIANCES.items():
             self.appliance_suggestions[name] = self._appliance_calc.best_window(
                 inputs=inputs,
@@ -136,37 +302,123 @@ class HEO2Coordinator(DataUpdateCoordinator):
                 appliance_name=name,
             )
 
-        # Calculate SOC trajectory for dashboard
         from datetime import datetime, timezone
         current_hour = datetime.now(timezone.utc).hour
         self.soc_trajectory = calculate_soc_trajectory(
             current_soc=inputs.current_soc,
             solar_forecast_kwh=inputs.solar_forecast_kwh,
             load_forecast_kwh=inputs.load_forecast_kwh,
-            programme_slots=programme.slots,
+            programme_slots=fresh.slots,
             battery_capacity_kwh=self._config.get("battery_capacity_kwh", 20.0),
-            max_charge_kw=self._config.get("max_charge_kw", 5.0),
-            charge_efficiency=self._config.get("charge_efficiency", 0.95),
-            discharge_efficiency=self._config.get("discharge_efficiency", 0.95),
+            max_charge_kw=self._max_charge_kw,
+            charge_efficiency=self._charge_efficiency,
+            discharge_efficiency=self._discharge_efficiency,
             min_soc=self._config.get("min_soc", 20.0),
             max_soc=self._config.get("max_soc", 100.0),
             current_hour=current_hour,
         )
 
-        # Update savings vs flat rate
         flat_rate = self._config.get("flat_rate_pence", DEFAULT_FLAT_RATE_PENCE)
         self.cost_accumulator.calculate_savings_vs_flat(flat_rate)
 
-        # Apply programme to inverter via MQTT if enabled.
-        # Any failure is logged but does NOT abort the tick - the coordinator
-        # still returns a valid programme and the next tick will retry
-        # the diff against the un-updated _last_known_programme.
-        try:
-            await self._apply_programme_to_inverter(programme)
-        except Exception:
-            logger.exception("HEO-27: apply_programme failed")
+    def _local_tz(self):
+        """Resolve HA's local timezone, defaulting to UTC."""
+        from zoneinfo import ZoneInfo
+        tz_name = (
+            self.hass.config.time_zone
+            if self.hass and self.hass.config.time_zone
+            else "UTC"
+        )
+        return ZoneInfo(tz_name)
 
-        return programme
+    def _parse_time_config(self, key: str, default: str) -> time:
+        """Parse a "HH:MM" config value into a `time` object."""
+        raw = str(self._config.get(key, default))
+        try:
+            h, m = raw.split(":", 1)
+            return time(int(h), int(m))
+        except (ValueError, TypeError):
+            logger.warning(
+                "HEO-31 PR2: invalid %s=%r in config; falling back to %s",
+                key, raw, default,
+            )
+            h, m = default.split(":", 1)
+            return time(int(h), int(m))
+
+    async def _verify_pending_programme(self) -> None:
+        """SPEC §7 H6: read inverter state back and compare to the
+        programme we wrote on the previous tick.
+
+        On mismatch: log ERROR, set verify_mismatch_reason which drives
+        writes_blocked, and leave `_last_known_programme` un-advanced
+        so the next diff retries the missing fields.
+        """
+        if self._pending_verification is None:
+            return
+        observed = read_inverter_state(
+            self.hass, inverter_name=self._inverter_name,
+        )
+        if observed is None:
+            # SA entities still not populated. Defer verification one
+            # more tick rather than spuriously alerting.
+            logger.info(
+                "HEO-31 PR2 H6: SA entities unavailable; deferring verify",
+            )
+            return
+
+        mismatches = self._diff_programmes(observed, self._pending_verification)
+        if mismatches:
+            self._verify_mismatch_reason = (
+                f"slot {mismatches[0][0]} {mismatches[0][1]} "
+                f"sent={mismatches[0][2]} got={mismatches[0][3]}"
+                + (f" (+{len(mismatches) - 1} more)"
+                   if len(mismatches) > 1 else "")
+            )
+            logger.error(
+                "HEO-31 PR2 H6: post-write verify mismatch: %s",
+                self._verify_mismatch_reason,
+            )
+            # Do NOT advance _last_known_programme - the next tick's
+            # diff against `observed` will spot the missing writes
+            # and retry them.
+            self._last_known_programme = observed
+        else:
+            self._verify_mismatch_reason = None
+            logger.warning(
+                "HEO-31 PR2 H6: post-write verify OK across all 6 slots",
+            )
+
+        self._pending_verification = None
+
+    @staticmethod
+    def _diff_programmes(
+        observed: ProgrammeState, intended: ProgrammeState,
+    ) -> list[tuple[int, str, str, str]]:
+        """Return (slot_num, field, sent_value, observed_value) for
+        every slot field that differs between intended and observed.
+        Used by the post-write verify to surface concrete mismatches.
+        """
+        out: list[tuple[int, str, str, str]] = []
+        for i in range(6):
+            o = observed.slots[i]
+            n = intended.slots[i]
+            if o.start_time != n.start_time:
+                out.append((
+                    i + 1, "time_point",
+                    n.start_time.strftime("%H:%M"),
+                    o.start_time.strftime("%H:%M"),
+                ))
+            if o.capacity_soc != n.capacity_soc:
+                out.append((
+                    i + 1, "capacity",
+                    str(n.capacity_soc), str(o.capacity_soc),
+                ))
+            if o.grid_charge != n.grid_charge:
+                out.append((
+                    i + 1, "grid_charge",
+                    str(n.grid_charge), str(o.grid_charge),
+                ))
+        return out
 
     async def _apply_programme_to_inverter(
         self, new_programme: ProgrammeState,
@@ -278,6 +530,13 @@ class HEO2Coordinator(DataUpdateCoordinator):
                 "HEO-27: %d/%d writes confirmed",
                 result.writes_confirmed, result.writes_attempted,
             )
+            # SPEC §7 H6: queue a post-write verification for the next
+            # tick. We don't sleep-and-verify inline because SA's
+            # poll-then-publish cycle can take 5-10s and we don't want
+            # to extend the coordinator tick. The 15-min spacing
+            # between ticks is more than sufficient for SA to have
+            # caught up and the entities to reflect reality.
+            self._pending_verification = new_programme
         else:
             logger.warning(
                 "HEO-27: write failed at slot %s param %s: %s "
@@ -678,6 +937,8 @@ class HEO2Coordinator(DataUpdateCoordinator):
           - MqttWriter hasn't been constructed yet (early startup)
           - DirectMqttTransport exists but is not connected
           - HEO-14: BottlecapDave returned no live rates (SPEC H4)
+          - HEO-31 PR2: pre-write validator rejected the plan (H5)
+          - HEO-31 PR2: post-write verify saw a mismatch (H6)
         """
         blocked, _ = _compute_writes_blocked(
             dry_run=self._writer_dry_run,
@@ -689,6 +950,8 @@ class HEO2Coordinator(DataUpdateCoordinator):
             ),
             host=self._sa_mqtt_host,
             live_rates_present=self._live_rates_present,
+            plan_rejected_reason=self._plan_rejected_reason,
+            verify_mismatch_reason=self._verify_mismatch_reason,
         )
         return blocked
 
@@ -706,5 +969,20 @@ class HEO2Coordinator(DataUpdateCoordinator):
             ),
             host=self._sa_mqtt_host,
             live_rates_present=self._live_rates_present,
+            plan_rejected_reason=self._plan_rejected_reason,
+            verify_mismatch_reason=self._verify_mismatch_reason,
         )
         return reason
+
+    @property
+    def projection_today(self) -> Projection | None:
+        """Latest 24h forecast of expected return given the effective
+        programme. Populated even when validation rejected the plan,
+        so the dashboard always shows the projected outcome of what
+        the rules just produced.
+        """
+        return self._last_projection
+
+    @property
+    def validation_warnings(self) -> list[str]:
+        return list(self._validation_warnings)

--- a/custom_components/heo2/plan_validator.py
+++ b/custom_components/heo2/plan_validator.py
@@ -1,0 +1,242 @@
+# custom_components/heo2/plan_validator.py
+"""Pre-write plan validation per SPEC §6 / hard rule H5.
+
+Runs after the rule engine has produced a programme but BEFORE the
+coordinator hands it to the MQTT writer. Checks both:
+
+  1. Structural invariants (already enforced by SafetyRule, re-asserted
+     here so a SafetyRule bug can never silently leak a bad plan).
+  2. Sanity rules - the SPEC §6 "do not write a plan that is going to
+     cost money on purpose" guards.
+
+Hard failures cause the coordinator to keep the previous plan and set
+`binary_sensor.heo_ii_writes_blocked` ON with the rejection reason.
+Warnings are logged but do not block writes.
+
+Pure logic, no Home Assistant imports. The projection is computed
+alongside (it informs both the dashboard sensor and the
+peak-rate-import warning).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import time
+
+from .models import ProgrammeInputs, ProgrammeState, RateSlot, SlotConfig
+from .projection import Projection, project_day
+from .rank_pricing import bottom_n_pct, filter_today
+
+
+@dataclass
+class ValidationResult:
+    """Outcome of `validate_plan`. Errors block the write; warnings don't.
+
+    `projection` is always populated (even on validation failure) so the
+    dashboard projection sensor reflects the rejected plan's expected
+    behaviour and the user can see why it was rejected.
+    """
+
+    errors: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+    projection: Projection | None = None
+
+    @property
+    def passed(self) -> bool:
+        return not self.errors
+
+    def reason(self) -> str:
+        """One-line summary suitable for `writes_blocked` reason."""
+        if not self.errors:
+            return ""
+        if len(self.errors) == 1:
+            return f"plan rejected: {self.errors[0]}"
+        return f"plan rejected: {self.errors[0]} (+{len(self.errors) - 1} more)"
+
+
+def _slots_overlapping_rates(
+    programme: ProgrammeState, rate_slots: list[RateSlot],
+) -> list[tuple[int, RateSlot]]:
+    """Return (slot_index, rate_slot) pairs where the programme slot's
+    time window overlaps the rate slot's time window.
+
+    Programme slots are time-of-day; rate slots are absolute datetimes.
+    For overlap detection we project the rate slot onto its local
+    time-of-day. A rate slot crossing midnight is split into two
+    notional half-slots.
+    """
+    pairs: list[tuple[int, RateSlot]] = []
+    for r in rate_slots:
+        # Rate slots from BD/IGO are 30-min wide; the start time is
+        # enough to identify which programme slot it lands in.
+        local_clock = r.start.time()
+        for i, slot in enumerate(programme.slots):
+            if slot.contains_time(local_clock):
+                pairs.append((i, r))
+                break
+    return pairs
+
+
+def _check_no_grid_charge_in_peak(
+    programme: ProgrammeState,
+    import_rates: list[RateSlot],
+    peak_threshold_p: float,
+) -> list[str]:
+    """SPEC §6 sanity check: no `grid_charge=True` slot's time range may
+    overlap a peak-rate import window.
+
+    H1 hard rule: peak imports are NEVER scheduled (forced peak imports
+    that arise from reality are flagged separately as warnings).
+    """
+    errors: list[str] = []
+    peak_rates = [r for r in import_rates if r.rate_pence >= peak_threshold_p]
+    if not peak_rates:
+        return errors
+
+    for slot_idx, rate in _slots_overlapping_rates(programme, peak_rates):
+        slot = programme.slots[slot_idx]
+        if slot.grid_charge:
+            errors.append(
+                f"H1 violation: slot {slot_idx + 1} "
+                f"({slot.start_time.strftime('%H:%M')}-"
+                f"{slot.end_time.strftime('%H:%M')}) has grid_charge=True "
+                f"covering peak rate {rate.rate_pence:.2f}p at "
+                f"{rate.start.strftime('%H:%M')}"
+            )
+            # One error per slot is enough; further peak slots in the
+            # same programme slot would just be noise.
+            break
+    return errors
+
+
+def _check_static(programme: ProgrammeState, min_soc: float) -> list[str]:
+    """Re-assertion of SafetyRule invariants. Should be a no-op in
+    practice; if any of these fire there is a bug in the rule pipeline.
+    """
+    errors: list[str] = []
+    if len(programme.slots) != 6:
+        errors.append(
+            f"structural: expected 6 slots, got {len(programme.slots)}"
+        )
+        return errors  # subsequent checks assume 6 slots
+    if programme.slots[0].start_time != time(0, 0):
+        errors.append(
+            f"structural: slot 1 must start 00:00, got "
+            f"{programme.slots[0].start_time.strftime('%H:%M')}"
+        )
+    if programme.slots[-1].end_time != time(0, 0):
+        errors.append(
+            f"structural: slot 6 must end 00:00, got "
+            f"{programme.slots[-1].end_time.strftime('%H:%M')}"
+        )
+    for i in range(5):
+        if programme.slots[i].end_time != programme.slots[i + 1].start_time:
+            errors.append(
+                f"structural: slot {i + 2} starts "
+                f"{programme.slots[i + 1].start_time.strftime('%H:%M')} but "
+                f"slot {i + 1} ends "
+                f"{programme.slots[i].end_time.strftime('%H:%M')}"
+            )
+            break
+    for i, slot in enumerate(programme.slots):
+        if not (min_soc <= slot.capacity_soc <= 100):
+            errors.append(
+                f"structural: slot {i + 1} SOC {slot.capacity_soc}% "
+                f"outside [{min_soc:.0f}, 100]"
+            )
+            break
+    return errors
+
+
+def _check_cheap_window_covered(
+    programme: ProgrammeState,
+    import_rates: list[RateSlot],
+    inputs: ProgrammeInputs,
+    bottom_n_pct_threshold: int,
+) -> list[str]:
+    """Soft SPEC §6 check: at least one `grid_charge=True` slot should
+    cover the IGO cheap window.
+
+    Returns warnings (not errors) - the user may legitimately skip
+    cheap-rate charging on a sunny summer day where the battery will
+    refill from PV. The rule engine's CheapRateCharge rule already
+    handles that decision; this guard catches accidental misconfigs
+    that would silently leave the cheap window uncovered.
+    """
+    today_import = filter_today(import_rates, inputs.now)
+    cheap = bottom_n_pct(today_import, bottom_n_pct_threshold)
+    if not cheap:
+        return []
+
+    pairs = _slots_overlapping_rates(programme, cheap)
+    covered = any(programme.slots[i].grid_charge for i, _ in pairs)
+    if covered:
+        return []
+
+    cheap_start = min(c.start.strftime("%H:%M") for c in cheap)
+    cheap_end = max(c.end.strftime("%H:%M") for c in cheap)
+    return [
+        f"no grid_charge=True slot covers the cheap window "
+        f"({cheap_start}-{cheap_end}, "
+        f"{len(cheap)} slots @ avg "
+        f"{sum(c.rate_pence for c in cheap) / len(cheap):.2f}p)"
+    ]
+
+
+def validate_plan(
+    programme: ProgrammeState,
+    inputs: ProgrammeInputs,
+    *,
+    peak_threshold_p: float = 24.0,
+    cheap_bottom_pct: int = 25,
+    max_charge_kw: float = 5.0,
+    max_discharge_kw: float = 5.0,
+    charge_efficiency: float = 0.95,
+    discharge_efficiency: float = 0.95,
+) -> ValidationResult:
+    """Run all SPEC §6 pre-write checks and a 24-hour projection.
+
+    `errors` block the write (coordinator keeps the previous plan).
+    `warnings` are logged but allow the write to proceed.
+    `projection` is populated regardless so the dashboard can show
+    the expected return for both accepted and rejected plans.
+    """
+    errors: list[str] = []
+    warnings: list[str] = []
+
+    errors.extend(_check_static(programme, min_soc=inputs.min_soc))
+
+    if not errors:
+        errors.extend(_check_no_grid_charge_in_peak(
+            programme, inputs.import_rates, peak_threshold_p,
+        ))
+
+    warnings.extend(_check_cheap_window_covered(
+        programme, inputs.import_rates, inputs, cheap_bottom_pct,
+    ))
+
+    projection = project_day(
+        programme,
+        inputs,
+        battery_capacity_kwh=inputs.battery_capacity_kwh,
+        max_charge_kw=max_charge_kw,
+        max_discharge_kw=max_discharge_kw,
+        charge_efficiency=charge_efficiency,
+        discharge_efficiency=discharge_efficiency,
+        peak_threshold_p=peak_threshold_p,
+    )
+
+    if projection.peak_import_kwh > 0.001:
+        # H1 says reality wins for forced peak imports - it's a warning
+        # surfaced on the dashboard, not a reject. The plan-time GC=True
+        # check above catches the deliberate version of this mistake.
+        warnings.append(
+            f"projection forecasts {projection.peak_import_kwh:.2f} kWh "
+            f"of peak-rate import (cost "
+            f"{projection.peak_import_pence / 100.0:.2f}); "
+            f"likely battery floor reached during peak hours"
+        )
+
+    return ValidationResult(
+        errors=errors, warnings=warnings, projection=projection,
+    )

--- a/custom_components/heo2/projection.py
+++ b/custom_components/heo2/projection.py
@@ -1,0 +1,267 @@
+# custom_components/heo2/projection.py
+"""Day-ahead financial projection of a programme. No Home Assistant imports.
+
+Forward-simulates SOC and money flow over the next 24 hours given the
+6-slot programme and the inputs HEO II already has (rates, solar/load
+forecasts). Produces a one-line summary in the form required by SPEC §6:
+
+    Expected return today: +£X.YZ - sells N kWh @ avg Mp,
+    grid imports P kWh @ avg Qp, ZERO peak-rate import
+
+The simulation operates at 30-minute resolution (matching Octopus Agile
+slot granularity) and uses the active programme slot at each step to
+decide:
+
+  * `grid_charge=True`: import at the slot's import rate to push SOC
+    toward `capacity_soc`, capped by `max_charge_kw`.
+  * `grid_charge=False` and SOC > `capacity_soc` and slot rate is in the
+    top-N% export window: discharge to the grid, capped by
+    `max_discharge_kw`.
+  * Otherwise: cover load from solar + battery, importing only when the
+    battery hits `min_soc`. Import that hits a peak-rate slot is logged
+    as `peak_import_kwh` so SPEC H1 violations are visible even though
+    H1 itself permits "reality wins" (a reject would be inappropriate).
+
+Pure data; the validator and dashboard sensor consume it.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, time
+
+from .models import ProgrammeInputs, ProgrammeState, RateSlot, SlotConfig
+
+
+_SLOT_MINUTES = 30
+_SLOT_HOURS = _SLOT_MINUTES / 60.0
+
+
+@dataclass
+class Projection:
+    """Forward-simulated financial outcome of a programme over 24h."""
+
+    expected_return_pence: float = 0.0
+    sells_kwh: float = 0.0
+    sells_pence: float = 0.0
+    imports_kwh: float = 0.0
+    imports_pence: float = 0.0
+    peak_import_kwh: float = 0.0
+    peak_import_pence: float = 0.0
+
+    @property
+    def sells_avg_pence(self) -> float | None:
+        if self.sells_kwh <= 0:
+            return None
+        return self.sells_pence / self.sells_kwh
+
+    @property
+    def imports_avg_pence(self) -> float | None:
+        if self.imports_kwh <= 0:
+            return None
+        return self.imports_pence / self.imports_kwh
+
+    def summary(self) -> str:
+        """One-line projection per SPEC §6.
+
+        Format:
+            Expected return today: +£X.YZ - sells N kWh @ avg Mp,
+            grid imports P kWh @ avg Qp, ZERO peak-rate import
+
+        The `+£X.YZ` carries a sign so a net-cost day reads `-£0.45`.
+        Average prices are omitted when the corresponding kWh is zero.
+        """
+        sign = "+" if self.expected_return_pence >= 0 else "-"
+        pounds = abs(self.expected_return_pence) / 100.0
+
+        sells_avg = self.sells_avg_pence
+        imp_avg = self.imports_avg_pence
+        sells_part = (
+            f"sells {self.sells_kwh:.1f} kWh @ avg {sells_avg:.1f}p"
+            if sells_avg is not None
+            else f"sells 0 kWh"
+        )
+        imp_part = (
+            f"grid imports {self.imports_kwh:.1f} kWh @ avg {imp_avg:.1f}p"
+            if imp_avg is not None
+            else f"grid imports 0 kWh"
+        )
+        peak_part = (
+            "ZERO peak-rate import"
+            if self.peak_import_kwh <= 0.001
+            else f"{self.peak_import_kwh:.2f} kWh peak-rate import"
+        )
+        return (
+            f"Expected return today: {sign}£{pounds:.2f} - "
+            f"{sells_part}, {imp_part}, {peak_part}"
+        )
+
+
+def _slot_at(slots: list[SlotConfig], local_clock: time) -> SlotConfig:
+    """Return the programme slot whose time window contains `local_clock`."""
+    for slot in slots:
+        if slot.contains_time(local_clock):
+            return slot
+    # Fallback: shouldn't happen for a contiguous 6-slot programme that
+    # covers 00:00-00:00, but pick the first slot defensively.
+    return slots[0]
+
+
+def _rate_at(rates: list[RateSlot], at: datetime) -> RateSlot | None:
+    for r in rates:
+        if r.start <= at < r.end:
+            return r
+    return None
+
+
+def _top_export_window_starts(
+    today_export_rates: list[RateSlot], top_n_pct: int,
+) -> set[datetime]:
+    """Precompute the set of `start` datetimes for the top-N% export
+    rate slots.
+
+    Tie handling: a ranked slice keeps the first N after sorting by
+    rate desc - so two 25p slots in a sea of 5p both qualify, but a
+    sea of 5p with `top_n_pct=10` does NOT then qualify any extra
+    5p slots beyond the cut. This matches `rank_pricing.top_n_pct`.
+    """
+    if not today_export_rates or top_n_pct <= 0:
+        return set()
+    import math
+    count = max(1, math.ceil(len(today_export_rates) * top_n_pct / 100))
+    ordered = sorted(
+        today_export_rates, key=lambda r: r.rate_pence, reverse=True,
+    )
+    return {r.start for r in ordered[:count]}
+
+
+def project_day(
+    programme: ProgrammeState,
+    inputs: ProgrammeInputs,
+    *,
+    battery_capacity_kwh: float,
+    max_charge_kw: float = 5.0,
+    max_discharge_kw: float = 5.0,
+    charge_efficiency: float = 0.95,
+    discharge_efficiency: float = 0.95,
+    peak_threshold_p: float = 24.0,
+    export_top_pct: int = 30,
+    replacement_cost_p: float = 4.95,
+    horizon_hours: int = 24,
+) -> Projection:
+    """Forward-simulate the next `horizon_hours` and return a Projection.
+
+    Uses 30-min steps. Each step:
+      1. Resolve the programme slot active at the step's start time.
+      2. Look up import + export rates at that step.
+      3. If `grid_charge=True`: charge from the grid toward `capacity_soc`
+         (clamped by `max_charge_kw * step_hours`).
+      4. Else if export rate is in the top-N% of today's export rates and
+         SOC > capacity_soc: sell up to `max_discharge_kw * step_hours`
+         from battery, no battery use beyond `min_soc`.
+      5. Else: cover (load - solar) from battery; if battery hits
+         `min_soc`, import from grid for the shortfall.
+
+    Returns financial metrics plus peak_import_kwh (any forced import
+    that landed on a slot with rate >= peak_threshold_p).
+    """
+    soc = inputs.current_soc
+    min_soc = inputs.min_soc
+    p = Projection()
+
+    today_export_rates = inputs.export_rates  # already filtered to "now+24h"
+    top_export_starts = _top_export_window_starts(
+        today_export_rates, export_top_pct,
+    )
+
+    now = inputs.now
+    step_count = int(horizon_hours * 60 / _SLOT_MINUTES)
+
+    for step in range(step_count):
+        step_start = now + timedelta(minutes=_SLOT_MINUTES * step)
+        step_end = step_start + timedelta(minutes=_SLOT_MINUTES)
+
+        local_clock = step_start.time()
+        slot = _slot_at(programme.slots, local_clock)
+
+        # Import / export rates at this 30-min step. Either may be missing
+        # past BD's horizon; treat None as zero contribution to revenue
+        # (we still simulate behaviour, just don't book money).
+        imp = _rate_at(inputs.import_rates, step_start)
+        exp = _rate_at(inputs.export_rates, step_start)
+        imp_p = imp.rate_pence if imp is not None else 0.0
+        exp_p = exp.rate_pence if exp is not None else 0.0
+
+        # Solar / load at this step. Forecasts are hourly; pro-rate to 30 min.
+        hour_idx = step_start.hour
+        solar_kwh = inputs.solar_forecast_kwh[hour_idx] * _SLOT_HOURS
+        load_kwh = inputs.load_forecast_kwh[hour_idx] * _SLOT_HOURS
+
+        net_solar = solar_kwh - load_kwh
+
+        if slot.grid_charge:
+            # Charge from grid + use solar surplus toward capacity_soc.
+            target_kwh = (slot.capacity_soc - soc) / 100.0 * battery_capacity_kwh
+            grid_kwh = max(
+                0.0, min(target_kwh, max_charge_kw * _SLOT_HOURS),
+            )
+            soc += (grid_kwh * charge_efficiency) / battery_capacity_kwh * 100.0
+
+            p.imports_kwh += grid_kwh
+            p.imports_pence += grid_kwh * imp_p
+            if imp_p >= peak_threshold_p:
+                p.peak_import_kwh += grid_kwh
+                p.peak_import_pence += grid_kwh * imp_p
+
+            # Solar surplus also charges battery (free) up to 100%
+            if net_solar > 0:
+                soc += min(
+                    net_solar * charge_efficiency, max_charge_kw * _SLOT_HOURS,
+                ) / battery_capacity_kwh * 100.0
+
+        else:
+            # Sell only when the slot is in the top-N% AND the rate
+            # actually pays back the replacement cost (matches the rule
+            # engine's `is_worth_selling`). Without this floor, top-N%
+            # in a flat-rate day would erroneously sell at a loss.
+            in_top_export = (
+                exp is not None
+                and exp.start in top_export_starts
+                and exp_p * charge_efficiency * discharge_efficiency
+                > replacement_cost_p
+            )
+            headroom_kwh = (soc - max(min_soc, slot.capacity_soc)) / 100.0 * battery_capacity_kwh
+
+            if in_top_export and headroom_kwh > 0:
+                # Sell battery into top-N% export window.
+                sell_kwh = min(headroom_kwh, max_discharge_kw * _SLOT_HOURS)
+                soc -= (sell_kwh / discharge_efficiency) / battery_capacity_kwh * 100.0
+                p.sells_kwh += sell_kwh
+                p.sells_pence += sell_kwh * exp_p
+            else:
+                # Hold/cover-load mode. Solar covers load first; any
+                # shortfall comes from battery; if battery at min_soc,
+                # import from grid.
+                if net_solar >= 0:
+                    # Surplus solar charges battery
+                    soc += min(
+                        net_solar * charge_efficiency,
+                        max_charge_kw * _SLOT_HOURS,
+                    ) / battery_capacity_kwh * 100.0
+                else:
+                    deficit_kwh = -net_solar
+                    available_kwh = (soc - min_soc) / 100.0 * battery_capacity_kwh
+                    from_battery = min(deficit_kwh, available_kwh)
+                    from_grid = deficit_kwh - from_battery
+                    soc -= (from_battery / discharge_efficiency) / battery_capacity_kwh * 100.0
+                    if from_grid > 0:
+                        p.imports_kwh += from_grid
+                        p.imports_pence += from_grid * imp_p
+                        if imp_p >= peak_threshold_p:
+                            p.peak_import_kwh += from_grid
+                            p.peak_import_pence += from_grid * imp_p
+
+        soc = max(min_soc, min(100.0, soc))
+
+    p.expected_return_pence = p.sells_pence - p.imports_pence
+    return p

--- a/custom_components/heo2/replan_triggers.py
+++ b/custom_components/heo2/replan_triggers.py
@@ -1,0 +1,228 @@
+# custom_components/heo2/replan_triggers.py
+"""Decide whether a 15-min coordinator tick should commit a fresh
+programme to the inverter or re-use the most recent baseline plan.
+
+SPEC §8 separates two cadences:
+
+  * **Daily plan (18:00 local)**: full re-evaluation. Tomorrow's Octopus
+    rates have been published since 16:00 (2-hour safety margin); we
+    compute a new programme and write it.
+  * **15-min ticks** between daily plans: the rules still run for
+    sensors and the dashboard, but the programme that lands on the
+    inverter is the most recent baseline UNLESS one of the trigger
+    conditions has fired:
+
+      - Solar forecast deviation > replan_solar_pct from the rest-of-day
+        forecast captured at last plan time
+      - Load forecast deviation > replan_load_pct
+      - SOC deviation > replan_soc_pct from the projected trajectory
+      - New IGO dispatch announced (igo_dispatching transitioned False -> True)
+      - Saving session announced (saving_session transitioned False -> True)
+      - Grid restored after a previous loss (grid_connected False -> True)
+
+This module is pure logic. The coordinator owns the baseline state and
+calls `should_commit_replan()` each tick to decide whether to accept
+the new programme as a baseline replacement.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import date, datetime, time
+from zoneinfo import ZoneInfo
+
+from .models import ProgrammeInputs, ProgrammeState
+
+
+@dataclass
+class BaselineSnapshot:
+    """Captured state at the moment a baseline programme was committed.
+
+    Used to detect deviation triggers on subsequent ticks. The snapshot
+    fields are the inputs that drove the original plan; comparing
+    "what the world looked like then" vs "what it looks like now"
+    surfaces the SPEC §8 trigger conditions.
+    """
+
+    programme: ProgrammeState
+    captured_at: datetime
+    rest_of_day_solar_kwh: float
+    rest_of_day_load_kwh: float
+    soc_at_capture: float
+    igo_dispatching: bool
+    saving_session: bool
+    grid_connected: bool
+    daily_plan_date: date | None = None  # local date for which this is the 18:00 plan
+
+
+@dataclass
+class ReplanDecision:
+    """Result of `should_commit_replan`: whether to commit the new
+    programme as the baseline, and the trigger reason for logging."""
+
+    commit: bool
+    reason: str
+
+
+def _rest_of_day_kwh(forecast_24: list[float], current_hour_local: int) -> float:
+    """Sum the forecast kWh from the current local hour to end-of-day."""
+    if not forecast_24:
+        return 0.0
+    return float(sum(forecast_24[current_hour_local:24]))
+
+
+def _local_now(now_utc: datetime, tz: ZoneInfo | None) -> datetime:
+    if tz is None:
+        return now_utc
+    return now_utc.astimezone(tz)
+
+
+def _percent_change(current: float, baseline: float) -> float:
+    """Symmetric percent change. Zero baseline maps to:
+      - 0% if current is also zero
+      - 100% otherwise
+    Avoids divide-by-zero spam from quiet overnight hours.
+    """
+    if baseline <= 0:
+        return 0.0 if current <= 0 else 100.0
+    return abs(current - baseline) / baseline * 100.0
+
+
+def _is_daily_plan_window(
+    now_local: datetime,
+    daily_plan_time: time,
+    last_plan_date: date | None,
+    window_minutes: int = 30,
+) -> bool:
+    """True if `now_local` is within the daily-plan window AND we have
+    not yet committed a daily plan today.
+
+    The window is `[daily_plan_time, daily_plan_time + window_minutes)`
+    so a missed tick (e.g. HA restart at 18:02) still triggers the
+    daily plan when we recover. After 18:30 a missed window means we
+    wait until tomorrow.
+    """
+    today = now_local.date()
+    if last_plan_date == today:
+        return False
+    h, m = daily_plan_time.hour, daily_plan_time.minute
+    plan_dt = now_local.replace(hour=h, minute=m, second=0, microsecond=0)
+    window_end = plan_dt.replace(minute=m + window_minutes) if m + window_minutes < 60 else \
+        plan_dt.replace(hour=h + 1, minute=(m + window_minutes) % 60)
+    return plan_dt <= now_local < window_end
+
+
+def should_commit_replan(
+    *,
+    new_programme: ProgrammeState,
+    inputs: ProgrammeInputs,
+    baseline: BaselineSnapshot | None,
+    tz: ZoneInfo | None,
+    daily_plan_time: time,
+    replan_solar_pct: float,
+    replan_load_pct: float,
+    replan_soc_pct: float,
+) -> ReplanDecision:
+    """Decide if the new programme should replace the current baseline.
+
+    Trigger order (first match wins, for cleaner logs):
+      1. No baseline yet -> commit (first ever tick)
+      2. Daily-plan window AND not already planned today -> commit
+      3. Trigger condition fired -> commit
+      4. Otherwise -> hold the existing baseline
+    """
+    if baseline is None:
+        return ReplanDecision(True, "first plan: no prior baseline")
+
+    now_local = _local_now(inputs.now, tz)
+    if _is_daily_plan_window(
+        now_local, daily_plan_time, baseline.daily_plan_date,
+    ):
+        return ReplanDecision(
+            True,
+            f"daily plan window ({daily_plan_time.strftime('%H:%M')}): "
+            f"committing fresh programme for "
+            f"{now_local.date().isoformat()}",
+        )
+
+    # IGO dispatch - announced only at the boundary, so transition matters.
+    if inputs.igo_dispatching and not baseline.igo_dispatching:
+        return ReplanDecision(True, "trigger: new IGO dispatch announced")
+
+    # Saving session - same as IGO, transition-driven.
+    if inputs.saving_session and not baseline.saving_session:
+        return ReplanDecision(True, "trigger: saving session announced")
+
+    # Grid loss/restore: an EPS event will have set grid_connected=False
+    # somewhere; restoring it should re-plan against fresh state.
+    if inputs.grid_connected and not baseline.grid_connected:
+        return ReplanDecision(True, "trigger: grid restored")
+
+    # Quantitative deviations - take the local-hour rest-of-day slice
+    # of the same forecasts captured in the baseline.
+    current_hour_local = now_local.hour
+    new_solar = _rest_of_day_kwh(inputs.solar_forecast_kwh, current_hour_local)
+    new_load = _rest_of_day_kwh(inputs.load_forecast_kwh, current_hour_local)
+
+    solar_dev = _percent_change(new_solar, baseline.rest_of_day_solar_kwh)
+    if solar_dev > replan_solar_pct:
+        return ReplanDecision(
+            True,
+            f"trigger: solar forecast deviation {solar_dev:.0f}% "
+            f"({baseline.rest_of_day_solar_kwh:.1f} -> {new_solar:.1f} kWh)"
+        )
+
+    load_dev = _percent_change(new_load, baseline.rest_of_day_load_kwh)
+    if load_dev > replan_load_pct:
+        return ReplanDecision(
+            True,
+            f"trigger: load forecast deviation {load_dev:.0f}% "
+            f"({baseline.rest_of_day_load_kwh:.1f} -> {new_load:.1f} kWh)"
+        )
+
+    soc_dev = abs(inputs.current_soc - baseline.soc_at_capture)
+    if soc_dev > replan_soc_pct:
+        return ReplanDecision(
+            True,
+            f"trigger: SOC deviation {soc_dev:.0f}% "
+            f"({baseline.soc_at_capture:.0f} -> {inputs.current_soc:.0f}%)"
+        )
+
+    return ReplanDecision(
+        False,
+        f"hold baseline ({baseline.captured_at.strftime('%H:%M')}; "
+        f"solar dev {solar_dev:.0f}% < {replan_solar_pct:.0f}%, "
+        f"load dev {load_dev:.0f}% < {replan_load_pct:.0f}%, "
+        f"SOC dev {soc_dev:.1f}% < {replan_soc_pct:.0f}%)"
+    )
+
+
+def capture_baseline(
+    programme: ProgrammeState,
+    inputs: ProgrammeInputs,
+    *,
+    tz: ZoneInfo | None,
+    is_daily_plan: bool,
+) -> BaselineSnapshot:
+    """Build a BaselineSnapshot from the inputs that drove `programme`.
+
+    `is_daily_plan` marks this baseline as the canonical 18:00 plan for
+    its local date; further ticks on the same date won't fire a second
+    daily-plan commit.
+    """
+    now_local = _local_now(inputs.now, tz)
+    return BaselineSnapshot(
+        programme=programme,
+        captured_at=inputs.now,
+        rest_of_day_solar_kwh=_rest_of_day_kwh(
+            inputs.solar_forecast_kwh, now_local.hour,
+        ),
+        rest_of_day_load_kwh=_rest_of_day_kwh(
+            inputs.load_forecast_kwh, now_local.hour,
+        ),
+        soc_at_capture=inputs.current_soc,
+        igo_dispatching=inputs.igo_dispatching,
+        saving_session=inputs.saving_session,
+        grid_connected=inputs.grid_connected,
+        daily_plan_date=now_local.date() if is_daily_plan else None,
+    )

--- a/custom_components/heo2/rules/safety.py
+++ b/custom_components/heo2/rules/safety.py
@@ -9,6 +9,25 @@ from ..models import ProgrammeState, ProgrammeInputs, SlotConfig
 from ..rule_engine import Rule
 
 
+# Sunsynk inverter timer fields have 5-minute granularity. Sending a
+# value like 23:57 returns "Saved" from SA but the inverter floors to
+# 23:55, then SA's polling reflects 23:55 in the entity. If HEO II
+# leaves un-snapped values in the plan, the PR 2 post-write verify
+# (SPEC §7 H6) would latch a permanent mismatch reason because the
+# plan and the read-back never agree. Snap proactively in the rule
+# engine so what's written is what comes back. Verified manually on
+# 2026-05-02: 23:57/23:58/23:56/23:51 all floor to the prior :X0/:X5.
+_TIME_GRANULARITY_MINUTES = 5
+
+
+def _snap_to_granularity(t: time) -> time:
+    """Floor a `time` to the nearest 5-min boundary (Sunsynk timer
+    granularity). Same direction as the hardware itself uses.
+    """
+    snapped_minute = (t.minute // _TIME_GRANULARITY_MINUTES) * _TIME_GRANULARITY_MINUTES
+    return time(t.hour, snapped_minute)
+
+
 class SafetyRule(Rule):
     """Final validation pass over the programme.
 
@@ -18,6 +37,7 @@ class SafetyRule(Rule):
     - Exactly 6 slots
     - Full 24h coverage (00:00–00:00)
     - Contiguous time boundaries
+    - Sunsynk 5-minute time granularity (floor each boundary)
 
     Cannot be disabled.
     """
@@ -51,6 +71,23 @@ class SafetyRule(Rule):
                 fixes.append(f"Slot {i + 1}: capped SOC {slot.capacity_soc}→100%")
                 slot.capacity_soc = 100
 
+        # Snap every boundary to Sunsynk's 5-min granularity. Doing this
+        # before the contiguous fix-up below means any boundary the rule
+        # engine produced like 23:57 collapses to 23:55, both for that
+        # slot's start and the previous slot's end.
+        for i, slot in enumerate(state.slots):
+            snapped_start = _snap_to_granularity(slot.start_time)
+            if snapped_start != slot.start_time:
+                fixes.append(
+                    f"Slot {i + 1}: snapped start "
+                    f"{slot.start_time.strftime('%H:%M')}→"
+                    f"{snapped_start.strftime('%H:%M')} (5-min granularity)"
+                )
+                slot.start_time = snapped_start
+            snapped_end = _snap_to_granularity(slot.end_time)
+            if snapped_end != slot.end_time:
+                slot.end_time = snapped_end
+
         # Ensure slot 1 starts at 00:00
         if state.slots[0].start_time != time(0, 0):
             fixes.append(f"Slot 1: fixed start to 00:00")
@@ -61,7 +98,8 @@ class SafetyRule(Rule):
             fixes.append(f"Slot 6: fixed end to 00:00")
             state.slots[-1].end_time = time(0, 0)
 
-        # Ensure contiguous
+        # Ensure contiguous (after snapping, otherwise a snap on slot N's
+        # start could leave a gap between slots N-1 and N).
         for i in range(len(state.slots) - 1):
             if state.slots[i].end_time != state.slots[i + 1].start_time:
                 fixes.append(

--- a/custom_components/heo2/sensor.py
+++ b/custom_components/heo2/sensor.py
@@ -43,6 +43,7 @@ async def async_setup_entry(
     entities.append(ProgrammeSlotsSensor(coordinator, entry))
     entities.append(ProgrammeReasonSensor(coordinator, entry))
     entities.append(ActiveRulesSensor(coordinator, entry))
+    entities.append(ProjectionTodaySensor(coordinator, entry))
 
     # Dashboard sensors (Group 2: Cost Accumulator)
     entities.append(DailyImportCostSensor(coordinator, entry))
@@ -450,6 +451,44 @@ class ActiveRulesSensor(CoordinatorEntity, SensorEntity):
     @property
     def extra_state_attributes(self) -> dict:
         return {"rules": self.coordinator.active_rule_names}
+
+
+class ProjectionTodaySensor(CoordinatorEntity, SensorEntity):
+    """SPEC §6 projection report: 1-line summary of expected daily return
+    plus structured kWh / pence breakdown for the dashboard."""
+
+    def __init__(self, coordinator: HEO2Coordinator, entry: ConfigEntry):
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{entry.entry_id}_projection_today"
+        self._attr_name = "HEO II Projection Today"
+
+    @property
+    def native_value(self) -> str | None:
+        p = self.coordinator.projection_today
+        if p is None:
+            return None
+        return p.summary()
+
+    @property
+    def extra_state_attributes(self) -> dict:
+        p = self.coordinator.projection_today
+        if p is None:
+            return {"warnings": self.coordinator.validation_warnings}
+        return {
+            "expected_return_pence": round(p.expected_return_pence, 2),
+            "sells_kwh": round(p.sells_kwh, 2),
+            "sells_avg_pence": (
+                round(p.sells_avg_pence, 2)
+                if p.sells_avg_pence is not None else None
+            ),
+            "imports_kwh": round(p.imports_kwh, 2),
+            "imports_avg_pence": (
+                round(p.imports_avg_pence, 2)
+                if p.imports_avg_pence is not None else None
+            ),
+            "peak_import_kwh": round(p.peak_import_kwh, 2),
+            "warnings": self.coordinator.validation_warnings,
+        }
 
 
 # ---------------------------------------------------------------------------

--- a/custom_components/heo2/writes_status.py
+++ b/custom_components/heo2/writes_status.py
@@ -18,6 +18,8 @@ def _compute_writes_blocked(
     transport_connected: bool,
     host: str,
     live_rates_present: bool = True,
+    plan_rejected_reason: str | None = None,
+    verify_mismatch_reason: str | None = None,
 ) -> tuple[bool, str]:
     """Determine if writes are currently blocked and why.
 
@@ -31,10 +33,14 @@ def _compute_writes_blocked(
          misleading.
       2. Transport readiness comes next so early-startup state is
          described accurately.
-      3. SPEC H4 (live-prices-only writes) is checked last: by this
-         point the transport is up, so the only remaining reason to
-         block is missing live BottlecapDave rates. The default True
-         keeps backward compatibility for callers that pre-date HEO-14.
+      3. SPEC H4 (live-prices-only writes) is checked before plan-level
+         issues: if rates aren't live the plan content is moot.
+      4. Plan rejection from the H5 pre-write validator.
+      5. Post-write verification mismatch from H6.
+
+    Plan rejection / verify mismatch reasons are passed in by the
+    coordinator; they default to None so existing callers stay
+    backward-compatible.
     """
     if dry_run:
         return True, "dry_run enabled"
@@ -44,4 +50,8 @@ def _compute_writes_blocked(
         return True, f"MQTT transport disconnected from {host}"
     if not live_rates_present:
         return True, "HEO-14: no live BottlecapDave rates (SPEC H4)"
+    if plan_rejected_reason:
+        return True, f"H5: {plan_rejected_reason}"
+    if verify_mismatch_reason:
+        return True, f"H6: {verify_mismatch_reason}"
     return False, ""

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -4,7 +4,7 @@
 > writes. Update this document FIRST when changing intent. Code follows spec,
 > not the other way round.
 >
-> Tracking issue: #31. Last updated: 2026-04-29.
+> Tracking issue: #31. Last updated: 2026-05-02 (HEO-31 PR2: planning lifecycle + safety).
 
 ## 1. Hardware and tariff context
 
@@ -138,41 +138,65 @@ without code changes.
 
 ## 6. Pre-write validation (H5 detail)
 
-Before any write reaches the inverter, the plan must pass:
+Implemented in `custom_components/heo2/plan_validator.py`. Runs after
+the rule engine has produced a programme and BEFORE the coordinator
+hands it to the MQTT writer.
 
-### Static checks (existing in SafetyRule)
+### Static checks (re-asserted; SafetyRule fixes them in-place)
 - Exactly 6 slots
 - Slot 1 starts 00:00, slot 6 ends 00:00
 - Contiguous time boundaries
 - All SOCs in [min_soc, 100]
 
-### Sanity checks (NEW)
-- No `grid_charge=true` slot covering peak-rate window (H1)
-- No SOC < expected_load_during_slot for slots without grid_charge that occur in peak window (would force unplanned peak grid use)
-- At least one `grid_charge=true` slot covering the IGO cheap window (otherwise we miss it entirely)
+### Sanity checks (hard - reject the plan)
+- **H1**: No `grid_charge=true` slot's time window may overlap any
+  import rate slot at >= `peak_threshold_p` (24.0p default).
 
-### Projection report (NEW)
-A 1-line summary written to a sensor BEFORE write so the projection is
-visible:
+### Sanity checks (soft - log warning, allow write)
+- No `grid_charge=true` slot covers the bottom-25% cheap window
+  (the rule engine's CheapRateCharge rule is normally responsible
+  for this; missing coverage is sometimes legitimate in summer).
+- Projection forecasts > 0 kWh peak-rate import (battery hits floor
+  during peak hours). H1 says reality wins for forced peak imports;
+  the warning is informational so the user can investigate.
+
+### Projection report
+A 1-line summary written to `sensor.heo_ii_projection_today` every
+tick (whether the plan was accepted or rejected) so the projected
+outcome is always visible:
 
 > Expected return today: +£X.YZ - sells N kWh @ avg Mp, grid imports P kWh @ avg Qp, ZERO peak-rate import
 
-If projection breaches a hard rule, plan is rejected and previous plan kept.
-Logged at WARNING. Sensor `binary_sensor.heo_ii_writes_blocked` goes ON
-with reason explaining the rejection.
+When validation fails, the plan is rejected and the previous baseline
+stays on the inverter. Logged at WARNING. Sensor
+`binary_sensor.heo_ii_writes_blocked` goes ON with reason `H5: <error>`.
 
 ## 7. Post-write verification (H6 detail)
 
-After all per-slot writes complete:
+Implemented in the coordinator. The check is **deferred to the next
+tick** rather than running inline at the end of the writing tick:
 
-1. Read back full 6-slot programme from `sensor.sa_inverter_1_*` entities
-2. Compare each slot field to what was sent
-3. If any field doesn't match: log ERROR, set `binary_sensor.heo_ii_writes_blocked` ON with reason "post-write verify mismatch", DO NOT advance `_last_known_programme`
-4. Next tick will re-diff and retry
+1. After a successful per-slot write batch, the new programme is
+   stored in `_pending_verification`.
+2. The next 15-min tick begins by reading back the 6-slot programme
+   from `sensor.sa_inverter_1_*` entities and diffing each field
+   against `_pending_verification`.
+3. If any field mismatches: log ERROR, set
+   `binary_sensor.heo_ii_writes_blocked` ON with reason
+   `H6: slot N <field> sent=A got=B`, and reset
+   `_last_known_programme` to the observed state so the next diff
+   targets the correct delta.
+4. If all match: clear the pending state silently.
 
-This is on top of the per-write "Saved" readback that MqttWriter already
-does (HEO-2). Per-write confirms SA accepted the publish; post-write
-programme verify confirms the inverter's actual state matches.
+Why next-tick rather than inline? SA's MQTT polling cadence updates
+the discovered HA entities every few seconds. An inline read would
+race with that cadence; the 15-min tick spacing gives plenty of
+margin without padding the current tick with an artificial sleep.
+
+This is on top of the per-write "Saved" readback that MqttWriter
+already does (HEO-2). Per-write confirms SA accepted the publish;
+post-write programme verify confirms the inverter's actual state
+matches what we sent.
 
 ## 8. Planning cadence
 

--- a/tests/test_plan_validator.py
+++ b/tests/test_plan_validator.py
@@ -1,0 +1,189 @@
+# tests/test_plan_validator.py
+"""Tests for the SPEC §6 / H5 pre-write plan validator."""
+
+from __future__ import annotations
+
+from datetime import datetime, time, timedelta, timezone
+
+import pytest
+
+from heo2.models import ProgrammeInputs, ProgrammeState, RateSlot, SlotConfig
+from heo2.plan_validator import ValidationResult, validate_plan
+
+
+def _slot(start_h, start_m, end_h, end_m, soc, gc):
+    return SlotConfig(
+        start_time=time(start_h, start_m),
+        end_time=time(end_h, end_m),
+        capacity_soc=soc,
+        grid_charge=gc,
+    )
+
+
+def _good_programme(min_soc=10):
+    """Spec-shaped 6-slot programme: cheap-charge overnight, hold day,
+    drain in evening export window."""
+    return ProgrammeState(slots=[
+        _slot(0, 0, 5, 30, 80, True),   # IGO cheap window: charge to 80
+        _slot(5, 30, 16, 0, 80, False), # day: hold
+        _slot(16, 0, 19, 0, min_soc, False),  # evening drain window
+        _slot(19, 0, 23, 30, min_soc, False),
+        _slot(23, 30, 23, 59, 80, True),
+        _slot(23, 59, 0, 0, 80, True),
+    ])
+
+
+def _half_hour_rates(start, hours, rate_pence):
+    out = []
+    for i in range(hours * 2):
+        out.append(RateSlot(
+            start=start + timedelta(minutes=30 * i),
+            end=start + timedelta(minutes=30 * (i + 1)),
+            rate_pence=rate_pence,
+        ))
+    return out
+
+
+def _igo_import_rates_today(midnight: datetime) -> list[RateSlot]:
+    """Standard IGO shape: ~5p 23:30-05:30, ~25p the rest of the day."""
+    out = []
+    for i in range(48):
+        start = midnight + timedelta(minutes=30 * i)
+        end = start + timedelta(minutes=30)
+        h = start.hour
+        rate = 4.95 if h < 5 or (h == 5 and start.minute < 30) or h >= 23 \
+            else 24.84
+        if h == 23 and start.minute < 30:
+            rate = 24.84
+        out.append(RateSlot(start=start, end=end, rate_pence=rate))
+    return out
+
+
+def _inputs(
+    *, programme=None, current_soc=50.0, igo=True, midnight=None,
+    export_rates=None,
+):
+    midnight = midnight or datetime(2026, 5, 1, 0, 0, tzinfo=timezone.utc)
+    return ProgrammeInputs(
+        now=midnight,
+        current_soc=current_soc,
+        battery_capacity_kwh=20.0,
+        min_soc=10.0,
+        import_rates=_igo_import_rates_today(midnight) if igo else [],
+        export_rates=export_rates or _half_hour_rates(midnight, 24, 8.0),
+        solar_forecast_kwh=[0.0] * 24,
+        load_forecast_kwh=[1.0] * 24,
+        igo_dispatching=False,
+        saving_session=False,
+        saving_session_start=None,
+        saving_session_end=None,
+        ev_charging=False,
+        grid_connected=True,
+        active_appliances=[],
+        appliance_expected_kwh=0.0,
+    )
+
+
+class TestValidatePlanStructural:
+    def test_good_plan_passes(self):
+        result = validate_plan(_good_programme(), _inputs())
+        assert result.passed
+        assert result.errors == []
+        assert result.projection is not None
+
+    def test_wrong_slot_count_fails(self):
+        prog = ProgrammeState(slots=[
+            _slot(0, 0, 12, 0, 50, False),
+            _slot(12, 0, 0, 0, 50, False),
+        ])
+        result = validate_plan(prog, _inputs())
+        assert not result.passed
+        assert any("expected 6 slots" in e for e in result.errors)
+
+    def test_slot1_not_starting_at_midnight_fails(self):
+        prog = _good_programme()
+        prog.slots[0].start_time = time(1, 0)
+        result = validate_plan(prog, _inputs())
+        assert not result.passed
+        assert any("slot 1 must start 00:00" in e for e in result.errors)
+
+    def test_non_contiguous_fails(self):
+        prog = _good_programme()
+        prog.slots[2].start_time = time(17, 0)  # gap from slot 2 end (16:00)
+        result = validate_plan(prog, _inputs())
+        assert not result.passed
+        assert any("structural" in e for e in result.errors)
+
+    def test_soc_below_min_fails(self):
+        prog = _good_programme()
+        prog.slots[2].capacity_soc = 5  # min_soc is 10
+        result = validate_plan(prog, _inputs())
+        assert not result.passed
+        assert any("SOC" in e for e in result.errors)
+
+
+class TestValidatePlanH1PeakCharge:
+    def test_grid_charge_in_peak_window_rejects(self):
+        """A GC=True slot covering the day-rate IGO peak hours fires H1."""
+        prog = _good_programme()
+        # Slot 2 (05:30-16:00) at 80% no-GC. Replace with a GC=True slot
+        # that overlaps the IGO peak day-rate window.
+        prog.slots[1] = _slot(5, 30, 16, 0, 80, True)
+        result = validate_plan(prog, _inputs())
+        assert not result.passed
+        assert any("H1 violation" in e for e in result.errors)
+        # The reason should call out that the peak rate is what makes
+        # this a violation
+        assert any("peak rate" in e for e in result.errors)
+
+    def test_grid_charge_only_in_off_peak_passes_h1(self):
+        """The good programme has GC=True only 23:30-05:30 (off-peak)."""
+        result = validate_plan(_good_programme(), _inputs())
+        assert result.passed
+
+
+class TestValidatePlanCheapWindowWarning:
+    def test_no_grid_charge_in_cheap_window_warns(self):
+        """A plan that never grid-charges produces a warning, not error."""
+        prog = ProgrammeState(slots=[
+            _slot(0, 0, 5, 30, 50, False),
+            _slot(5, 30, 8, 0, 50, False),
+            _slot(8, 0, 12, 0, 50, False),
+            _slot(12, 0, 16, 0, 50, False),
+            _slot(16, 0, 23, 30, 50, False),
+            _slot(23, 30, 0, 0, 50, False),
+        ])
+        result = validate_plan(prog, _inputs())
+        # No H1 violation, no structural issue; warning only
+        assert result.passed
+        assert any("cheap window" in w for w in result.warnings)
+
+
+class TestValidatePlanProjection:
+    def test_projection_populated_even_on_reject(self):
+        prog = _good_programme()
+        # Force a structural reject (slot count)
+        prog.slots = prog.slots[:2]
+        result = validate_plan(prog, _inputs())
+        assert not result.passed
+        # Projection still attempted; may be empty values, but not None
+        assert result.projection is not None
+
+    def test_peak_import_emits_warning_not_error(self):
+        """SPEC H1: forced peak import (battery hits floor) is a
+        warning, not a hard reject - reality wins."""
+        # A plan that doesn't charge -> battery drains -> forced peak
+        # imports during the day at IGO peak rate.
+        prog = ProgrammeState(slots=[
+            _slot(0, 0, 5, 30, 10, False),
+            _slot(5, 30, 8, 0, 10, False),
+            _slot(8, 0, 12, 0, 10, False),
+            _slot(12, 0, 16, 0, 10, False),
+            _slot(16, 0, 23, 30, 10, False),
+            _slot(23, 30, 0, 0, 10, False),
+        ])
+        result = validate_plan(prog, _inputs(current_soc=10.0))
+        # No H1 plan-level error: no GC=True in peak.
+        assert all("H1 violation" not in e for e in result.errors)
+        # But a peak-import warning is present from the projection.
+        assert any("peak-rate import" in w for w in result.warnings)

--- a/tests/test_projection.py
+++ b/tests/test_projection.py
@@ -1,0 +1,213 @@
+# tests/test_projection.py
+"""Tests for the day-ahead programme projection."""
+
+from __future__ import annotations
+
+from datetime import datetime, time, timedelta, timezone
+
+import pytest
+
+from heo2.models import ProgrammeInputs, ProgrammeState, RateSlot, SlotConfig
+from heo2.projection import Projection, project_day
+
+
+def _slot(start_h, start_m, end_h, end_m, soc, gc):
+    return SlotConfig(
+        start_time=time(start_h, start_m),
+        end_time=time(end_h, end_m),
+        capacity_soc=soc,
+        grid_charge=gc,
+    )
+
+
+def _half_hour_rates(
+    start: datetime, hours: int, rate_pence: float,
+) -> list[RateSlot]:
+    """Generate 30-min rate slots from `start` for `hours` at fixed rate."""
+    slots = []
+    for i in range(hours * 2):
+        slots.append(RateSlot(
+            start=start + timedelta(minutes=30 * i),
+            end=start + timedelta(minutes=30 * (i + 1)),
+            rate_pence=rate_pence,
+        ))
+    return slots
+
+
+def _inputs_at_midnight(
+    *, current_soc=50.0, import_rates=None, export_rates=None,
+    solar_24=None, load_24=None, capacity_kwh=20.0,
+):
+    """Build ProgrammeInputs starting from a known midnight datetime."""
+    now = datetime(2026, 5, 1, 0, 0, tzinfo=timezone.utc)
+    return ProgrammeInputs(
+        now=now,
+        current_soc=current_soc,
+        battery_capacity_kwh=capacity_kwh,
+        min_soc=10.0,
+        import_rates=import_rates or [],
+        export_rates=export_rates or [],
+        solar_forecast_kwh=solar_24 or [0.0] * 24,
+        load_forecast_kwh=load_24 or [1.0] * 24,
+        igo_dispatching=False,
+        saving_session=False,
+        saving_session_start=None,
+        saving_session_end=None,
+        ev_charging=False,
+        grid_connected=True,
+        active_appliances=[],
+        appliance_expected_kwh=0.0,
+    )
+
+
+class TestProjectionSummaryFormatting:
+    def test_zero_imports_renders_zero_peak(self):
+        p = Projection(
+            expected_return_pence=123.4,
+            sells_kwh=5.0,
+            sells_pence=100.0,
+            imports_kwh=0.0,
+            imports_pence=0.0,
+            peak_import_kwh=0.0,
+        )
+        s = p.summary()
+        assert "+£1.23" in s
+        assert "ZERO peak-rate import" in s
+
+    def test_negative_return_renders_minus_pounds(self):
+        p = Projection(
+            expected_return_pence=-50.0,
+            sells_kwh=0.0,
+            sells_pence=0.0,
+            imports_kwh=2.0,
+            imports_pence=50.0,
+        )
+        s = p.summary()
+        assert "-£0.50" in s
+
+    def test_peak_kwh_visible_when_nonzero(self):
+        p = Projection(peak_import_kwh=1.5, peak_import_pence=37.0)
+        s = p.summary()
+        assert "1.50 kWh peak-rate import" in s
+        assert "ZERO" not in s
+
+
+class TestProjectDay:
+    def test_idle_programme_no_solar_no_export_imports_to_cover_load(self):
+        """Programme that holds floor and never grid-charges should
+        import enough to cover load once SOC hits min_soc."""
+        prog = ProgrammeState(slots=[
+            _slot(0, 0, 4, 0, 10, False),
+            _slot(4, 0, 8, 0, 10, False),
+            _slot(8, 0, 12, 0, 10, False),
+            _slot(12, 0, 16, 0, 10, False),
+            _slot(16, 0, 20, 0, 10, False),
+            _slot(20, 0, 0, 0, 10, False),
+        ])
+        # Cheap flat 5p import, no export rates, no solar, 1 kWh/h load
+        midnight = datetime(2026, 5, 1, 0, 0, tzinfo=timezone.utc)
+        inputs = _inputs_at_midnight(
+            current_soc=10.0,
+            import_rates=_half_hour_rates(midnight, 24, 5.0),
+            load_24=[1.0] * 24,
+        )
+
+        p = project_day(
+            prog, inputs,
+            battery_capacity_kwh=20.0,
+            max_charge_kw=5.0, max_discharge_kw=5.0,
+        )
+        # Battery starts at min_soc, so all 24 kWh of load is imported.
+        assert p.imports_kwh == pytest.approx(24.0, abs=0.5)
+        assert p.peak_import_kwh == 0.0
+        # No exports happened
+        assert p.sells_kwh == 0.0
+
+    def test_grid_charge_in_cheap_window_imports_to_target(self):
+        """A grid_charge=True slot pushes SOC up to capacity_soc using
+        grid imports, capped by max_charge_kw."""
+        prog = ProgrammeState(slots=[
+            _slot(0, 0, 5, 30, 80, True),  # Charge to 80% in 5.5h
+            _slot(5, 30, 8, 0, 10, False),
+            _slot(8, 0, 12, 0, 10, False),
+            _slot(12, 0, 16, 0, 10, False),
+            _slot(16, 0, 20, 0, 10, False),
+            _slot(20, 0, 0, 0, 10, False),
+        ])
+        midnight = datetime(2026, 5, 1, 0, 0, tzinfo=timezone.utc)
+        inputs = _inputs_at_midnight(
+            current_soc=10.0,
+            import_rates=_half_hour_rates(midnight, 24, 5.0),
+            load_24=[0.0] * 24,  # No load -> sole demand is the GC
+        )
+
+        p = project_day(
+            prog, inputs,
+            battery_capacity_kwh=20.0,
+            max_charge_kw=5.0, max_discharge_kw=5.0,
+        )
+        # 70% of 20 kWh = 14 kWh stored; with 95% charge eff that's
+        # ~14.7 kWh imported. Cap is 5kW * 5.5h = 27.5kWh, so cheap-rate
+        # window can finish the job.
+        assert p.imports_kwh > 13.0
+        assert p.imports_kwh < 17.0
+        assert p.peak_import_kwh == 0.0
+
+    def test_peak_import_logged_when_floor_forces_grid(self):
+        """Battery at floor + load with peak-rate import -> peak_import_kwh > 0."""
+        prog = ProgrammeState(slots=[
+            _slot(0, 0, 4, 0, 10, False),
+            _slot(4, 0, 8, 0, 10, False),
+            _slot(8, 0, 12, 0, 10, False),
+            _slot(12, 0, 16, 0, 10, False),
+            _slot(16, 0, 20, 0, 10, False),
+            _slot(20, 0, 0, 0, 10, False),
+        ])
+        midnight = datetime(2026, 5, 1, 0, 0, tzinfo=timezone.utc)
+        # 25p flat all day -> well above 24p peak threshold
+        inputs = _inputs_at_midnight(
+            current_soc=10.0,
+            import_rates=_half_hour_rates(midnight, 24, 25.0),
+            load_24=[1.0] * 24,
+        )
+
+        p = project_day(
+            prog, inputs,
+            battery_capacity_kwh=20.0,
+            peak_threshold_p=24.0,
+        )
+        assert p.peak_import_kwh == pytest.approx(p.imports_kwh, abs=0.5)
+        assert p.peak_import_kwh > 20.0
+
+    def test_top_export_window_drains_battery_to_grid(self):
+        """When SOC is high and export rate is in top-N% with capacity_soc
+        below current SOC, projection sells to grid."""
+        prog = ProgrammeState(slots=[
+            _slot(0, 0, 4, 0, 30, False),
+            _slot(4, 0, 8, 0, 30, False),
+            _slot(8, 0, 12, 0, 30, False),
+            _slot(12, 0, 16, 0, 30, False),
+            _slot(16, 0, 20, 0, 30, False),  # SOC target 30 -> headroom
+            _slot(20, 0, 0, 0, 30, False),
+        ])
+        midnight = datetime(2026, 5, 1, 0, 0, tzinfo=timezone.utc)
+        # Single high export rate at 16:00-17:00 (~25p), rest 5p
+        export = _half_hour_rates(midnight, 24, 5.0)
+        for s in export:
+            if s.start.hour == 16:
+                s.rate_pence = 25.0
+        inputs = _inputs_at_midnight(
+            current_soc=80.0,
+            import_rates=_half_hour_rates(midnight, 24, 5.0),
+            export_rates=export,
+            load_24=[0.0] * 24,
+        )
+
+        p = project_day(
+            prog, inputs,
+            battery_capacity_kwh=20.0,
+            export_top_pct=10,  # top 10% catches just 16:00-17:00
+        )
+        assert p.sells_kwh > 0
+        assert p.sells_avg_pence is not None
+        assert p.sells_avg_pence == pytest.approx(25.0, abs=0.1)

--- a/tests/test_replan_triggers.py
+++ b/tests/test_replan_triggers.py
@@ -1,0 +1,263 @@
+# tests/test_replan_triggers.py
+"""Tests for the SPEC §8 daily-plan / 15-min trigger separation."""
+
+from __future__ import annotations
+
+from datetime import datetime, time, timedelta, timezone
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from heo2.models import ProgrammeInputs, ProgrammeState, SlotConfig
+from heo2.replan_triggers import (
+    BaselineSnapshot,
+    capture_baseline,
+    should_commit_replan,
+)
+
+
+_LON = ZoneInfo("Europe/London")
+
+
+def _slot(start_h, start_m, end_h, end_m, soc=50, gc=False):
+    return SlotConfig(
+        start_time=time(start_h, start_m),
+        end_time=time(end_h, end_m),
+        capacity_soc=soc,
+        grid_charge=gc,
+    )
+
+
+def _default_programme() -> ProgrammeState:
+    return ProgrammeState(slots=[
+        _slot(0, 0, 5, 30),
+        _slot(5, 30, 12, 0),
+        _slot(12, 0, 16, 0),
+        _slot(16, 0, 19, 0),
+        _slot(19, 0, 23, 30),
+        _slot(23, 30, 0, 0),
+    ])
+
+
+def _inputs(
+    *, now=None, current_soc=50.0, solar=None, load=None,
+    igo=False, saving=False, grid=True,
+):
+    return ProgrammeInputs(
+        now=now or datetime(2026, 5, 1, 12, 0, tzinfo=timezone.utc),
+        current_soc=current_soc,
+        battery_capacity_kwh=20.0,
+        min_soc=10.0,
+        import_rates=[],
+        export_rates=[],
+        solar_forecast_kwh=solar or [1.0] * 24,
+        load_forecast_kwh=load or [0.5] * 24,
+        igo_dispatching=igo,
+        saving_session=saving,
+        saving_session_start=None,
+        saving_session_end=None,
+        ev_charging=False,
+        grid_connected=grid,
+        active_appliances=[],
+        appliance_expected_kwh=0.0,
+    )
+
+
+class TestFirstTickAlwaysCommits:
+    def test_no_baseline_commits_immediately(self):
+        decision = should_commit_replan(
+            new_programme=_default_programme(),
+            inputs=_inputs(),
+            baseline=None,
+            tz=_LON,
+            daily_plan_time=time(18, 0),
+            replan_solar_pct=25,
+            replan_load_pct=25,
+            replan_soc_pct=10,
+        )
+        assert decision.commit
+        assert "first plan" in decision.reason
+
+
+class TestDailyPlanWindow:
+    def test_within_18h_window_on_new_date_commits(self):
+        # Capture a yesterday-baseline so today's 18:00 fires
+        yesterday_inputs = _inputs(
+            now=datetime(2026, 4, 30, 18, 0, tzinfo=timezone.utc),
+        )
+        baseline = capture_baseline(
+            _default_programme(), yesterday_inputs, tz=_LON, is_daily_plan=True,
+        )
+        # Today 18:05 BST = 17:05 UTC
+        today_inputs = _inputs(
+            now=datetime(2026, 5, 1, 17, 5, tzinfo=timezone.utc),
+        )
+        decision = should_commit_replan(
+            new_programme=_default_programme(),
+            inputs=today_inputs,
+            baseline=baseline,
+            tz=_LON,
+            daily_plan_time=time(18, 0),
+            replan_solar_pct=25,
+            replan_load_pct=25,
+            replan_soc_pct=10,
+        )
+        assert decision.commit
+        assert "daily plan" in decision.reason
+
+    def test_already_planned_today_no_commit(self):
+        """Second 18:xx tick on the same day shouldn't fire a replan."""
+        baseline_inputs = _inputs(
+            now=datetime(2026, 5, 1, 17, 0, tzinfo=timezone.utc),  # 18:00 BST
+        )
+        baseline = capture_baseline(
+            _default_programme(), baseline_inputs,
+            tz=_LON, is_daily_plan=True,
+        )
+        # 18:15 BST same day
+        next_tick = _inputs(
+            now=datetime(2026, 5, 1, 17, 15, tzinfo=timezone.utc),
+        )
+        decision = should_commit_replan(
+            new_programme=_default_programme(),
+            inputs=next_tick,
+            baseline=baseline,
+            tz=_LON,
+            daily_plan_time=time(18, 0),
+            replan_solar_pct=25,
+            replan_load_pct=25,
+            replan_soc_pct=10,
+        )
+        assert not decision.commit
+        assert "hold baseline" in decision.reason
+
+
+class TestQuantitativeTriggers:
+    def _baseline_at(self, hour_utc=12, soc=50.0, solar=None, load=None):
+        inputs = _inputs(
+            now=datetime(2026, 5, 1, hour_utc, 0, tzinfo=timezone.utc),
+            current_soc=soc,
+            solar=solar or [1.0] * 24,
+            load=load or [0.5] * 24,
+        )
+        return capture_baseline(
+            _default_programme(), inputs, tz=_LON, is_daily_plan=True,
+        )
+
+    def test_solar_deviation_above_threshold_commits(self):
+        baseline = self._baseline_at(
+            hour_utc=12, solar=[1.0] * 24,  # rest-of-day = 12 kWh
+        )
+        # Same time on the same day, solar forecast halved -> 50% dev
+        new = _inputs(
+            now=datetime(2026, 5, 1, 12, 0, tzinfo=timezone.utc),
+            solar=[0.5] * 24,
+        )
+        decision = should_commit_replan(
+            new_programme=_default_programme(),
+            inputs=new, baseline=baseline, tz=_LON,
+            daily_plan_time=time(18, 0),
+            replan_solar_pct=25, replan_load_pct=25, replan_soc_pct=10,
+        )
+        assert decision.commit
+        assert "solar" in decision.reason
+
+    def test_load_deviation_above_threshold_commits(self):
+        baseline = self._baseline_at(load=[0.5] * 24)
+        new = _inputs(
+            now=datetime(2026, 5, 1, 12, 0, tzinfo=timezone.utc),
+            load=[1.0] * 24,  # 100% deviation
+        )
+        decision = should_commit_replan(
+            new_programme=_default_programme(),
+            inputs=new, baseline=baseline, tz=_LON,
+            daily_plan_time=time(18, 0),
+            replan_solar_pct=25, replan_load_pct=25, replan_soc_pct=10,
+        )
+        assert decision.commit
+        assert "load" in decision.reason
+
+    def test_soc_deviation_above_threshold_commits(self):
+        baseline = self._baseline_at(soc=50.0)
+        new = _inputs(
+            now=datetime(2026, 5, 1, 12, 0, tzinfo=timezone.utc),
+            current_soc=70.0,  # 20pt deviation
+        )
+        decision = should_commit_replan(
+            new_programme=_default_programme(),
+            inputs=new, baseline=baseline, tz=_LON,
+            daily_plan_time=time(18, 0),
+            replan_solar_pct=25, replan_load_pct=25, replan_soc_pct=10,
+        )
+        assert decision.commit
+        assert "SOC" in decision.reason
+
+    def test_small_deviation_no_commit(self):
+        baseline = self._baseline_at(soc=50.0)
+        new = _inputs(
+            now=datetime(2026, 5, 1, 12, 0, tzinfo=timezone.utc),
+            current_soc=55.0,
+        )
+        decision = should_commit_replan(
+            new_programme=_default_programme(),
+            inputs=new, baseline=baseline, tz=_LON,
+            daily_plan_time=time(18, 0),
+            replan_solar_pct=25, replan_load_pct=25, replan_soc_pct=10,
+        )
+        assert not decision.commit
+
+
+class TestEventTriggers:
+    def _baseline(self, *, igo=False, saving=False, grid=True):
+        inputs = _inputs(igo=igo, saving=saving, grid=grid)
+        return capture_baseline(
+            _default_programme(), inputs, tz=_LON, is_daily_plan=True,
+        )
+
+    def test_igo_dispatch_announced_commits(self):
+        baseline = self._baseline(igo=False)
+        new = _inputs(igo=True)
+        decision = should_commit_replan(
+            new_programme=_default_programme(),
+            inputs=new, baseline=baseline, tz=_LON,
+            daily_plan_time=time(18, 0),
+            replan_solar_pct=25, replan_load_pct=25, replan_soc_pct=10,
+        )
+        assert decision.commit
+        assert "IGO dispatch" in decision.reason
+
+    def test_saving_session_commits(self):
+        baseline = self._baseline(saving=False)
+        new = _inputs(saving=True)
+        decision = should_commit_replan(
+            new_programme=_default_programme(),
+            inputs=new, baseline=baseline, tz=_LON,
+            daily_plan_time=time(18, 0),
+            replan_solar_pct=25, replan_load_pct=25, replan_soc_pct=10,
+        )
+        assert decision.commit
+        assert "saving session" in decision.reason
+
+    def test_grid_restored_commits(self):
+        baseline = self._baseline(grid=False)
+        new = _inputs(grid=True)
+        decision = should_commit_replan(
+            new_programme=_default_programme(),
+            inputs=new, baseline=baseline, tz=_LON,
+            daily_plan_time=time(18, 0),
+            replan_solar_pct=25, replan_load_pct=25, replan_soc_pct=10,
+        )
+        assert decision.commit
+        assert "grid restored" in decision.reason
+
+    def test_igo_dispatching_continuing_no_commit(self):
+        """Already-dispatching baseline + still-dispatching new = no trigger."""
+        baseline = self._baseline(igo=True)
+        new = _inputs(igo=True)
+        decision = should_commit_replan(
+            new_programme=_default_programme(),
+            inputs=new, baseline=baseline, tz=_LON,
+            daily_plan_time=time(18, 0),
+            replan_solar_pct=25, replan_load_pct=25, replan_soc_pct=10,
+        )
+        assert not decision.commit

--- a/tests/test_rules/test_safety.py
+++ b/tests/test_rules/test_safety.py
@@ -70,3 +70,54 @@ class TestSafetyRule:
         result = rule.apply(state, default_inputs)
         socs_after = [s.capacity_soc for s in result.slots]
         assert socs_before == socs_after
+
+    def test_snaps_minutes_to_5min_granularity(self, default_inputs):
+        """Sunsynk inverter timer fields have 5-minute granularity. Any
+        boundary at, say, 23:57 must snap to 23:55 in the rule output
+        so the post-write verify (HEO-31 PR2 H6) doesn't perpetually
+        flag a mismatch between what HEO sent and what the inverter
+        actually stores. Verified manually 2026-05-02:
+            23:57 -> 23:55, 23:58 -> 23:55, 23:51 -> 23:50.
+        """
+        state = ProgrammeState(
+            slots=[
+                SlotConfig(time(0, 0), time(5, 32), 50, True),
+                SlotConfig(time(5, 32), time(18, 33), 50, False),
+                SlotConfig(time(18, 33), time(23, 30), 50, False),
+                SlotConfig(time(23, 30), time(23, 57), 80, True),
+                SlotConfig(time(23, 57), time(23, 58), 50, False),
+                SlotConfig(time(23, 58), time(0, 0), 50, False),
+            ],
+            reason_log=[],
+        )
+        rule = SafetyRule()
+        result = rule.apply(state, default_inputs)
+        for i, slot in enumerate(result.slots):
+            assert slot.start_time.minute % 5 == 0, (
+                f"slot {i + 1} start {slot.start_time} not on 5-min boundary"
+            )
+            assert slot.end_time.minute % 5 == 0, (
+                f"slot {i + 1} end {slot.end_time} not on 5-min boundary"
+            )
+        # Floor direction: 23:57 should become 23:55, not 24:00
+        assert result.slots[3].end_time == time(23, 55)
+        assert result.slots[4].start_time == time(23, 55)
+
+    def test_snap_preserves_contiguity(self, default_inputs):
+        """After snapping, slot N's end_time must still equal slot N+1's
+        start_time. The snap is applied before the contiguous fix-up."""
+        state = ProgrammeState(
+            slots=[
+                SlotConfig(time(0, 0), time(5, 32), 50, True),
+                SlotConfig(time(5, 32), time(18, 0), 50, False),
+                SlotConfig(time(18, 0), time(20, 0), 50, False),
+                SlotConfig(time(20, 0), time(22, 0), 50, False),
+                SlotConfig(time(22, 0), time(23, 33), 50, False),
+                SlotConfig(time(23, 33), time(0, 0), 50, False),
+            ],
+            reason_log=[],
+        )
+        rule = SafetyRule()
+        result = rule.apply(state, default_inputs)
+        for i in range(5):
+            assert result.slots[i].end_time == result.slots[i + 1].start_time

--- a/tests/test_writes_status.py
+++ b/tests/test_writes_status.py
@@ -127,3 +127,46 @@ class TestComputeWritesBlocked:
         )
         assert blocked is True
         assert "10.0.5.42" in reason
+
+    def test_plan_rejected_blocks_with_h5_prefix(self):
+        """SPEC §6 / H5: validator-rejected plan blocks writes."""
+        blocked, reason = _compute_writes_blocked(
+            dry_run=False,
+            writer_constructed=True,
+            transport_exists=True,
+            transport_connected=True,
+            host="192.168.4.7",
+            plan_rejected_reason="H1 violation: slot 2 grid_charge in peak",
+        )
+        assert blocked is True
+        assert "H5" in reason
+        assert "H1 violation" in reason
+
+    def test_verify_mismatch_blocks_with_h6_prefix(self):
+        """SPEC §7 / H6: post-write verify mismatch blocks subsequent writes."""
+        blocked, reason = _compute_writes_blocked(
+            dry_run=False,
+            writer_constructed=True,
+            transport_exists=True,
+            transport_connected=True,
+            host="192.168.4.7",
+            verify_mismatch_reason="slot 2 cap sent=80 got=50",
+        )
+        assert blocked is True
+        assert "H6" in reason
+
+    def test_h4_takes_precedence_over_h5(self):
+        """If we never had live rates we can't have a valid plan; the
+        H4 reason is the more useful one to report."""
+        blocked, reason = _compute_writes_blocked(
+            dry_run=False,
+            writer_constructed=True,
+            transport_exists=True,
+            transport_connected=True,
+            host="192.168.4.7",
+            live_rates_present=False,
+            plan_rejected_reason="some H5 reason",
+        )
+        assert blocked is True
+        assert "H4" in reason
+        assert "H5" not in reason


### PR DESCRIPTION
## Summary
PR 2 of 3 in the rules-redesign roadmap (#31). Bundles SPEC §6 / §7 / §8 because they share coordinator state.

- **§8 daily plan vs 15-min ticks**: rule engine still runs every tick (sensors live), but the inverter only gets re-programmed at the daily-plan window (default 18:00 local) or when a trigger fires (IGO dispatch announced, saving session, grid restored, solar/load >25% deviation, SOC >10% deviation). Stops the constant-rewrite churn.
- **§6 / H5 pre-write validator**: rejects plans that schedule `grid_charge=true` in a peak window. Soft warns when the cheap window isn't covered or when the projection forecasts forced peak-rate import. New `sensor.heo_ii_projection_today` always shows the SPEC §6 one-line summary, accepted or rejected.
- **§7 / H6 post-write verification**: deferred to the next tick (avoids racing SA's poll cadence). Mismatch -> `H6:` reason on `binary_sensor.heo_ii_writes_blocked` + reset of `_last_known_programme` so subsequent diffs target the right delta.
- **5-minute timer granularity snap (SafetyRule)**: Sunsynk inverters floor `time_point_N` to 5-min boundaries (verified via mosquitto: `23:57 -> 23:55`, `23:51 -> 23:50`). SafetyRule now snaps every boundary. Without this, H6 would latch a permanent mismatch every tick because the plan and the read-back never agree.

## Why
Paddy's manual edits + HEO-30 rank pricing surfaced cases where every 15-min tick rewrote slots based on minor forecast wobbles. SPEC §8 caps the rewrites; §6/§7 add the H5/H6 guardrails the spec already lists but the code didn't enforce. SPEC.md updated FIRST per the convention.

## What landed
New modules:
- `custom_components/heo2/projection.py` (24h forward sim, ProjectionReport summary)
- `custom_components/heo2/plan_validator.py` (errors + warnings + projection)
- `custom_components/heo2/replan_triggers.py` (BaselineSnapshot, should_commit_replan, capture_baseline)

Coordinator changes:
- baseline tracking, validation hook, deferred verify, projection wiring
- `writes_status._compute_writes_blocked` extended with optional `plan_rejected_reason` and `verify_mismatch_reason`
- new config knobs in `const.py` matching SPEC §10 defaults
- `SafetyRule` snaps slot boundaries to 5-min Sunsynk granularity

New tests (379 total, +33 over baseline):
- `tests/test_projection.py` — formatting + 4 forward-sim scenarios
- `tests/test_plan_validator.py` — structural rejects, H1 peak-charge, cheap-window warning, projection-on-reject
- `tests/test_replan_triggers.py` — first tick / daily window / quantitative + event triggers / hold
- `tests/test_rules/test_safety.py` — granularity snap + contiguity preservation

## Test plan
- [x] `pytest tests/ --ignore=tests/test_config_flow_dashboard.py -q` -> 379 pass
- [x] HEO-32 (writer fix) on master, verified converging via mosquitto probe + PROD tick at 13:15 BST
- [x] Granularity behaviour confirmed via mosquitto: 23:57 -> 23:55 floor on real Sunsynk
- [ ] Deploy PR 2 to PROD, watch first daily-plan window (18:00 BST today)
- [ ] Verify `sensor.heo_ii_projection_today` populates with the summary line on next tick
- [ ] Verify `binary_sensor.heo_ii_writes_blocked` stays OFF for spec-shaped plans
- [ ] Verify slot 5/6 boundaries don't generate spurious re-writes (granularity snap working)

🤖 Generated with [Claude Code](https://claude.com/claude-code)