### PR TITLE
fix(HEO-6, HEO-7): time-arithmetic bugs in evening + export rules

### DIFF
--- a/custom_components/heo2/rules/evening_protect.py
+++ b/custom_components/heo2/rules/evening_protect.py
@@ -35,22 +35,42 @@ class EveningProtectRule(Rule):
         required_soc = min(required_soc, 100)
 
         from datetime import time
-        evening_mins = self.evening_start_hour * 60
+
+        # HEO-6 fix: pre-fix logic only protected slots whose end_time
+        # was <= evening_start (e.g. a slot ending at 18:00 exactly).
+        # In Paddy's typical plan, slot 2 runs 05:30-18:30 - it spans
+        # evening_start at 18:00, so the old condition skipped it and
+        # no protection ever applied. The inverter could discharge
+        # slot 2 toward whatever low cap ExportWindow set, leaving
+        # the battery empty entering the evening window.
+        #
+        # New rule: any non-GC slot that overlaps the evening_start
+        # boundary (start_time < evening_start AND end_time > evening_start
+        # OR end_time == 00:00 wrap) gets its cap raised to required_soc.
+        # This is the slot whose `capacity_soc` is in effect AT the
+        # moment evening starts, so it determines the SOC the battery
+        # carries into the evening window.
+        evening_t = time(self.evening_start_hour, 0)
+
+        def _slot_covers_boundary(slot) -> bool:
+            # Slot covers the evening boundary iff `evening_t` falls in
+            # [slot.start_time, slot.end_time). end==00:00 wraps midnight.
+            if slot.end_time == time(0, 0):
+                # Slot wraps; covers anything >= start_time
+                return slot.start_time <= evening_t
+            return slot.start_time <= evening_t < slot.end_time
 
         modified = False
         for slot in state.slots:
-            slot_end_mins = slot.end_time.hour * 60 + slot.end_time.minute
-            if slot_end_mins == 0:
-                slot_end_mins = 1440
-
-            if slot_end_mins <= evening_mins and not slot.grid_charge:
+            if _slot_covers_boundary(slot) and not slot.grid_charge:
                 if slot.capacity_soc < required_soc:
                     slot.capacity_soc = required_soc
                     modified = True
 
         if modified:
             state.reason_log.append(
-                f"EveningProtect: raised pre-evening SOC to {required_soc}% "
+                f"EveningProtect: raised SOC to {required_soc}% in slot "
+                f"covering {evening_t.strftime('%H:%M')} "
                 f"({evening_demand_kwh:.1f} kWh evening demand)"
             )
         else:

--- a/custom_components/heo2/rules/export_window.py
+++ b/custom_components/heo2/rules/export_window.py
@@ -21,6 +21,23 @@ from ..rank_pricing import (
 from ..rule_engine import Rule
 
 
+def _slot_covers_rate(slot, rate, tz):
+    """True iff the programme `slot` (local time-of-day) covers the
+    `rate.start` (UTC absolute datetime) in local time. HEO-7 fix:
+    pre-2026-05 ExportWindowRule built `slot_hours = set(range(start.hour,
+    end.hour))` and matched against `rate.start.hour`. That dropped
+    half-hour Agile slots crossing the hour and entirely missed slots
+    like 16:30-17:00 against a programme slot of 17:00-19:00. Working
+    in absolute time (rate.start in local tz, against slot.start_time
+    / slot.end_time) catches the overlap without rounding.
+    """
+    if tz is not None and rate.start.tzinfo is not None:
+        local_t = rate.start.astimezone(tz).time()
+    else:
+        local_t = rate.start.time()
+    return slot.contains_time(local_t)
+
+
 class ExportWindowRule(Rule):
     """Drain the battery during the top-ranked export windows of today.
 
@@ -103,10 +120,12 @@ class ExportWindowRule(Rule):
             )
             return state
 
-        # Local-hour view of which slots overlap a worth-selling window.
-        # SlotConfig stores time-of-day; we render the worth-selling
-        # windows' UTC starts back to local hour using inputs.now's tz.
-        tz = inputs.now.tzinfo
+        # HEO-7: local-tz aware slot matching. Use inputs.local_tz
+        # (set by the coordinator post-PR2) so DST is respected;
+        # fall back to inputs.now.tzinfo for tests that don't set it.
+        tz = inputs.local_tz or inputs.now.tzinfo
+        # Kept for the diagnostic log line below; the actual slot
+        # selection uses _slot_covers_rate which is sub-hour accurate.
         worth_hours = hours_covered_by(worth_windows, tz=tz)
 
         # Per SPEC §5 priority 1 (avoid peak import) DOMINATES priority 3
@@ -130,14 +149,18 @@ class ExportWindowRule(Rule):
 
         modified = False
         for slot in state.slots:
-            start_hour = slot.start_time.hour
-            end_hour = slot.end_time.hour if slot.end_time > slot.start_time else 24
-            slot_hours = set(range(start_hour, end_hour))
-
-            if slot_hours & worth_hours and not slot.grid_charge:
-                if slot.capacity_soc > drain_target:
-                    slot.capacity_soc = drain_target
-                    modified = True
+            if slot.grid_charge:
+                continue
+            # Slot drains only if at least one worth-selling rate slot
+            # falls within its time window. Sub-hour accurate via
+            # `_slot_covers_rate`, unlike the pre-HEO-7 hour-set
+            # intersection.
+            covers_any = any(
+                _slot_covers_rate(slot, r, tz) for r in worth_windows
+            )
+            if covers_any and slot.capacity_soc > drain_target:
+                slot.capacity_soc = drain_target
+                modified = True
 
         sorted_hours = sorted(worth_hours)
         rate_summary = (

--- a/tests/test_rules/test_evening_protect.py
+++ b/tests/test_rules/test_evening_protect.py
@@ -46,3 +46,58 @@ class TestEveningProtectRule:
         rule = EveningProtectRule(evening_start_hour=17, evening_end_hour=24)
         result = rule.apply(state, default_inputs)
         assert any("EveningProtect" in r for r in result.reason_log)
+
+    def test_heo6_slot_spanning_evening_boundary_gets_protected(
+        self, default_inputs,
+    ):
+        """HEO-6 regression: pre-fix, the rule only protected slots
+        whose `end_time <= 18:00`. Production plan slot 2 is 05:30-18:30
+        (ends AFTER evening_start), so the bug left it unprotected and
+        the inverter could discharge through the day to the export
+        target, leaving zero reserve at 18:00.
+
+        Now: any non-GC slot covering the evening_start time-of-day
+        gets the floor.
+        """
+        from heo2.models import SlotConfig
+        # Realistic production-shaped programme: charge overnight,
+        # day slot 05:30-18:30 set to a low cap by some upstream rule,
+        # evening drain slot 18:30-23:30, etc.
+        prog = ProgrammeState(slots=[
+            SlotConfig(time(0, 0), time(5, 30), 80, True),
+            SlotConfig(time(5, 30), time(18, 30), 25, False),  # day slot
+            SlotConfig(time(18, 30), time(23, 30), 10, False),
+            SlotConfig(time(23, 30), time(23, 55), 80, True),
+            SlotConfig(time(23, 55), time(23, 55), 10, False),
+            SlotConfig(time(23, 55), time(0, 0), 10, False),
+        ], reason_log=[])
+        default_inputs.load_forecast_kwh = [1.0] * 18 + [2.5] * 6
+        rule = EveningProtectRule()
+        result = rule.apply(prog, default_inputs)
+        # Slot 2 covers 18:00 (05:30 <= 18:00 < 18:30) -> must be raised.
+        # required_soc = 20 + (15 kWh / 20 kWh * 100) = 95
+        assert result.slots[1].capacity_soc >= 80, (
+            f"slot 2 (05:30-18:30) was NOT protected; cap stayed at "
+            f"{result.slots[1].capacity_soc}"
+        )
+
+    def test_grid_charge_slot_spanning_boundary_not_overridden(
+        self, default_inputs,
+    ):
+        """A GC=True slot must keep its grid_charge target whatever
+        time it spans - the cheap-charge rule owns those caps."""
+        from heo2.models import SlotConfig
+        prog = ProgrammeState(slots=[
+            SlotConfig(time(0, 0), time(20, 0), 50, True),  # GC spanning evening
+            SlotConfig(time(20, 0), time(22, 0), 30, False),
+            SlotConfig(time(22, 0), time(23, 0), 30, False),
+            SlotConfig(time(23, 0), time(23, 30), 30, False),
+            SlotConfig(time(23, 30), time(23, 55), 30, False),
+            SlotConfig(time(23, 55), time(0, 0), 30, False),
+        ], reason_log=[])
+        default_inputs.load_forecast_kwh = [1.0] * 18 + [2.5] * 6
+        rule = EveningProtectRule()
+        result = rule.apply(prog, default_inputs)
+        # Slot 1 is GC=True, must NOT be touched
+        assert result.slots[0].capacity_soc == 50
+        assert result.slots[0].grid_charge is True

--- a/tests/test_rules/test_export_window.py
+++ b/tests/test_rules/test_export_window.py
@@ -128,3 +128,61 @@ class TestExportWindowRule:
         rule = ExportWindowRule()
         result = rule.apply(state, default_inputs)
         assert any("ExportWindow" in r for r in result.reason_log)
+
+    def test_heo7_half_hour_slot_within_programme_slot_drains(
+        self, default_inputs,
+    ):
+        """HEO-7 regression: a worth-selling 30-min Agile slot at
+        16:30-17:00 falls inside a programme slot 16:00-20:00. Pre-fix
+        `slot_hours = set(range(16, 20)) = {16,17,18,19}` and the rate
+        slot's hour was 16, so it matched - but a programme slot
+        17:00-19:00 vs the same 16:30 rate would have hour-set
+        {17, 18} which doesn't include 16, missing the overlap.
+
+        We test the second case explicitly: programme slot 17:00-19:00
+        with a worth-selling rate at 16:30-17:00. Pre-fix would NOT
+        drain; post-fix DOES because the rate's local time-of-day
+        (16:30) falls in slot.contains_time(16:30)==False... actually
+        16:30 is BEFORE slot 17:00-19:00 starts, so it shouldn't drain
+        that slot.
+
+        Better test: a programme slot 16:30-19:00 vs a rate slot
+        starting at 16:30. Pre-fix: start_hour=16, end_hour=19,
+        slot_hours={16,17,18}, rate.hour=16 -> matches (lucky). Pre-
+        fix would also match a rate at 16:00 even though the slot
+        starts at 16:30. Post-fix is sub-hour accurate.
+        """
+        from heo2.models import SlotConfig
+        # Programme: a single drain slot 16:30-19:00, GC=False.
+        # Worth-selling rate: a single 30-min slot at 16:00-16:30
+        # (hour 16). Pre-fix: slot_hours={16,17,18} intersects {16}
+        # -> DRAIN (incorrectly, since slot starts at 16:30 AFTER the
+        # rate window has ended). Post-fix: rate.start.time()=16:00
+        # is NOT in slot 16:30-19:00 -> NO DRAIN.
+        prog = ProgrammeState(slots=[
+            SlotConfig(time(0, 0), time(5, 30), 50, True),
+            SlotConfig(time(5, 30), time(16, 30), 80, False),
+            SlotConfig(time(16, 30), time(19, 0), 80, False),
+            SlotConfig(time(19, 0), time(23, 0), 80, False),
+            SlotConfig(time(23, 0), time(23, 55), 80, False),
+            SlotConfig(time(23, 55), time(0, 0), 80, False),
+        ], reason_log=[])
+        # 48 slots flat at 3p, except 16:00-16:30 at 25p.
+        rates = [3.0] * 48
+        rates[32] = 25.0  # index 32 = 16:00 (32 * 30 / 60)
+        default_inputs.export_rates = _today_export_distribution(rates)
+        default_inputs.current_soc = 80.0
+        result = ExportWindowRule().apply(prog, default_inputs)
+        # Slot 2 (16:30-19:00) should NOT have its cap lowered by a
+        # rate that ends at 16:30 - the cheap window has passed
+        # before the slot even starts.
+        assert result.slots[2].capacity_soc == 80, (
+            f"slot 16:30-19:00 was incorrectly drained by a rate window "
+            f"ending at 16:30. Cap = {result.slots[2].capacity_soc}"
+        )
+        # The slot 2 (05:30-16:30) covers the 16:00 rate and should
+        # be drained.
+        assert result.slots[1].capacity_soc < 80, (
+            f"slot 05:30-16:30 covers the 16:00-16:30 worth-sell rate "
+            f"but cap unchanged at {result.slots[1].capacity_soc}"
+        )


### PR DESCRIPTION
## Summary
Two related off-by-one fixes in older rules where coarse hour-level maths missed real overlaps against PR2's 30-minute-aware programme shape.

**HEO-6** EveningProtectRule: pre-fix only protected slots ending AT-or-before 18:00; production slot 2 (05:30-18:30) was skipped, so the inverter could drain the battery through the day to whatever the export rule set, leaving zero evening reserve. Post-fix: protect any non-GC slot whose window CONTAINS 18:00.

**HEO-7** ExportWindowRule: pre-fix used `slot_hours = set(range(start.hour, end.hour))` and intersected with rate-slot hours, dropping sub-hour boundaries. Post-fix: `_slot_covers_rate` is sub-hour accurate via `slot.contains_time(rate.start.astimezone(tz).time())`.

## Test plan
- [x] 401 tests pass (+3 regression tests)
- [ ] Deploy + watch tonight's tick: reason_log should show EveningProtect raising slot 2's cap, and ExportWindow's drain selection should respect 30-min boundaries

🤖 Generated with [Claude Code](https://claude.com/claude-code)