### PR TITLE
fix(HEO-31): validator/projection respect local timezone

### DIFF
--- a/custom_components/heo2/coordinator.py
+++ b/custom_components/heo2/coordinator.py
@@ -250,6 +250,7 @@ class HEO2Coordinator(DataUpdateCoordinator):
             max_discharge_kw=self._max_discharge_kw,
             charge_efficiency=self._charge_efficiency,
             discharge_efficiency=self._discharge_efficiency,
+            tz=tz,
         )
         self._validation_warnings = validation.warnings
         self._last_projection = validation.projection

--- a/custom_components/heo2/plan_validator.py
+++ b/custom_components/heo2/plan_validator.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from datetime import time
+from zoneinfo import ZoneInfo
 
 from .models import ProgrammeInputs, ProgrammeState, RateSlot, SlotConfig
 from .projection import Projection, project_day
@@ -55,21 +56,30 @@ class ValidationResult:
 
 
 def _slots_overlapping_rates(
-    programme: ProgrammeState, rate_slots: list[RateSlot],
+    programme: ProgrammeState,
+    rate_slots: list[RateSlot],
+    tz: ZoneInfo | None,
 ) -> list[tuple[int, RateSlot]]:
     """Return (slot_index, rate_slot) pairs where the programme slot's
     time window overlaps the rate slot's time window.
 
-    Programme slots are time-of-day; rate slots are absolute datetimes.
-    For overlap detection we project the rate slot onto its local
-    time-of-day. A rate slot crossing midnight is split into two
-    notional half-slots.
+    Programme slots are local time-of-day (Europe/London for Paddy's
+    install). Rate slots from BottlecapDave / AgilePredict are tz-aware
+    absolute UTC datetimes. To compare them we project the rate's start
+    onto local time-of-day FIRST. Without this, a rate slot at 04:30
+    UTC (= 05:30 BST in summer) would be checked as if it were 04:30
+    BST and falsely match a slot that ends at 05:30 BST.
+
+    `tz` is the local zoneinfo. None falls back to whatever timezone
+    the rate's own start carries (legacy behaviour, used by tests
+    where rates and slots share the same tz).
     """
     pairs: list[tuple[int, RateSlot]] = []
     for r in rate_slots:
-        # Rate slots from BD/IGO are 30-min wide; the start time is
-        # enough to identify which programme slot it lands in.
-        local_clock = r.start.time()
+        if tz is not None and r.start.tzinfo is not None:
+            local_clock = r.start.astimezone(tz).time()
+        else:
+            local_clock = r.start.time()
         for i, slot in enumerate(programme.slots):
             if slot.contains_time(local_clock):
                 pairs.append((i, r))
@@ -81,6 +91,7 @@ def _check_no_grid_charge_in_peak(
     programme: ProgrammeState,
     import_rates: list[RateSlot],
     peak_threshold_p: float,
+    tz: ZoneInfo | None,
 ) -> list[str]:
     """SPEC §6 sanity check: no `grid_charge=True` slot's time range may
     overlap a peak-rate import window.
@@ -93,15 +104,22 @@ def _check_no_grid_charge_in_peak(
     if not peak_rates:
         return errors
 
-    for slot_idx, rate in _slots_overlapping_rates(programme, peak_rates):
+    for slot_idx, rate in _slots_overlapping_rates(
+        programme, peak_rates, tz,
+    ):
         slot = programme.slots[slot_idx]
         if slot.grid_charge:
+            local_start = (
+                rate.start.astimezone(tz)
+                if tz is not None and rate.start.tzinfo is not None
+                else rate.start
+            )
             errors.append(
                 f"H1 violation: slot {slot_idx + 1} "
                 f"({slot.start_time.strftime('%H:%M')}-"
                 f"{slot.end_time.strftime('%H:%M')}) has grid_charge=True "
                 f"covering peak rate {rate.rate_pence:.2f}p at "
-                f"{rate.start.strftime('%H:%M')}"
+                f"{local_start.strftime('%H:%M')}"
             )
             # One error per slot is enough; further peak slots in the
             # same programme slot would just be noise.
@@ -153,6 +171,7 @@ def _check_cheap_window_covered(
     import_rates: list[RateSlot],
     inputs: ProgrammeInputs,
     bottom_n_pct_threshold: int,
+    tz: ZoneInfo | None,
 ) -> list[str]:
     """Soft SPEC §6 check: at least one `grid_charge=True` slot should
     cover the IGO cheap window.
@@ -163,18 +182,23 @@ def _check_cheap_window_covered(
     handles that decision; this guard catches accidental misconfigs
     that would silently leave the cheap window uncovered.
     """
-    today_import = filter_today(import_rates, inputs.now)
+    today_import = filter_today(import_rates, inputs.now, tz=tz)
     cheap = bottom_n_pct(today_import, bottom_n_pct_threshold)
     if not cheap:
         return []
 
-    pairs = _slots_overlapping_rates(programme, cheap)
+    pairs = _slots_overlapping_rates(programme, cheap, tz)
     covered = any(programme.slots[i].grid_charge for i, _ in pairs)
     if covered:
         return []
 
-    cheap_start = min(c.start.strftime("%H:%M") for c in cheap)
-    cheap_end = max(c.end.strftime("%H:%M") for c in cheap)
+    def _local_hhmm(d):
+        if tz is not None and d.tzinfo is not None:
+            return d.astimezone(tz).strftime("%H:%M")
+        return d.strftime("%H:%M")
+
+    cheap_start = min(_local_hhmm(c.start) for c in cheap)
+    cheap_end = max(_local_hhmm(c.end) for c in cheap)
     return [
         f"no grid_charge=True slot covers the cheap window "
         f"({cheap_start}-{cheap_end}, "
@@ -193,6 +217,7 @@ def validate_plan(
     max_discharge_kw: float = 5.0,
     charge_efficiency: float = 0.95,
     discharge_efficiency: float = 0.95,
+    tz: ZoneInfo | None = None,
 ) -> ValidationResult:
     """Run all SPEC §6 pre-write checks and a 24-hour projection.
 
@@ -200,6 +225,10 @@ def validate_plan(
     `warnings` are logged but allow the write to proceed.
     `projection` is populated regardless so the dashboard can show
     the expected return for both accepted and rejected plans.
+
+    `tz` is the local zoneinfo for projecting tz-aware rate slots
+    onto the programme's local time-of-day. Defaults to None for
+    backward compat with tests where rates and slots share a tz.
     """
     errors: list[str] = []
     warnings: list[str] = []
@@ -208,11 +237,11 @@ def validate_plan(
 
     if not errors:
         errors.extend(_check_no_grid_charge_in_peak(
-            programme, inputs.import_rates, peak_threshold_p,
+            programme, inputs.import_rates, peak_threshold_p, tz,
         ))
 
     warnings.extend(_check_cheap_window_covered(
-        programme, inputs.import_rates, inputs, cheap_bottom_pct,
+        programme, inputs.import_rates, inputs, cheap_bottom_pct, tz,
     ))
 
     projection = project_day(
@@ -224,6 +253,7 @@ def validate_plan(
         charge_efficiency=charge_efficiency,
         discharge_efficiency=discharge_efficiency,
         peak_threshold_p=peak_threshold_p,
+        tz=tz,
     )
 
     if projection.peak_import_kwh > 0.001:

--- a/custom_components/heo2/projection.py
+++ b/custom_components/heo2/projection.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, time
+from zoneinfo import ZoneInfo
 
 from .models import ProgrammeInputs, ProgrammeState, RateSlot, SlotConfig
 
@@ -148,6 +149,7 @@ def project_day(
     export_top_pct: int = 30,
     replacement_cost_p: float = 4.95,
     horizon_hours: int = 24,
+    tz: ZoneInfo | None = None,
 ) -> Projection:
     """Forward-simulate the next `horizon_hours` and return a Projection.
 
@@ -181,19 +183,28 @@ def project_day(
         step_start = now + timedelta(minutes=_SLOT_MINUTES * step)
         step_end = step_start + timedelta(minutes=_SLOT_MINUTES)
 
-        local_clock = step_start.time()
+        # Programme slots are local time-of-day; solar/load forecasts
+        # are 24-element arrays indexed by LOCAL hour. Project the UTC
+        # step_start onto local time before looking either up.
+        if tz is not None and step_start.tzinfo is not None:
+            step_local = step_start.astimezone(tz)
+        else:
+            step_local = step_start
+        local_clock = step_local.time()
         slot = _slot_at(programme.slots, local_clock)
 
         # Import / export rates at this 30-min step. Either may be missing
         # past BD's horizon; treat None as zero contribution to revenue
-        # (we still simulate behaviour, just don't book money).
+        # (we still simulate behaviour, just don't book money). Rate
+        # lookup uses the absolute UTC datetime, since RateSlots are
+        # tz-aware.
         imp = _rate_at(inputs.import_rates, step_start)
         exp = _rate_at(inputs.export_rates, step_start)
         imp_p = imp.rate_pence if imp is not None else 0.0
         exp_p = exp.rate_pence if exp is not None else 0.0
 
         # Solar / load at this step. Forecasts are hourly; pro-rate to 30 min.
-        hour_idx = step_start.hour
+        hour_idx = step_local.hour
         solar_kwh = inputs.solar_forecast_kwh[hour_idx] * _SLOT_HOURS
         load_kwh = inputs.load_forecast_kwh[hour_idx] * _SLOT_HOURS
 

--- a/tests/test_plan_validator.py
+++ b/tests/test_plan_validator.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 from datetime import datetime, time, timedelta, timezone
+from zoneinfo import ZoneInfo
 
 import pytest
 
@@ -187,3 +188,69 @@ class TestValidatePlanProjection:
         assert all("H1 violation" not in e for e in result.errors)
         # But a peak-import warning is present from the projection.
         assert any("peak-rate import" in w for w in result.warnings)
+
+
+class TestValidatePlanTimezone:
+    def test_uk_summer_peak_at_0430_utc_does_not_alias_into_overnight_slot(self):
+        """Regression: a peak rate slot at 04:30 UTC (= 05:30 BST) was
+        being aliased into the 00:00-05:30 BST overnight cheap-charge
+        slot, falsely flagging an H1 violation. The fix passes tz to
+        validate_plan and projects rate.start onto local time-of-day
+        before comparing against programme slots.
+
+        Observed in PROD on 2026-05-02: BottlecapDave returned 28.58p
+        at 04:30 UTC (peak day rate boundary), the validator flagged
+        slot 1 (00:00-05:30 BST, GC=True) as covering peak, the plan
+        was rejected on every tick.
+        """
+        london = ZoneInfo("Europe/London")
+        # A summer day in BST (DST active)
+        midnight_utc = datetime(2026, 5, 2, 23, 0, tzinfo=timezone.utc)
+        # Generate IGO-shaped UTC rates: ~5p 22:30 UTC -> 04:30 UTC,
+        # peak (28.58p) 04:30 UTC -> 22:30 UTC. (= 23:30 BST -> 05:30 BST
+        # off-peak, peak the rest of the day.)
+        rates = []
+        for i in range(48):
+            start = midnight_utc + timedelta(minutes=30 * i)
+            end = start + timedelta(minutes=30)
+            local_h = start.astimezone(london).hour
+            local_m = start.astimezone(london).minute
+            is_offpeak = (
+                local_h < 5 or (local_h == 5 and local_m < 30) or
+                local_h >= 23 and (local_h > 23 or local_m >= 30)
+            )
+            rates.append(RateSlot(start=start, end=end, rate_pence=4.95 if is_offpeak else 28.58))
+
+        # A spec-shaped plan: GC overnight only (00:00-05:30 BST).
+        prog = ProgrammeState(slots=[
+            _slot(0, 0, 5, 30, 80, True),    # BST overnight cheap-charge
+            _slot(5, 30, 16, 0, 80, False),  # BST day hold
+            _slot(16, 0, 19, 0, 10, False),  # BST evening drain
+            _slot(19, 0, 23, 30, 10, False),
+            _slot(23, 30, 23, 55, 80, True), # post-23:30 cheap window
+            _slot(23, 55, 0, 0, 80, True),
+        ])
+
+        # Build inputs with a "now" early in the day so all 48 rates fall
+        # within the validator's "today".
+        inputs = ProgrammeInputs(
+            now=datetime(2026, 5, 3, 0, 0, tzinfo=timezone.utc),
+            current_soc=50.0, battery_capacity_kwh=20.0, min_soc=10.0,
+            import_rates=rates, export_rates=[],
+            solar_forecast_kwh=[0.0] * 24, load_forecast_kwh=[0.5] * 24,
+            igo_dispatching=False, saving_session=False,
+            saving_session_start=None, saving_session_end=None,
+            ev_charging=False, grid_connected=True,
+            active_appliances=[], appliance_expected_kwh=0.0,
+        )
+
+        result = validate_plan(prog, inputs, tz=london, peak_threshold_p=24.0)
+        # No H1 violation: GC slots are 00:00-05:30 BST and 23:30+ BST,
+        # both fully inside the off-peak window.
+        h1_errors = [e for e in result.errors if "H1 violation" in e]
+        assert h1_errors == [], (
+            f"unexpected H1 violation(s): {h1_errors}; "
+            f"all errors: {result.errors}"
+        )
+        # Sanity: validator passed
+        assert result.passed


### PR DESCRIPTION
## Summary
Hot-fix on top of PR #38. The validator and projection were comparing local-time programme slots to UTC rate-slot times-of-day, falsely flagging slot 1 (00:00-05:30 BST GC=true) as covering the 04:30 UTC = 05:30 BST peak boundary.

## Why
PROD deployed PR #38 at 13:21 BST and immediately rejected every plan with the bogus H1 violation. Inverter stuck on its current state.

## Fix
Pass `tz: ZoneInfo` through `validate_plan` -> `_slots_overlapping_rates` and `project_day`. Convert `rate.start.astimezone(tz).time()` before checking against programme slots. Coordinator passes `self._local_tz()`.

## Test plan
- [x] `pytest tests/ --ignore=tests/test_config_flow_dashboard.py -q` -> 380 pass
- [x] New regression test pins BST off-peak boundary scenario
- [ ] Deploy + restart, watch next tick log accept the plan
- [ ] `binary_sensor.heo_ii_writes_blocked` returns to OFF

🤖 Generated with [Claude Code](https://claude.com/claude-code)