### PR TITLE
feat(HEO-8): pre-position SOC for planned IGO dispatches

### DIFF
--- a/custom_components/heo2/coordinator.py
+++ b/custom_components/heo2/coordinator.py
@@ -559,6 +559,9 @@ class HEO2Coordinator(DataUpdateCoordinator):
         igo_dispatching = self._read_entity_bool(
             self._config.get("igo_dispatch_entity", ""), default=False
         )
+        planned_dispatches = self._read_planned_dispatches(
+            self._config.get("igo_dispatch_entity", ""),
+        )
         saving_session = self._read_entity_bool(
             self._config.get("saving_session_entity", ""), default=False
         )
@@ -644,7 +647,66 @@ class HEO2Coordinator(DataUpdateCoordinator):
             live_export_rates=live_export_rates,
             solar_forecast_kwh_tomorrow=solar_tomorrow,
             local_tz=self._local_tz(),
+            planned_dispatches=planned_dispatches,
         )
+
+    def _read_planned_dispatches(self, entity_id: str) -> list:
+        """HEO-8: read `planned_dispatches` from the BottlecapDave IGO
+        intelligent_dispatching binary_sensor's attributes.
+
+        BD exposes a list-of-dicts shape:
+          [
+            {"start": "2026-05-02T16:00:00+00:00",
+             "end":   "2026-05-02T17:00:00+00:00",
+             "charge_in_kwh": -7.0,
+             "source": "smart-charge"},
+            ...
+          ]
+        Each entry becomes a `PlannedDispatch`. Missing/malformed
+        entries are skipped silently - the rule treats an empty list
+        as "no upcoming dispatches", which is also the safe fallback
+        when the attribute doesn't exist (older BD versions).
+        """
+        from .models import PlannedDispatch
+        if not entity_id:
+            return []
+        state = self.hass.states.get(entity_id) if self.hass else None
+        if state is None:
+            return []
+        raw = state.attributes.get("planned_dispatches") or []
+        out: list = []
+        for entry in raw:
+            try:
+                start = entry.get("start")
+                end = entry.get("end")
+                if not start or not end:
+                    continue
+                # BD entities return tz-aware ISO strings, but defensively
+                # coerce to datetime if a datetime object slipped through.
+                from datetime import datetime as _dt
+                start_dt = (
+                    start if isinstance(start, _dt)
+                    else _dt.fromisoformat(str(start))
+                )
+                end_dt = (
+                    end if isinstance(end, _dt)
+                    else _dt.fromisoformat(str(end))
+                )
+                charge = entry.get("charge_in_kwh")
+                source = entry.get("source")
+                out.append(PlannedDispatch(
+                    start=start_dt,
+                    end=end_dt,
+                    charge_kwh=float(charge) if charge is not None else None,
+                    source=str(source) if source is not None else None,
+                ))
+            except (ValueError, TypeError, AttributeError):
+                logger.debug(
+                    "HEO-8: skipping malformed planned_dispatches entry %r",
+                    entry,
+                )
+                continue
+        return out
 
     def _read_entity_float(self, entity_id: str, default: float) -> float:
         if not entity_id:

--- a/custom_components/heo2/models.py
+++ b/custom_components/heo2/models.py
@@ -17,6 +17,22 @@ class RateSlot:
 
 
 @dataclass
+class PlannedDispatch:
+    """A planned IGO smart-charge dispatch announced by Octopus.
+
+    Used by HEO-8 to pre-position the battery (gc=True + cap=100) on
+    slots covering the dispatch window so HEO II is at full when
+    Octopus takes control of the EV. Mirrors the BottlecapDave entity's
+    `planned_dispatches` attribute shape.
+    """
+
+    start: datetime
+    end: datetime
+    charge_kwh: Optional[float] = None
+    source: Optional[str] = None
+
+
+@dataclass
 class SlotConfig:
     """One of 6 inverter timer slots."""
     start_time: time
@@ -212,6 +228,12 @@ class ProgrammeInputs:
     # programme slot times MUST go through `now_local()` so a UTC `now`
     # doesn't alias against local-time slots in DST. See HEO-31 PR2 fix.
     local_tz: Optional[ZoneInfo] = None
+    # HEO-8: planned IGO dispatches in the next 24 hours, sourced from
+    # `binary_sensor.octopus_energy_..._intelligent_dispatching.attributes.planned_dispatches`.
+    # Empty list means no upcoming dispatches; the rule treats it as
+    # such and stays a no-op. Defaults preserve backward compatibility
+    # with tests built before HEO-8.
+    planned_dispatches: list["PlannedDispatch"] = field(default_factory=list)
 
     def now_local(self) -> datetime:
         """Return `now` projected into the local timezone if known.

--- a/custom_components/heo2/rules/igo_dispatch.py
+++ b/custom_components/heo2/rules/igo_dispatch.py
@@ -1,38 +1,121 @@
 # custom_components/heo2/rules/igo_dispatch.py
-"""IGODispatchRule — charge battery during IGO dispatch periods."""
+"""IGODispatchRule -- pre-position and ride out IGO smart-charge dispatches.
+
+Two code paths inside one rule:
+
+1. **Active dispatch** (`igo_dispatching=True`): set the slot containing
+   local-now to grid_charge=True + cap=100. This was the original HEO
+   behaviour from before HEO-8.
+
+2. **Planned dispatches** (HEO-8): for every entry in
+   `inputs.planned_dispatches` whose window starts in the next 24h, set
+   every covering programme slot to grid_charge=True + cap=100 so the
+   battery is already at full when Octopus takes control.
+
+The two paths agree on intent (be full + charging during the cheap
+window) so they can both run; the active-dispatch path is a no-op when
+the planned-dispatch path has already pre-positioned the slot.
+"""
 
 from __future__ import annotations
 
-from ..models import ProgrammeState, ProgrammeInputs
+from ..models import PlannedDispatch, ProgrammeInputs, ProgrammeState
 from ..rule_engine import Rule
 
 
-class IGODispatchRule(Rule):
-    """When IGO dispatch is active, enable grid charge and raise SOC target.
-
-    Never drain battery during dispatch — the cheap rate means we should
-    be filling up, not selling.
+def _slot_indices_covering_dispatch(
+    state: ProgrammeState,
+    dispatch: PlannedDispatch,
+    inputs: ProgrammeInputs,
+) -> list[int]:
+    """Return programme slot indices that overlap the dispatch window
+    in local time-of-day. Multi-slot dispatches collect every covering
+    slot index. A dispatch fully in tomorrow returns no indices for
+    today's programme; a dispatch crossing midnight returns indices
+    for both halves.
     """
+    tz = inputs.local_tz
+    if tz is not None:
+        start_local = (
+            dispatch.start.astimezone(tz)
+            if dispatch.start.tzinfo is not None
+            else dispatch.start
+        )
+        end_local = (
+            dispatch.end.astimezone(tz)
+            if dispatch.end.tzinfo is not None
+            else dispatch.end
+        )
+    else:
+        start_local = dispatch.start
+        end_local = dispatch.end
+
+    # Sample every 15 min between start and end, mark each slot that
+    # contains the sample. 15 min granularity is finer than any inverter
+    # boundary HEO II writes (5-min). Avoids hand-rolling overlap maths
+    # for the wrap-midnight case.
+    from datetime import timedelta
+    indices: set[int] = set()
+    cursor = start_local
+    while cursor < end_local:
+        try:
+            idx = state.find_slot_at(cursor.time())
+            indices.add(idx)
+        except ValueError:
+            pass
+        cursor += timedelta(minutes=15)
+    return sorted(indices)
+
+
+class IGODispatchRule(Rule):
+    """Enable grid charge + cap=100 around IGO dispatches (active and planned)."""
 
     name = "igo_dispatch"
     description = "Enable grid charge during IGO dispatch"
 
     def apply(self, state: ProgrammeState, inputs: ProgrammeInputs) -> ProgrammeState:
-        if not inputs.igo_dispatching:
-            return state
+        modified_log: list[str] = []
 
-        now_time = inputs.now.time().replace(second=0, microsecond=0)
-        try:
-            idx = state.find_slot_at(now_time)
-        except ValueError:
-            return state
+        # Path 1: planned dispatches (HEO-8). Pre-position covering slots.
+        if inputs.planned_dispatches:
+            now = inputs.now
+            from datetime import timedelta
+            horizon_end = now + timedelta(hours=24)
+            covered_slot_idxs: set[int] = set()
+            for d in inputs.planned_dispatches:
+                if d.end <= now or d.start >= horizon_end:
+                    continue
+                for idx in _slot_indices_covering_dispatch(state, d, inputs):
+                    covered_slot_idxs.add(idx)
 
-        slot = state.slots[idx]
-        slot.grid_charge = True
-        slot.capacity_soc = max(slot.capacity_soc, int(inputs.current_soc), 100)
+            for idx in sorted(covered_slot_idxs):
+                slot = state.slots[idx]
+                if not slot.grid_charge or slot.capacity_soc < 100:
+                    slot.grid_charge = True
+                    slot.capacity_soc = 100
+                    modified_log.append(
+                        f"slot {idx + 1} pre-positioned for planned dispatch"
+                    )
 
-        state.reason_log.append(
-            f"IGODispatch: slot {idx + 1} grid charge enabled, "
-            f"SOC target {slot.capacity_soc}%"
-        )
+        # Path 2: in-progress dispatch. Force the active slot to gc=True
+        # + cap=100 even if planned_dispatches is empty (e.g. older BD
+        # versions that don't expose the attribute).
+        if inputs.igo_dispatching:
+            try:
+                local_now = inputs.now_local()
+                idx = state.find_slot_at(local_now.time())
+            except ValueError:
+                idx = None
+            if idx is not None:
+                slot = state.slots[idx]
+                slot.grid_charge = True
+                slot.capacity_soc = max(slot.capacity_soc, 100)
+                modified_log.append(
+                    f"slot {idx + 1} active dispatch (cap={slot.capacity_soc}%)"
+                )
+
+        if modified_log:
+            state.reason_log.append(
+                f"IGODispatch: {'; '.join(modified_log)}"
+            )
         return state

--- a/tests/test_rules/test_igo_dispatch.py
+++ b/tests/test_rules/test_igo_dispatch.py
@@ -49,3 +49,126 @@ class TestIGODispatchRule:
         rule = IGODispatchRule()
         result = rule.apply(state, default_inputs)
         assert any("IGODispatch" in r for r in result.reason_log)
+
+
+class TestIGODispatchPlannedDispatches:
+    """HEO-8: pre-position covering slots when planned_dispatches has
+    entries, even with igo_dispatching=False.
+    """
+
+    def test_planned_dispatch_pre_positions_covering_slot(
+        self, default_inputs,
+    ):
+        """A planned dispatch from 14:00-15:00 UTC falls inside slot 2
+        (05:30-18:30) of the default programme (UTC, no tz). The slot
+        should be set to grid_charge=True + cap=100."""
+        from datetime import datetime, timezone, timedelta
+        from heo2.models import PlannedDispatch
+        # default_inputs.now is 12:00 UTC; dispatch in 2h
+        dispatch_start = datetime(2026, 4, 13, 14, 0, tzinfo=timezone.utc)
+        dispatch_end = dispatch_start + timedelta(hours=1)
+        default_inputs.planned_dispatches = [PlannedDispatch(
+            start=dispatch_start,
+            end=dispatch_end,
+            charge_kwh=-7.0,
+            source="smart-charge",
+        )]
+        default_inputs.igo_dispatching = False
+
+        state = _make_baseline(default_inputs)
+        rule = IGODispatchRule()
+        result = rule.apply(state, default_inputs)
+
+        from datetime import time
+        idx = result.find_slot_at(time(14, 0))
+        assert result.slots[idx].grid_charge is True
+        assert result.slots[idx].capacity_soc == 100
+        assert any("IGODispatch" in r for r in result.reason_log)
+        assert any("planned" in r for r in result.reason_log)
+
+    def test_planned_dispatch_outside_24h_horizon_ignored(
+        self, default_inputs,
+    ):
+        """Dispatch tomorrow afternoon (>24h) shouldn't pre-position
+        anything today. The rule's horizon is 24h."""
+        from datetime import timedelta
+        from heo2.models import PlannedDispatch
+        future = default_inputs.now + timedelta(hours=48)
+        default_inputs.planned_dispatches = [PlannedDispatch(
+            start=future,
+            end=future + timedelta(hours=1),
+        )]
+        default_inputs.igo_dispatching = False
+        state = _make_baseline(default_inputs)
+        grid_before = [s.grid_charge for s in state.slots]
+        socs_before = [s.capacity_soc for s in state.slots]
+        rule = IGODispatchRule()
+        result = rule.apply(state, default_inputs)
+        assert [s.grid_charge for s in result.slots] == grid_before
+        assert [s.capacity_soc for s in result.slots] == socs_before
+
+    def test_already_started_dispatch_still_pre_positions_remaining_window(
+        self, default_inputs,
+    ):
+        """A dispatch that started 30 min ago and runs another 30 min:
+        we should still set the covering slot to gc=True + cap=100,
+        because we're inside the cheap window right now."""
+        from datetime import timedelta
+        from heo2.models import PlannedDispatch
+        start = default_inputs.now - timedelta(minutes=30)
+        end = default_inputs.now + timedelta(minutes=30)
+        default_inputs.planned_dispatches = [PlannedDispatch(
+            start=start, end=end,
+        )]
+        default_inputs.igo_dispatching = True  # active too
+        state = _make_baseline(default_inputs)
+        rule = IGODispatchRule()
+        result = rule.apply(state, default_inputs)
+        from datetime import time
+        idx = result.find_slot_at(time(12, 0))
+        assert result.slots[idx].grid_charge is True
+        assert result.slots[idx].capacity_soc == 100
+
+    def test_multiple_planned_dispatches_collect_all_covering_slots(
+        self, default_inputs,
+    ):
+        """Two dispatches - one covers slot 2, one covers slot 3.
+        Both slots should be pre-positioned."""
+        from datetime import datetime, timezone, timedelta
+        from heo2.models import PlannedDispatch
+        d1 = PlannedDispatch(
+            start=datetime(2026, 4, 13, 14, 0, tzinfo=timezone.utc),
+            end=datetime(2026, 4, 13, 15, 0, tzinfo=timezone.utc),
+        )
+        # Slot 3 of default programme is 16:00-23:59 (insert_boundary
+        # not used, so default boundaries).
+        d2 = PlannedDispatch(
+            start=datetime(2026, 4, 13, 19, 0, tzinfo=timezone.utc),
+            end=datetime(2026, 4, 13, 20, 0, tzinfo=timezone.utc),
+        )
+        default_inputs.planned_dispatches = [d1, d2]
+        default_inputs.igo_dispatching = False
+        state = _make_baseline(default_inputs)
+        rule = IGODispatchRule()
+        result = rule.apply(state, default_inputs)
+        from datetime import time
+        idx1 = result.find_slot_at(time(14, 0))
+        idx2 = result.find_slot_at(time(19, 0))
+        # Different slots; both pre-positioned
+        assert result.slots[idx1].grid_charge is True
+        assert result.slots[idx1].capacity_soc == 100
+        assert result.slots[idx2].grid_charge is True
+        assert result.slots[idx2].capacity_soc == 100
+
+    def test_empty_planned_dispatches_is_noop(self, default_inputs):
+        """Empty planned_dispatches list with no active dispatch leaves
+        the programme unchanged."""
+        default_inputs.planned_dispatches = []
+        default_inputs.igo_dispatching = False
+        state = _make_baseline(default_inputs)
+        grid_before = [s.grid_charge for s in state.slots]
+        socs_before = [s.capacity_soc for s in state.slots]
+        rule = IGODispatchRule()
+        result = rule.apply(state, default_inputs)
+        assert [s.grid_charge for s in result.slots] == grid_before
+        assert [s.capacity_soc for s in result.slots] == socs_before


### PR DESCRIPTION
## Summary
Second slice of PR 3 (#31). Extends `IGODispatchRule` to consume BottlecapDave's `planned_dispatches` attribute so HEO II pre-positions the battery (gc=True + cap=100) on slots covering upcoming dispatches, rather than only reacting once the dispatch has already started.

## Why
Pre-HEO-8 the rule only fired on `igo_dispatching=True`. By then the slot covering the dispatch may have been left at min_soc, and the inverter would be discharging instead of charging during the cheap window. Issue #8: "HEO II could plan future slots to maximise SOC before each scheduled dispatch."

## What landed
- `PlannedDispatch` dataclass in `models.py`.
- `ProgrammeInputs.planned_dispatches` (default empty - backward-compat).
- `_read_planned_dispatches` in coordinator parses BD's ISO-string list-of-dicts attribute.
- `IGODispatchRule` adds the planned-dispatch path. 15-min sampling covers multi-slot dispatches and wrap-midnight cases without bespoke overlap maths.
- 5 new tests in `tests/test_rules/test_igo_dispatch.py` covering single-dispatch pre-position, >24h horizon ignore, in-progress + planned combo, multi-dispatch collection, empty-list no-op.

## Test plan
- [x] `pytest tests/ --ignore=tests/test_config_flow_dashboard.py -q` -> 390 pass
- [ ] Deploy + verify `IGODispatchRule` activates ahead of next IGO dispatch
- [ ] When a dispatch is scheduled, check `sensor.heo_ii_programme_reason` for "planned dispatch" entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)