### PR TITLE
feat(safety): surface 5-min granularity snaps as a dedicated sensor

### DIFF
--- a/custom_components/heo2/coordinator.py
+++ b/custom_components/heo2/coordinator.py
@@ -1057,3 +1057,18 @@ class HEO2Coordinator(DataUpdateCoordinator):
     @property
     def validation_warnings(self) -> list[str]:
         return list(self._validation_warnings)
+
+    @property
+    def granularity_snaps(self) -> list[str]:
+        """Latest tick's 5-min Sunsynk granularity snaps applied by
+        SafetyRule. Pulled from the current programme's reason_log so
+        the coordinator doesn't need its own bookkeeping field. Empty
+        when the rule engine produced boundaries already on 5-min."""
+        prog = self.current_programme
+        if prog is None:
+            return []
+        prefix = "GranularitySnap: "
+        for entry in reversed(prog.reason_log):
+            if entry.startswith(prefix):
+                return [s.strip() for s in entry[len(prefix):].split(";")]
+        return []

--- a/custom_components/heo2/rules/safety.py
+++ b/custom_components/heo2/rules/safety.py
@@ -56,6 +56,7 @@ class SafetyRule(Rule):
     def apply(self, state: ProgrammeState, inputs: ProgrammeInputs) -> ProgrammeState:
         min_soc = int(inputs.min_soc)
         fixes: list[str] = []
+        snaps: list[str] = []  # 5-min granularity snaps surfaced separately
 
         # Fix slot count if wrong
         if len(state.slots) != 6:
@@ -74,18 +75,26 @@ class SafetyRule(Rule):
         # Snap every boundary to Sunsynk's 5-min granularity. Doing this
         # before the contiguous fix-up below means any boundary the rule
         # engine produced like 23:57 collapses to 23:55, both for that
-        # slot's start and the previous slot's end.
+        # slot's start and the previous slot's end. Snaps are surfaced
+        # in a dedicated `GranularitySnap:` reason_log entry so a
+        # dashboard sensor can show them separately from generic safety
+        # fixes (the snap is expected behaviour, not a fault).
         for i, slot in enumerate(state.slots):
             snapped_start = _snap_to_granularity(slot.start_time)
             if snapped_start != slot.start_time:
-                fixes.append(
-                    f"Slot {i + 1}: snapped start "
+                snaps.append(
+                    f"slot {i + 1} start "
                     f"{slot.start_time.strftime('%H:%M')}→"
-                    f"{snapped_start.strftime('%H:%M')} (5-min granularity)"
+                    f"{snapped_start.strftime('%H:%M')}"
                 )
                 slot.start_time = snapped_start
             snapped_end = _snap_to_granularity(slot.end_time)
             if snapped_end != slot.end_time:
+                snaps.append(
+                    f"slot {i + 1} end "
+                    f"{slot.end_time.strftime('%H:%M')}→"
+                    f"{snapped_end.strftime('%H:%M')}"
+                )
                 slot.end_time = snapped_end
 
         # Ensure slot 1 starts at 00:00
@@ -110,5 +119,7 @@ class SafetyRule(Rule):
 
         if fixes:
             state.reason_log.append(f"Safety: {'; '.join(fixes)}")
+        if snaps:
+            state.reason_log.append(f"GranularitySnap: {'; '.join(snaps)}")
 
         return state

--- a/custom_components/heo2/sensor.py
+++ b/custom_components/heo2/sensor.py
@@ -44,6 +44,7 @@ async def async_setup_entry(
     entities.append(ProgrammeReasonSensor(coordinator, entry))
     entities.append(ActiveRulesSensor(coordinator, entry))
     entities.append(ProjectionTodaySensor(coordinator, entry))
+    entities.append(GranularitySnapSensor(coordinator, entry))
 
     # Dashboard sensors (Group 2: Cost Accumulator)
     entities.append(DailyImportCostSensor(coordinator, entry))
@@ -489,6 +490,30 @@ class ProjectionTodaySensor(CoordinatorEntity, SensorEntity):
             "peak_import_kwh": round(p.peak_import_kwh, 2),
             "warnings": self.coordinator.validation_warnings,
         }
+
+
+class GranularitySnapSensor(CoordinatorEntity, SensorEntity):
+    """Surfaces the 5-min Sunsynk timer-granularity snaps applied by
+    SafetyRule on the latest tick. Native value is the count; the
+    `snaps` attribute is the list of `slot N <start|end> HH:MM->HH:MM`
+    strings. A non-zero value isn't a fault - it's a transparent record
+    that the rule engine produced a boundary the hardware couldn't
+    store exactly. Useful when chasing 'why did the inverter store a
+    different time than I sent' questions.
+    """
+
+    def __init__(self, coordinator: HEO2Coordinator, entry: ConfigEntry):
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{entry.entry_id}_granularity_snaps"
+        self._attr_name = "HEO II Granularity Snaps"
+
+    @property
+    def native_value(self) -> int:
+        return len(self.coordinator.granularity_snaps)
+
+    @property
+    def extra_state_attributes(self) -> dict:
+        return {"snaps": self.coordinator.granularity_snaps}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Splits the 5-min Sunsynk granularity snap out of the generic `Safety:` reason_log entry into its own `GranularitySnap:` line, and adds `sensor.heo_ii_granularity_snaps` (count as native value, per-slot strings as `snaps` attribute) so the dashboard can show what got floored.

## Why
The snap is expected behaviour, not a fault. Burying it inside `Safety: ...` made it look like a violation and made post-incident questions ('why did the inverter store 23:55?') harder to answer.

## Test plan
- [x] 391 tests pass
- [ ] Deploy + check `sensor.heo_ii_granularity_snaps` in HA - should show the count of snapped boundaries plus the strings