### PR TITLE
fix(number): persist NumberEntity tweaks via entry.options

### DIFF
--- a/custom_components/heo2/number.py
+++ b/custom_components/heo2/number.py
@@ -13,6 +13,19 @@ from .const import DOMAIN, DEFAULT_MIN_SOC
 from .coordinator import HEO2Coordinator
 
 
+async def _persist_option(
+    hass: HomeAssistant, entry: ConfigEntry, key: str, value,
+) -> None:
+    """Write a single option into entry.options so it survives HA
+    restart. Mirror the value into coordinator._config too so the
+    next tick sees it without waiting for the update_listener reload.
+    """
+    new_options = {**(entry.options or {}), key: value}
+    hass.config_entries.async_update_entry(entry, options=new_options)
+    coordinator: HEO2Coordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator._config[key] = value
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: ConfigEntry,
@@ -43,7 +56,9 @@ class MinSocNumber(CoordinatorEntity, NumberEntity):
         return self.coordinator._config.get("min_soc", DEFAULT_MIN_SOC)
 
     async def async_set_native_value(self, value: float) -> None:
-        self.coordinator._config["min_soc"] = value
+        await _persist_option(
+            self.hass, self.coordinator._entry, "min_soc", value,
+        )
         await self.coordinator.async_request_refresh()
 
 
@@ -64,7 +79,9 @@ class SystemCostNumber(CoordinatorEntity, NumberEntity):
         return self.coordinator._config.get("system_cost", 16800.0)
 
     async def async_set_native_value(self, value: float) -> None:
-        self.coordinator._config["system_cost"] = value
+        await _persist_option(
+            self.hass, self.coordinator._entry, "system_cost", value,
+        )
         self.async_write_ha_state()
 
 
@@ -85,5 +102,7 @@ class AdditionalCostsNumber(CoordinatorEntity, NumberEntity):
         return self.coordinator._config.get("additional_costs", 0.0)
 
     async def async_set_native_value(self, value: float) -> None:
-        self.coordinator._config["additional_costs"] = value
+        await _persist_option(
+            self.hass, self.coordinator._entry, "additional_costs", value,
+        )
         self.async_write_ha_state()


### PR DESCRIPTION
## Summary
The three NumberEntity sliders (Min SOC, System Cost, Additional Costs) wrote only to in-memory `coordinator._config`. Values were lost on HA restart, silently reverting to the setup-wizard defaults.

Fix: new `_persist_option` helper writes to `entry.options` via `async_update_entry`, mirroring the value into `_config` for the current tick. The existing `add_update_listener` reload then rebuilds the coordinator with the merged options on next pass.

## Test plan
- [x] 401 tests pass (no new tests - HA state-management not covered by pure-logic suite)
- [ ] Deploy + slide Min SOC, restart HA, verify the new value persists (was reverting before)