### PR TITLE
feat(HEO-11): SPEC §10 rule knobs editable via OptionsFlow

### DIFF
--- a/custom_components/heo2/config_flow.py
+++ b/custom_components/heo2/config_flow.py
@@ -182,11 +182,11 @@ class HEO2ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         )
 
 
-# Fields shown in the OptionsFlow. Limited to entity wiring (HEO-9
-# motivating use case) plus dry_run, which is the other knob users
-# want to flip post-setup. Everything else (battery, tariff, payback)
-# rarely changes and stays in the initial setup wizard.
-_OPTIONS_FIELDS = (
+# Fields shown in the OptionsFlow. Entity wiring (HEO-9 motivating
+# use case), dry_run, and the SPEC §10 tunable rule knobs (HEO-11).
+# Battery / tariff / payback rarely change and stay in the initial
+# setup wizard.
+_OPTIONS_ENTITY_FIELDS = (
     "soc_entity",
     "load_power_entity",
     "pv_power_entity",
@@ -196,7 +196,18 @@ _OPTIONS_FIELDS = (
     "tapo_wash_entity",
     "tapo_dryer_entity",
     "tapo_dishwasher_entity",
-    "dry_run",
+)
+
+# (key, default, type) - SPEC §10 rule knobs
+_OPTIONS_RULE_KNOBS = (
+    ("peak_threshold_p", 24.0, float),
+    ("max_target_soc", 100, int),
+    ("daily_plan_time", "18:00", str),
+    ("replan_solar_pct", 25, int),
+    ("replan_load_pct", 25, int),
+    ("replan_soc_pct", 10, int),
+    ("sell_top_pct_default", 30, int),
+    ("cheap_charge_bottom_pct", 25, int),
 )
 
 
@@ -223,16 +234,39 @@ class HEO2OptionsFlow(config_entries.OptionsFlow):
             }
             return self.async_create_entry(title="", data=cleaned)
 
-        # Pre-fill from existing options first, then data. dry_run
-        # default mirrors the services step (True for safety).
+        # Pre-fill from existing options first, then data.
         merged = {**self.config_entry.data, **self.config_entry.options}
         schema_dict: dict = {}
-        for key in _OPTIONS_FIELDS:
-            current = merged.get(key, "" if key != "dry_run" else True)
-            if key == "dry_run":
-                schema_dict[vol.Required(key, default=bool(current))] = bool
-            else:
-                schema_dict[vol.Optional(key, default=str(current))] = str
+
+        # Entity wiring fields (always strings)
+        for key in _OPTIONS_ENTITY_FIELDS:
+            schema_dict[vol.Optional(
+                key, default=str(merged.get(key, "")),
+            )] = str
+
+        # dry_run flag (always shown)
+        schema_dict[vol.Required(
+            "dry_run", default=bool(merged.get("dry_run", True)),
+        )] = bool
+
+        # SPEC §10 rule knobs (HEO-11). Coerce to the declared type at
+        # save time so the coordinator's `_cfg_float`/`_cfg_int` can
+        # parse them. Pre-fill with the user's current value or the
+        # SPEC default.
+        for key, default, kind in _OPTIONS_RULE_KNOBS:
+            current = merged.get(key, default)
+            if kind is float:
+                schema_dict[vol.Optional(
+                    key, default=float(current),
+                )] = vol.Coerce(float)
+            elif kind is int:
+                schema_dict[vol.Optional(
+                    key, default=int(current),
+                )] = vol.Coerce(int)
+            else:  # str (e.g. daily_plan_time = "HH:MM")
+                schema_dict[vol.Optional(
+                    key, default=str(current),
+                )] = str
 
         return self.async_show_form(
             step_id="init",

--- a/custom_components/heo2/coordinator.py
+++ b/custom_components/heo2/coordinator.py
@@ -146,29 +146,10 @@ class HEO2Coordinator(DataUpdateCoordinator):
         # actively pushed (never the lazy seed).
         self._pending_verification: ProgrammeState | None = None
 
-        # SPEC §10 tunable knobs. Defaults match the SPEC table; any
-        # of these will become HA UI number entities under HEO-11.
-        self._daily_plan_time: time = self._parse_time_config(
-            "daily_plan_time", DEFAULT_DAILY_PLAN_TIME,
-        )
-        self._replan_solar_pct: float = self._config.get(
-            "replan_solar_pct", DEFAULT_REPLAN_SOLAR_PCT,
-        )
-        self._replan_load_pct: float = self._config.get(
-            "replan_load_pct", DEFAULT_REPLAN_LOAD_PCT,
-        )
-        self._replan_soc_pct: float = self._config.get(
-            "replan_soc_pct", DEFAULT_REPLAN_SOC_PCT,
-        )
-        self._peak_threshold_p: float = self._config.get(
-            "peak_threshold_p", DEFAULT_PEAK_THRESHOLD_PENCE,
-        )
-        self._sell_top_pct_default: int = self._config.get(
-            "sell_top_pct_default", DEFAULT_SELL_TOP_PCT,
-        )
-        self._cheap_bottom_pct: int = self._config.get(
-            "cheap_charge_bottom_pct", DEFAULT_CHEAP_CHARGE_BOTTOM_PCT,
-        )
+        # SPEC §10 tunable knobs. Read fresh from `_config` each tick
+        # via the `_pcfg`/`_icfg` helpers below so the OptionsFlow
+        # update_listener path takes effect on the next tick - no
+        # restart needed. Defaults match the SPEC table.
         self._max_charge_kw: float = self._config.get(
             "max_charge_kw", DEFAULT_MAX_CHARGE_KW,
         )
@@ -228,10 +209,12 @@ class HEO2Coordinator(DataUpdateCoordinator):
             inputs=inputs,
             baseline=self._baseline,
             tz=tz,
-            daily_plan_time=self._daily_plan_time,
-            replan_solar_pct=self._replan_solar_pct,
-            replan_load_pct=self._replan_load_pct,
-            replan_soc_pct=self._replan_soc_pct,
+            daily_plan_time=self._parse_time_config(
+                "daily_plan_time", DEFAULT_DAILY_PLAN_TIME,
+            ),
+            replan_solar_pct=self._cfg_float("replan_solar_pct", DEFAULT_REPLAN_SOLAR_PCT),
+            replan_load_pct=self._cfg_float("replan_load_pct", DEFAULT_REPLAN_LOAD_PCT),
+            replan_soc_pct=self._cfg_float("replan_soc_pct", DEFAULT_REPLAN_SOC_PCT),
         )
         is_daily_plan = "daily plan" in decision.reason
 
@@ -248,8 +231,8 @@ class HEO2Coordinator(DataUpdateCoordinator):
         # rejection reason.
         validation = validate_plan(
             effective, inputs,
-            peak_threshold_p=self._peak_threshold_p,
-            cheap_bottom_pct=self._cheap_bottom_pct,
+            peak_threshold_p=self._cfg_float("peak_threshold_p", DEFAULT_PEAK_THRESHOLD_PENCE),
+            cheap_bottom_pct=self._cfg_int("cheap_charge_bottom_pct", DEFAULT_CHEAP_CHARGE_BOTTOM_PCT),
             max_charge_kw=self._max_charge_kw,
             max_discharge_kw=self._max_discharge_kw,
             charge_efficiency=self._charge_efficiency,
@@ -328,6 +311,22 @@ class HEO2Coordinator(DataUpdateCoordinator):
 
         flat_rate = self._config.get("flat_rate_pence", DEFAULT_FLAT_RATE_PENCE)
         self.cost_accumulator.calculate_savings_vs_flat(flat_rate)
+
+    def _cfg_float(self, key: str, default: float) -> float:
+        """Read a runtime-tunable knob from `_config` as float. Read
+        each tick rather than cached at __init__, so OptionsFlow
+        changes take effect on the next tick (HEO-11)."""
+        try:
+            return float(self._config.get(key, default))
+        except (TypeError, ValueError):
+            return float(default)
+
+    def _cfg_int(self, key: str, default: int) -> int:
+        """Same as _cfg_float but coerces to int."""
+        try:
+            return int(self._config.get(key, default))
+        except (TypeError, ValueError):
+            return int(default)
 
     def _local_tz(self):
         """Resolve HA's local timezone, defaulting to UTC."""


### PR DESCRIPTION
## Summary
Extends the HEO-9 OptionsFlow with 8 runtime-tunable knobs from SPEC §10: peak_threshold_p, max_target_soc, daily_plan_time, replan_solar/load/soc_pct, sell_top_pct_default, cheap_charge_bottom_pct.

Coordinator drops the cached `self._peak_threshold_p` etc. in favour of `_cfg_float(key, default)` / `_cfg_int(...)` helpers that re-read each tick. OptionsFlow save -> add_update_listener reload -> next tick picks up the new value. No HA restart needed.

## Test plan
- [x] 391 tests pass
- [ ] Deploy + open Configure -> verify the new fields appear with current values pre-filled
- [ ] Tweak `replan_soc_pct` from 10 to 20, save, watch next tick log to confirm the new threshold takes effect