### PR TITLE
feat(HEO-10): SavingSessionRule drains battery during Octoplus sessions

### DIFF
--- a/custom_components/heo2/coordinator.py
+++ b/custom_components/heo2/coordinator.py
@@ -643,6 +643,7 @@ class HEO2Coordinator(DataUpdateCoordinator):
             live_import_rates=live_import_rates,
             live_export_rates=live_export_rates,
             solar_forecast_kwh_tomorrow=solar_tomorrow,
+            local_tz=self._local_tz(),
         )
 
     def _read_entity_float(self, entity_id: str, default: float) -> float:

--- a/custom_components/heo2/models.py
+++ b/custom_components/heo2/models.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from datetime import time, datetime
 from typing import Optional
+from zoneinfo import ZoneInfo
 
 
 @dataclass
@@ -204,6 +205,24 @@ class ProgrammeInputs:
     # working; the rank logic treats an empty list as "no forecast"
     # which biases towards the conservative top-15% sell window.
     solar_forecast_kwh_tomorrow: list[float] = field(default_factory=list)
+    # Local timezone for projecting `now` and tz-aware rate slots onto
+    # programme-slot time-of-day. Optional for tests that share a single
+    # tz between rates and slots; coordinator passes the real local tz
+    # in production. Rules that compare `inputs.now.time()` against
+    # programme slot times MUST go through `now_local()` so a UTC `now`
+    # doesn't alias against local-time slots in DST. See HEO-31 PR2 fix.
+    local_tz: Optional[ZoneInfo] = None
+
+    def now_local(self) -> datetime:
+        """Return `now` projected into the local timezone if known.
+
+        Falls back to whatever tz `now` already carries (UTC in
+        production) so existing tests that don't set local_tz continue
+        to work.
+        """
+        if self.local_tz is not None and self.now.tzinfo is not None:
+            return self.now.astimezone(self.local_tz)
+        return self.now
 
     def rate_at(self, dt: datetime) -> float | None:
         """Find the import rate at a specific datetime. Returns None if no rate covers it."""

--- a/custom_components/heo2/rules/__init__.py
+++ b/custom_components/heo2/rules/__init__.py
@@ -11,13 +11,18 @@ from .export_window import ExportWindowRule
 from .evening_protect import EveningProtectRule
 from .igo_dispatch import IGODispatchRule
 from .ev_charging import EVChargingRule
+from .saving_session import SavingSessionRule
 from .safety import SafetyRule
 
 
 def default_rules() -> list[Rule]:
-    """Return the 8 default rules in priority order.
+    """Return the 9 default rules in priority order.
 
-    SafetyRule is always last and cannot be disabled.
+    SafetyRule is always last and cannot be disabled. SavingSessionRule
+    sits AFTER ExportWindowRule + EveningProtectRule so an active
+    session always wins over a normal export window or evening floor:
+    SPEC §9 says drain to min_soc regardless of the standard Agile
+    threshold or evening reserve.
     """
     return [
         BaselineRule(),
@@ -25,6 +30,7 @@ def default_rules() -> list[Rule]:
         SolarSurplusRule(),
         ExportWindowRule(),
         EveningProtectRule(),
+        SavingSessionRule(),
         IGODispatchRule(),
         EVChargingRule(),
         SafetyRule(),

--- a/custom_components/heo2/rules/saving_session.py
+++ b/custom_components/heo2/rules/saving_session.py
@@ -1,0 +1,72 @@
+# custom_components/heo2/rules/saving_session.py
+"""SavingSessionRule -- drain to floor when an Octoplus saving session is
+active.
+
+SPEC §9 row 3:
+
+    Saving Session | saving_session_active | Drain to min_soc as fast
+    as inverter allows (Selling first + max discharge); resume normal
+    at session end.
+
+Octoplus Saving Sessions typically pay £3+/kWh of battery export. Missing
+one is directly equivalent to losing £10-50 of revenue.
+
+This rule fires when `inputs.saving_session` is True. It overrides the
+slot containing local-now to `capacity_soc=min_soc, grid_charge=False`
+so the inverter discharges the battery to the floor. Other slots are
+left untouched so the session ending mid-tick (next coordinator pass)
+returns the schedule to normal.
+
+Work-mode / discharge-rate writes (SPEC §2 items 4-7) aren't yet wired
+into MqttWriter; once they are, this rule can also force "Selling first"
++ max discharge for the duration of the session. For now, the SOC + GC
+override gives the inverter permission to discharge against load + grid
+export; the existing work mode handles the rest.
+"""
+
+from __future__ import annotations
+
+from ..models import ProgrammeInputs, ProgrammeState
+from ..rule_engine import Rule
+
+
+class SavingSessionRule(Rule):
+    """When a saving session is active, override the current slot to
+    drain the battery to floor."""
+
+    name = "saving_session"
+    description = "Drain battery to floor during Octoplus saving sessions"
+
+    def apply(self, state: ProgrammeState, inputs: ProgrammeInputs) -> ProgrammeState:
+        if not inputs.saving_session:
+            return state
+
+        local_now = inputs.now_local()
+        try:
+            current_idx = state.find_slot_at(local_now.time())
+        except ValueError:
+            # Programme isn't covering local-now; SafetyRule will fix
+            # the contiguity, but this rule has nothing to do.
+            return state
+
+        slot = state.slots[current_idx]
+        floor = int(inputs.min_soc)
+
+        before = (slot.capacity_soc, slot.grid_charge)
+        slot.capacity_soc = floor
+        slot.grid_charge = False
+        after = (slot.capacity_soc, slot.grid_charge)
+
+        if before != after:
+            state.reason_log.append(
+                f"SavingSession: drain slot {current_idx + 1} "
+                f"({slot.start_time.strftime('%H:%M')}-"
+                f"{slot.end_time.strftime('%H:%M')}) "
+                f"to {floor}% (was cap={before[0]}% gc={before[1]})"
+            )
+        else:
+            state.reason_log.append(
+                f"SavingSession: active but slot {current_idx + 1} "
+                f"already at floor"
+            )
+        return state

--- a/tests/test_rules/test_saving_session.py
+++ b/tests/test_rules/test_saving_session.py
@@ -1,0 +1,146 @@
+# tests/test_rules/test_saving_session.py
+"""Tests for SavingSessionRule (HEO-10)."""
+
+from __future__ import annotations
+
+from datetime import datetime, time, timezone
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from heo2.models import ProgrammeInputs, ProgrammeState, RateSlot, SlotConfig
+from heo2.rules.saving_session import SavingSessionRule
+
+
+def _slot(start_h, start_m, end_h, end_m, soc, gc):
+    return SlotConfig(
+        start_time=time(start_h, start_m),
+        end_time=time(end_h, end_m),
+        capacity_soc=soc,
+        grid_charge=gc,
+    )
+
+
+def _spec_programme():
+    """A programme matching SPEC §5 baseline plus a high-SOC slot 2
+    so we can see SavingSession actually drain it."""
+    return ProgrammeState(slots=[
+        _slot(0, 0, 5, 30, 80, True),
+        _slot(5, 30, 18, 30, 80, False),  # daytime hold high
+        _slot(18, 30, 23, 30, 80, False),  # evening with reserve
+        _slot(23, 30, 23, 55, 80, True),
+        _slot(23, 55, 23, 55, 10, False),
+        _slot(23, 55, 0, 0, 10, False),
+    ], reason_log=[])
+
+
+def _inputs(*, now_utc, saving=False, tz=None):
+    return ProgrammeInputs(
+        now=now_utc,
+        current_soc=80.0,
+        battery_capacity_kwh=20.0,
+        min_soc=10.0,
+        import_rates=[],
+        export_rates=[],
+        solar_forecast_kwh=[0.0] * 24,
+        load_forecast_kwh=[0.5] * 24,
+        igo_dispatching=False,
+        saving_session=saving,
+        saving_session_start=None,
+        saving_session_end=None,
+        ev_charging=False,
+        grid_connected=True,
+        active_appliances=[],
+        appliance_expected_kwh=0.0,
+        local_tz=tz,
+    )
+
+
+class TestSavingSessionRule:
+    def test_inactive_session_is_noop(self):
+        rule = SavingSessionRule()
+        prog = _spec_programme()
+        socs_before = [s.capacity_soc for s in prog.slots]
+        gcs_before = [s.grid_charge for s in prog.slots]
+
+        result = rule.apply(prog, _inputs(
+            now_utc=datetime(2026, 5, 2, 17, 0, tzinfo=timezone.utc),
+            saving=False,
+        ))
+
+        assert [s.capacity_soc for s in result.slots] == socs_before
+        assert [s.grid_charge for s in result.slots] == gcs_before
+        assert not any("SavingSession" in r for r in result.reason_log)
+
+    def test_active_session_drains_current_slot_to_floor(self):
+        """Session at 18:00 BST falls in slot 3 (18:30 BST exclusive
+        end). Set now=17:00 BST = 16:00 UTC, slot 2 active. Slot 2
+        should drain to min_soc=10, gc=False."""
+        rule = SavingSessionRule()
+        prog = _spec_programme()
+        london = ZoneInfo("Europe/London")
+
+        result = rule.apply(prog, _inputs(
+            now_utc=datetime(2026, 5, 2, 16, 0, tzinfo=timezone.utc),  # 17:00 BST
+            saving=True,
+            tz=london,
+        ))
+
+        # Slot 2 (05:30-18:30 BST) is the active local slot at 17:00 BST.
+        assert result.slots[1].capacity_soc == 10
+        assert result.slots[1].grid_charge is False
+        # Other slots preserved
+        assert result.slots[0].capacity_soc == 80  # overnight cheap-charge intact
+        assert result.slots[2].capacity_soc == 80  # evening reserve intact
+        assert any("SavingSession" in r for r in result.reason_log)
+
+    def test_no_local_tz_falls_back_to_now_tzinfo(self):
+        """When local_tz is unset (e.g. a test that doesn't care) the
+        rule still runs against now's own tzinfo. UTC `now` directly
+        feeds the slot lookup."""
+        rule = SavingSessionRule()
+        prog = _spec_programme()
+
+        # 17:00 UTC, no local_tz -> looks up slot containing 17:00.
+        # Slot 2 (05:30-18:30) contains 17:00.
+        result = rule.apply(prog, _inputs(
+            now_utc=datetime(2026, 5, 2, 17, 0, tzinfo=timezone.utc),
+            saving=True,
+            tz=None,
+        ))
+        assert result.slots[1].capacity_soc == 10
+
+    def test_already_at_floor_logs_no_change(self):
+        rule = SavingSessionRule()
+        prog = _spec_programme()
+        prog.slots[1].capacity_soc = 10
+        prog.slots[1].grid_charge = False
+
+        result = rule.apply(prog, _inputs(
+            now_utc=datetime(2026, 5, 2, 16, 0, tzinfo=timezone.utc),
+            saving=True,
+            tz=ZoneInfo("Europe/London"),
+        ))
+        assert result.slots[1].capacity_soc == 10
+        assert any("already at floor" in r for r in result.reason_log)
+
+    def test_overnight_slot_correctly_resolved_through_local_tz(self):
+        """A session at 00:30 BST = 23:30 UTC. Without tz, lookup uses
+        UTC 23:30 which falls in slot 4 (23:30-23:55). With tz, we
+        project to BST 00:30 which falls in slot 1 (00:00-05:30).
+        Verifies the tz path picks slot 1."""
+        rule = SavingSessionRule()
+        prog = _spec_programme()
+        london = ZoneInfo("Europe/London")
+
+        result = rule.apply(prog, _inputs(
+            now_utc=datetime(2026, 5, 2, 23, 30, tzinfo=timezone.utc),
+            saving=True,
+            tz=london,
+        ))
+        # 00:30 BST -> slot 1
+        assert result.slots[0].capacity_soc == 10
+        assert result.slots[0].grid_charge is False
+        # Slot 4 (23:30-23:55 BST) untouched
+        assert result.slots[3].capacity_soc == 80
+        assert result.slots[3].grid_charge is True


### PR DESCRIPTION
## Summary
First slice of PR 3 (rules-redesign roadmap #31). Adds the SPEC §9 row 3 saving-session behaviour the spec already promised: when an Octoplus saving session is active, override the current local-time slot to `capacity_soc=min_soc, grid_charge=False` so the inverter discharges to the floor.

## Why
Pre-HEO-10, `inputs.saving_session` was wired but unused as a price signal. Octoplus pays £3+/kWh during sessions (~£10-50 per session, 10-30/winter). Missing them is direct lost revenue.

## What landed
- New `SavingSessionRule` in `rules/saving_session.py`, registered after ExportWindowRule + EveningProtectRule (saving sessions outweigh both).
- New `local_tz: ZoneInfo | None` field + `now_local()` helper on `ProgrammeInputs` so rules pick the correct slot under DST. Coordinator passes its existing `_local_tz()`.
- 5 new tests in `tests/test_rules/test_saving_session.py` covering: inactive no-op, BST midday slot lookup, no-tz fallback, no-op when already at floor, midnight-BST lookup correctly resolved through tz.

## Dependency
HEO-9 (`saving_session_entity` config currently points at the IGO dispatching binary_sensor instead of `binary_sensor.octopus_energy_..._octoplus_saving_sessions`). Until that's fixed via HA UI, the rule sees `saving_session=False` and stays a no-op. Shipping the rule now means the fix becomes one UI tweak.

## Test plan
- [x] `pytest tests/ --ignore=tests/test_config_flow_dashboard.py -q` -> 385 pass
- [ ] Deploy + verify rule shows up in `sensor.heo_ii_active_rules` attributes
- [ ] After HEO-9 config fix, simulate a saving session via developer-tools and verify the active slot drains

🤖 Generated with [Claude Code](https://claude.com/claude-code)