### PR TITLE
fix(projection): IGO smart-charge windows are off-peak retroactively

### DIFF
--- a/custom_components/heo2/coordinator.py
+++ b/custom_components/heo2/coordinator.py
@@ -20,6 +20,7 @@ from .const import (
     DEFAULT_REPLAN_LOAD_PCT,
     DEFAULT_REPLAN_SOC_PCT,
     DEFAULT_PEAK_THRESHOLD_PENCE,
+    DEFAULT_IGO_OFF_PEAK_PENCE,
     DEFAULT_SELL_TOP_PCT,
     DEFAULT_CHEAP_CHARGE_BOTTOM_PCT,
     DEFAULT_MAX_CHARGE_KW,
@@ -254,6 +255,9 @@ class HEO2Coordinator(DataUpdateCoordinator):
             charge_efficiency=self._charge_efficiency,
             discharge_efficiency=self._discharge_efficiency,
             tz=tz,
+            igo_off_peak_p=self._config.get(
+                "igo_night_rate", DEFAULT_IGO_OFF_PEAK_PENCE,
+            ),
         )
         self._validation_warnings = validation.warnings
         self._last_projection = validation.projection

--- a/custom_components/heo2/plan_validator.py
+++ b/custom_components/heo2/plan_validator.py
@@ -218,6 +218,7 @@ def validate_plan(
     charge_efficiency: float = 0.95,
     discharge_efficiency: float = 0.95,
     tz: ZoneInfo | None = None,
+    igo_off_peak_p: float = 4.95,
 ) -> ValidationResult:
     """Run all SPEC §6 pre-write checks and a 24-hour projection.
 
@@ -254,6 +255,7 @@ def validate_plan(
         discharge_efficiency=discharge_efficiency,
         peak_threshold_p=peak_threshold_p,
         tz=tz,
+        igo_off_peak_p=igo_off_peak_p,
     )
 
     if projection.peak_import_kwh > 0.001:

--- a/custom_components/heo2/projection.py
+++ b/custom_components/heo2/projection.py
@@ -136,6 +136,24 @@ def _top_export_window_starts(
     return {r.start for r in ordered[:count]}
 
 
+def _step_in_planned_dispatch(
+    step_start: datetime, dispatches: list,
+) -> bool:
+    """True if any planned IGO dispatch covers this 30-min step start.
+
+    Used to override the published import rate with the IGO off-peak
+    price during smart-charge windows: Octopus retroactively bills
+    those imports at the cheap rate even though the live rate sensor
+    shows the day rate at the moment of import.
+    """
+    if not dispatches:
+        return False
+    for d in dispatches:
+        if d.start <= step_start < d.end:
+            return True
+    return False
+
+
 def project_day(
     programme: ProgrammeState,
     inputs: ProgrammeInputs,
@@ -150,6 +168,7 @@ def project_day(
     replacement_cost_p: float = 4.95,
     horizon_hours: int = 24,
     tz: ZoneInfo | None = None,
+    igo_off_peak_p: float = 4.95,
 ) -> Projection:
     """Forward-simulate the next `horizon_hours` and return a Projection.
 
@@ -202,6 +221,15 @@ def project_day(
         exp = _rate_at(inputs.export_rates, step_start)
         imp_p = imp.rate_pence if imp is not None else 0.0
         exp_p = exp.rate_pence if exp is not None else 0.0
+
+        # IGO smart-charge windows: Octopus retroactively re-bills any
+        # import landing inside a planned dispatch at the IGO off-peak
+        # rate, regardless of what the published live-rate sensor said
+        # at the moment of import. Reflect that in the projection so we
+        # don't false-alarm on "peak-rate import" when the EV is on
+        # a smart charge.
+        if _step_in_planned_dispatch(step_start, inputs.planned_dispatches):
+            imp_p = igo_off_peak_p
 
         # Solar / load at this step. Forecasts are hourly; pro-rate to 30 min.
         hour_idx = step_local.hour

--- a/tests/test_projection.py
+++ b/tests/test_projection.py
@@ -179,6 +179,51 @@ class TestProjectDay:
         assert p.peak_import_kwh == pytest.approx(p.imports_kwh, abs=0.5)
         assert p.peak_import_kwh > 20.0
 
+    def test_planned_dispatch_overrides_published_rate_to_off_peak(self):
+        """Octopus retroactively bills any import inside a smart-charge
+        dispatch at the IGO off-peak rate, regardless of what the
+        published live-rate sensor said at the moment of import. The
+        projection must reflect this so it doesn't false-alarm on
+        peak-rate import while the EV is being smart-charged.
+        """
+        from datetime import timedelta as _td
+        from heo2.models import PlannedDispatch
+        prog = ProgrammeState(slots=[
+            _slot(0, 0, 4, 0, 100, True),
+            _slot(4, 0, 8, 0, 10, False),
+            _slot(8, 0, 12, 0, 10, False),
+            _slot(12, 0, 16, 0, 10, False),
+            _slot(16, 0, 20, 0, 10, False),
+            _slot(20, 0, 0, 0, 10, False),
+        ])
+        midnight = datetime(2026, 5, 1, 0, 0, tzinfo=timezone.utc)
+        # All-day 25p (above peak threshold). Without the dispatch
+        # override, slot 1's grid_charge=True window books at 25p.
+        # With the override it books at the off-peak 4.95p.
+        inputs = _inputs_at_midnight(
+            current_soc=10.0,
+            import_rates=_half_hour_rates(midnight, 24, 25.0),
+            load_24=[0.0] * 24,
+        )
+        # Dispatch covers the whole 00:00-04:00 charge window
+        inputs.planned_dispatches = [PlannedDispatch(
+            start=midnight,
+            end=midnight + _td(hours=4),
+        )]
+
+        p = project_day(
+            prog, inputs,
+            battery_capacity_kwh=20.0,
+            peak_threshold_p=24.0,
+            igo_off_peak_p=4.95,
+        )
+        # All imports during the dispatch window -> none should land
+        # in peak_import_kwh.
+        assert p.peak_import_kwh == pytest.approx(0.0, abs=0.01)
+        # imports_avg should reflect the off-peak rate.
+        assert p.imports_avg_pence is not None
+        assert p.imports_avg_pence == pytest.approx(4.95, abs=0.5)
+
     def test_top_export_window_drains_battery_to_grid(self):
         """When SOC is high and export rate is in top-N% with capacity_soc
         below current SOC, projection sells to grid."""


### PR DESCRIPTION
## Summary
The H5 'X kWh peak-rate import' warning was firing during planned IGO smart-charge windows because the projection used the published live rate (28.58p day rate) instead of the off-peak rate Octopus actually bills (~4.95p).

Fix: in `project_day`, when a 30-min step falls inside any `planned_dispatches` entry, override the import rate to `igo_off_peak_p` (default 4.95p, plumbed from coordinator config). The override flows through both cost accounting and peak-import classification.

## Test plan
- [x] Full suite -> 391 pass
- [x] New regression test asserts `peak_import_kwh==0` + `imports_avg~=4.95` when a charge window sits inside a dispatch with 25p published rate
- [ ] Deploy + watch next tick: projection summary should drop the peak-import figure when EV is being smart-charged

🤖 Generated with [Claude Code](https://claude.com/claude-code)