### PR TITLE
feat: SPEC §9 / H3 EPS / power-failure mode

### DIFF
--- a/custom_components/heo2/binary_sensor.py
+++ b/custom_components/heo2/binary_sensor.py
@@ -25,6 +25,7 @@ async def async_setup_entry(
     async_add_entities([
         HealthySensor(coordinator, entry),
         WritesBlockedSensor(coordinator, entry),
+        EPSActiveSensor(coordinator, entry),
     ])
 
 
@@ -65,3 +66,21 @@ class WritesBlockedSensor(CoordinatorEntity, BinarySensorEntity):
         return {
             "reason": self.coordinator.writes_blocked_reason or "writes enabled",
         }
+
+
+class EPSActiveSensor(CoordinatorEntity, BinarySensorEntity):
+    """SPEC §9 / H3 dashboard banner: ON when the grid is down and the
+    inverter is supplying the house from EPS / battery. While active:
+    SOC floor relaxes to 0%, EV/washer/dryer/dishwasher get
+    switch.turn_off, MQTT writes are suppressed.
+    """
+    _attr_device_class = BinarySensorDeviceClass.PROBLEM
+
+    def __init__(self, coordinator: HEO2Coordinator, entry: ConfigEntry):
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{entry.entry_id}_eps_active"
+        self._attr_name = "HEO II EPS Active"
+
+    @property
+    def is_on(self) -> bool:
+        return self.coordinator.eps_active

--- a/custom_components/heo2/coordinator.py
+++ b/custom_components/heo2/coordinator.py
@@ -145,6 +145,10 @@ class HEO2Coordinator(DataUpdateCoordinator):
         # verify completes. Only ever holds a programme that we
         # actively pushed (never the lazy seed).
         self._pending_verification: ProgrammeState | None = None
+        # SPEC §9 / H3 EPS mode. Tracked so we can fire appliance
+        # shutoffs once on the False -> True transition rather than
+        # spamming switch.turn_off every tick.
+        self._eps_active: bool = False
 
         # SPEC §10 tunable knobs. Read fresh from `_config` each tick
         # via the `_pcfg`/`_icfg` helpers below so the OptionsFlow
@@ -568,6 +572,12 @@ class HEO2Coordinator(DataUpdateCoordinator):
         planned_dispatches = self._read_planned_dispatches(
             self._config.get("igo_dispatch_entity", ""),
         )
+        eps_active = self._read_eps_active()
+        if eps_active and not self._eps_active:
+            # Transition: just lost grid. Fire appliance shutoffs
+            # once. Guarded so we don't spam the service every tick.
+            await self._eps_shutdown_appliances()
+        self._eps_active = eps_active
         saving_session = self._read_entity_bool(
             self._config.get("saving_session_entity", ""), default=False
         )
@@ -646,7 +656,7 @@ class HEO2Coordinator(DataUpdateCoordinator):
             saving_session_start=None,
             saving_session_end=None,
             ev_charging=ev_charging,
-            grid_connected=True,
+            grid_connected=not eps_active,
             active_appliances=[],
             appliance_expected_kwh=0.0,
             live_import_rates=live_import_rates,
@@ -654,7 +664,66 @@ class HEO2Coordinator(DataUpdateCoordinator):
             solar_forecast_kwh_tomorrow=solar_tomorrow,
             local_tz=self._local_tz(),
             planned_dispatches=planned_dispatches,
+            eps_active=eps_active,
         )
+
+    def _read_eps_active(self) -> bool:
+        """SPEC §9 / H3: detect EPS / power failure.
+
+        Two ways the user can wire this:
+          1. `eps_entity`: a binary_sensor that's `on` when EPS is
+             active. Cleanest if their inverter exposes one.
+          2. `grid_voltage_entity`: a numeric V sensor; treated as
+             EPS-active when value <= `eps_voltage_threshold` (default
+             50V, well below mains 230V).
+
+        Either route returns False when not configured or unparseable,
+        so EPS stays off-by-default for setups that haven't wired the
+        signal yet.
+        """
+        eps_entity = self._config.get("eps_entity", "")
+        if eps_entity:
+            return self._read_entity_bool(eps_entity, default=False)
+
+        gv_entity = self._config.get("grid_voltage_entity", "")
+        if not gv_entity:
+            return False
+        threshold = self._cfg_float("eps_voltage_threshold", 50.0)
+        v = self._read_entity_float(gv_entity, default=-1.0)
+        if v < 0:
+            return False  # unavailable / unparseable - assume grid up
+        return v <= threshold
+
+    async def _eps_shutdown_appliances(self) -> None:
+        """SPEC H3: kill EV / washer / dryer / dishwasher when EPS goes
+        active so the EPS-supplied loop isn't dragged down by 7kW Tesla
+        + 2kW washer + 2.5kW dryer. One-shot per transition.
+        """
+        targets = [
+            self._config.get(k, "")
+            for k in (
+                "ev_status_entity",  # Tesla / EV charger switch
+                "tapo_wash_entity",
+                "tapo_dryer_entity",
+                "tapo_dishwasher_entity",
+            )
+        ]
+        for entity_id in targets:
+            if not entity_id or not entity_id.startswith("switch."):
+                continue
+            try:
+                await self.hass.services.async_call(
+                    "switch", "turn_off",
+                    {"entity_id": entity_id},
+                    blocking=False,
+                )
+                logger.warning(
+                    "H3 EPS: turn_off dispatched for %s", entity_id,
+                )
+            except Exception:
+                logger.exception(
+                    "H3 EPS: failed to turn_off %s", entity_id,
+                )
 
     def _read_planned_dispatches(self, entity_id: str) -> list:
         """HEO-8: read `planned_dispatches` from the BottlecapDave IGO
@@ -1022,6 +1091,7 @@ class HEO2Coordinator(DataUpdateCoordinator):
             live_rates_present=self._live_rates_present,
             plan_rejected_reason=self._plan_rejected_reason,
             verify_mismatch_reason=self._verify_mismatch_reason,
+            eps_active=self._eps_active,
         )
         return blocked
 
@@ -1041,8 +1111,15 @@ class HEO2Coordinator(DataUpdateCoordinator):
             live_rates_present=self._live_rates_present,
             plan_rejected_reason=self._plan_rejected_reason,
             verify_mismatch_reason=self._verify_mismatch_reason,
+            eps_active=self._eps_active,
         )
         return reason
+
+    @property
+    def eps_active(self) -> bool:
+        """SPEC §9 / H3: True when EPS is supplying the house and HEO
+        II is in power-failure mode."""
+        return self._eps_active
 
     @property
     def projection_today(self) -> Projection | None:

--- a/custom_components/heo2/models.py
+++ b/custom_components/heo2/models.py
@@ -234,6 +234,10 @@ class ProgrammeInputs:
     # such and stays a no-op. Defaults preserve backward compatibility
     # with tests built before HEO-8.
     planned_dispatches: list["PlannedDispatch"] = field(default_factory=list)
+    # SPEC §9 / H3 EPS mode: True when grid is down and the inverter
+    # is supplying via EPS. Drives EPSModeRule (cap=0% / no GC) and
+    # writes_blocked H3. Defaults False so existing tests pre-EPS pass.
+    eps_active: bool = False
 
     def now_local(self) -> datetime:
         """Return `now` projected into the local timezone if known.

--- a/custom_components/heo2/rules/__init__.py
+++ b/custom_components/heo2/rules/__init__.py
@@ -12,17 +12,18 @@ from .evening_protect import EveningProtectRule
 from .igo_dispatch import IGODispatchRule
 from .ev_charging import EVChargingRule
 from .saving_session import SavingSessionRule
+from .eps_mode import EPSModeRule
 from .safety import SafetyRule
 
 
 def default_rules() -> list[Rule]:
-    """Return the 9 default rules in priority order.
+    """Return the 10 default rules in priority order.
 
-    SafetyRule is always last and cannot be disabled. SavingSessionRule
-    sits AFTER ExportWindowRule + EveningProtectRule so an active
-    session always wins over a normal export window or evening floor:
-    SPEC §9 says drain to min_soc regardless of the standard Agile
-    threshold or evening reserve.
+    SafetyRule is always last and cannot be disabled. EPSModeRule sits
+    JUST before SafetyRule because it must override every other rule's
+    decisions (SPEC H3: drop SOC floor to 0% during grid loss). It
+    can't go after SafetyRule because SafetyRule would re-clamp SOC
+    back to min_soc.
     """
     return [
         BaselineRule(),
@@ -33,5 +34,6 @@ def default_rules() -> list[Rule]:
         SavingSessionRule(),
         IGODispatchRule(),
         EVChargingRule(),
+        EPSModeRule(),
         SafetyRule(),
     ]

--- a/custom_components/heo2/rules/eps_mode.py
+++ b/custom_components/heo2/rules/eps_mode.py
@@ -1,0 +1,48 @@
+# custom_components/heo2/rules/eps_mode.py
+"""EPSModeRule -- SPEC §9 row 2 / hard rule H3.
+
+When the grid is down and the inverter is supplying via EPS, normal
+SOC reserves don't apply: the goal is to keep the house running until
+the grid comes back. The rule:
+
+* Overrides every slot's `capacity_soc` to 0% so the inverter can
+  discharge below the user-configured min_soc floor.
+* Disables `grid_charge` on every slot (no grid to charge from).
+
+The coordinator handles the rest of H3 (turn off EV/washer/dryer/
+dishwasher via switch.turn_off, suppress MQTT writes via writes_blocked,
+banner via binary_sensor.heo_ii_eps_active). The rule itself only
+shapes the programme.
+
+When EPS clears (grid restored) the rule returns the slots to
+whatever the upstream rules produced, since this rule is a no-op
+when `eps_active=False`. The replan_triggers logic detects the
+False -> False -> True or True -> False transition and commits a
+fresh baseline.
+"""
+
+from __future__ import annotations
+
+from ..models import ProgrammeInputs, ProgrammeState
+from ..rule_engine import Rule
+
+
+class EPSModeRule(Rule):
+    """When EPS is active, drop SOC floor to 0 and disable grid charge."""
+
+    name = "eps_mode"
+    description = "Override SOC floor + disable grid charge during EPS"
+
+    def apply(self, state: ProgrammeState, inputs: ProgrammeInputs) -> ProgrammeState:
+        if not inputs.eps_active:
+            return state
+
+        for slot in state.slots:
+            slot.capacity_soc = 0
+            slot.grid_charge = False
+
+        state.reason_log.append(
+            "EPSMode: grid down, all slots cap=0% gc=False "
+            "(H3: allow battery drain to 0%)"
+        )
+        return state

--- a/custom_components/heo2/rules/safety.py
+++ b/custom_components/heo2/rules/safety.py
@@ -54,7 +54,12 @@ class SafetyRule(Rule):
         pass  # cannot be disabled
 
     def apply(self, state: ProgrammeState, inputs: ProgrammeInputs) -> ProgrammeState:
-        min_soc = int(inputs.min_soc)
+        # SPEC H3: under EPS, the configured min_soc floor is overridden
+        # to 0 - the user wants the inverter to discharge the battery
+        # all the way to keep the house running. Use 0 as the effective
+        # floor so the SOC clamp below doesn't undo EPSModeRule's
+        # cap=0% setting.
+        min_soc = 0 if inputs.eps_active else int(inputs.min_soc)
         fixes: list[str] = []
         snaps: list[str] = []  # 5-min granularity snaps surfaced separately
 

--- a/custom_components/heo2/writes_status.py
+++ b/custom_components/heo2/writes_status.py
@@ -20,6 +20,7 @@ def _compute_writes_blocked(
     live_rates_present: bool = True,
     plan_rejected_reason: str | None = None,
     verify_mismatch_reason: str | None = None,
+    eps_active: bool = False,
 ) -> tuple[bool, str]:
     """Determine if writes are currently blocked and why.
 
@@ -31,12 +32,15 @@ def _compute_writes_blocked(
       1. dry_run takes precedence over everything else - it's an
          intentional user choice; reporting any other reason would be
          misleading.
-      2. Transport readiness comes next so early-startup state is
+      2. EPS / power failure (SPEC H3) - the inverter is busy supplying
+         the house from EPS, MQTT writes go nowhere or worse, mess up
+         the recovery sequence. Suppress writes hard.
+      3. Transport readiness comes next so early-startup state is
          described accurately.
-      3. SPEC H4 (live-prices-only writes) is checked before plan-level
+      4. SPEC H4 (live-prices-only writes) is checked before plan-level
          issues: if rates aren't live the plan content is moot.
-      4. Plan rejection from the H5 pre-write validator.
-      5. Post-write verification mismatch from H6.
+      5. Plan rejection from the H5 pre-write validator.
+      6. Post-write verification mismatch from H6.
 
     Plan rejection / verify mismatch reasons are passed in by the
     coordinator; they default to None so existing callers stay
@@ -44,6 +48,8 @@ def _compute_writes_blocked(
     """
     if dry_run:
         return True, "dry_run enabled"
+    if eps_active:
+        return True, "H3: EPS active (grid down) - writes suppressed"
     if not writer_constructed or not transport_exists:
         return True, "MQTT writer not yet initialised"
     if not transport_connected:

--- a/tests/test_rules/test_eps_mode.py
+++ b/tests/test_rules/test_eps_mode.py
@@ -1,0 +1,82 @@
+# tests/test_rules/test_eps_mode.py
+"""Tests for EPSModeRule (SPEC H3 / §9 row 2)."""
+
+from __future__ import annotations
+
+from datetime import time
+
+from heo2.models import ProgrammeInputs, ProgrammeState, SlotConfig
+from heo2.rules.eps_mode import EPSModeRule
+from heo2.rules.safety import SafetyRule
+
+
+def _slot(start_h, start_m, end_h, end_m, soc, gc):
+    return SlotConfig(
+        start_time=time(start_h, start_m),
+        end_time=time(end_h, end_m),
+        capacity_soc=soc,
+        grid_charge=gc,
+    )
+
+
+def _normal_programme():
+    return ProgrammeState(slots=[
+        _slot(0, 0, 5, 30, 80, True),
+        _slot(5, 30, 18, 30, 65, False),
+        _slot(18, 30, 23, 30, 10, False),
+        _slot(23, 30, 23, 55, 80, True),
+        _slot(23, 55, 23, 55, 10, False),
+        _slot(23, 55, 0, 0, 10, False),
+    ], reason_log=[])
+
+
+class TestEPSModeRule:
+    def test_no_change_when_eps_inactive(self, default_inputs):
+        default_inputs.eps_active = False
+        prog = _normal_programme()
+        socs_before = [s.capacity_soc for s in prog.slots]
+        gcs_before = [s.grid_charge for s in prog.slots]
+
+        result = EPSModeRule().apply(prog, default_inputs)
+        assert [s.capacity_soc for s in result.slots] == socs_before
+        assert [s.grid_charge for s in result.slots] == gcs_before
+
+    def test_eps_active_drops_all_caps_to_zero(self, default_inputs):
+        default_inputs.eps_active = True
+        prog = _normal_programme()
+        result = EPSModeRule().apply(prog, default_inputs)
+        for slot in result.slots:
+            assert slot.capacity_soc == 0
+            assert slot.grid_charge is False
+        assert any("EPSMode" in r for r in result.reason_log)
+
+    def test_safety_does_not_re_clamp_soc_when_eps_active(
+        self, default_inputs,
+    ):
+        """SafetyRule normally clamps SOC < min_soc up to min_soc.
+        Under EPS the effective floor is 0; otherwise EPSModeRule's
+        cap=0 would be undone by the next rule.
+        """
+        default_inputs.eps_active = True
+        prog = _normal_programme()
+        prog = EPSModeRule().apply(prog, default_inputs)
+        prog = SafetyRule().apply(prog, default_inputs)
+        for slot in prog.slots:
+            assert slot.capacity_soc == 0
+
+    def test_safety_still_clamps_soc_normally_when_eps_inactive(
+        self, default_inputs,
+    ):
+        """Sanity: the EPS-aware floor doesn't break the normal path."""
+        default_inputs.eps_active = False
+        prog = ProgrammeState(slots=[
+            _slot(0, 0, 5, 30, 5, True),  # below min_soc=20 from default
+            _slot(5, 30, 18, 30, 65, False),
+            _slot(18, 30, 23, 30, 10, False),
+            _slot(23, 30, 23, 55, 80, True),
+            _slot(23, 55, 23, 55, 10, False),
+            _slot(23, 55, 0, 0, 10, False),
+        ], reason_log=[])
+        prog = SafetyRule().apply(prog, default_inputs)
+        # min_soc=20 from default fixture
+        assert prog.slots[0].capacity_soc >= 20

--- a/tests/test_writes_status.py
+++ b/tests/test_writes_status.py
@@ -155,6 +155,46 @@ class TestComputeWritesBlocked:
         assert blocked is True
         assert "H6" in reason
 
+    def test_eps_active_blocks_with_h3_prefix(self):
+        """SPEC H3: writes suppressed when EPS / power failure active."""
+        blocked, reason = _compute_writes_blocked(
+            dry_run=False,
+            writer_constructed=True,
+            transport_exists=True,
+            transport_connected=True,
+            host="192.168.4.7",
+            eps_active=True,
+        )
+        assert blocked is True
+        assert "H3" in reason and "EPS" in reason
+
+    def test_dry_run_takes_precedence_over_eps(self):
+        blocked, reason = _compute_writes_blocked(
+            dry_run=True,
+            writer_constructed=True,
+            transport_exists=True,
+            transport_connected=True,
+            host="192.168.4.7",
+            eps_active=True,
+        )
+        assert blocked is True
+        assert "dry_run" in reason
+        assert "H3" not in reason
+
+    def test_eps_takes_precedence_over_h4(self):
+        blocked, reason = _compute_writes_blocked(
+            dry_run=False,
+            writer_constructed=True,
+            transport_exists=True,
+            transport_connected=True,
+            host="192.168.4.7",
+            live_rates_present=False,
+            eps_active=True,
+        )
+        assert blocked is True
+        assert "H3" in reason
+        assert "H4" not in reason
+
     def test_h4_takes_precedence_over_h5(self):
         """If we never had live rates we can't have a valid plan; the
         H4 reason is the more useful one to report."""


### PR DESCRIPTION
## Summary
Implements SPEC §9 row 2 / hard rule H3. When the grid is down:
- All slot SOC floors drop to 0% (battery can fully drain to keep house running).
- EV / washer / dryer / dishwasher get `switch.turn_off` (one-shot per transition).
- MQTT writes are suppressed (`writes_blocked` reason `H3: EPS active`).
- New `binary_sensor.heo_ii_eps_active` for the dashboard banner.

## Wiring
Configure either:
- `eps_entity`: binary_sensor that's `on` during EPS (preferred if the inverter exposes one)
- `grid_voltage_entity`: numeric V sensor (EPS when value <= `eps_voltage_threshold`, default 50V)

Both fields are optional; if neither is configured the feature is a no-op.

## Test plan
- [x] 398 tests pass (+7 new across test_eps_mode + test_writes_status)
- [ ] Deploy + manually trigger via developer-tools (set the eps_entity to on) and verify: SOC caps drop to 0%, switches turn off, writes_blocked flips to H3 reason
- [ ] Toggle back, confirm SOC restored, replan trigger fires "grid restored"

🤖 Generated with [Claude Code](https://claude.com/claude-code)