### PR TITLE
feat(spec2): wire work_mode global write so SavingSession actually exports

### DIFF
--- a/custom_components/heo2/inverter_state_reader.py
+++ b/custom_components/heo2/inverter_state_reader.py
@@ -26,6 +26,10 @@ logger = logging.getLogger(__name__)
 _CAPACITY_FMT = "sensor.sa_inverter_{inv}_capacity_point_{n}"
 _GRID_CHARGE_FMT = "sensor.sa_inverter_{inv}_grid_charge_point_{n}"
 _TIME_FMT = "sensor.sa_inverter_{inv}_time_point_{n}"
+# SPEC §2 globals. Currently only work_mode is wired (HEO follow-up
+# PRs will extend to energy_pattern / charge_rate / discharge_rate /
+# zero_export_to_CT).
+_WORK_MODE_FMT = "select.sa_inverter_{inv}_work_mode"
 
 
 # Fallback defaults when an entity is missing or unparseable. Chosen to
@@ -126,7 +130,10 @@ def read_programme_state(
             grid_charge=gc,
         ))
 
-    return ProgrammeState(slots=slots, reason_log=[])
+    work_mode_raw = state_lookup(_WORK_MODE_FMT.format(inv=inv))
+    work_mode = work_mode_raw.strip() if work_mode_raw else None
+
+    return ProgrammeState(slots=slots, reason_log=[], work_mode=work_mode)
 
 
 def read_from_hass(

--- a/custom_components/heo2/models.py
+++ b/custom_components/heo2/models.py
@@ -65,9 +65,21 @@ _FILLER_THRESHOLD_MINUTES = 30
 
 @dataclass
 class ProgrammeState:
-    """The 6-slot programme produced by the rule engine."""
+    """The 6-slot programme produced by the rule engine.
+
+    `work_mode` is a SPEC §2 global setting that overrides the
+    inverter's behaviour across slots (e.g. "Selling first" during a
+    saving session, "Zero export to CT" in normal operation). None
+    means "don't touch" so older callers and tests built before the
+    work_mode wiring still produce valid programmes that don't
+    accidentally write the field.
+
+    Valid values per SA discovery:
+      "Selling first" | "Zero export to load" | "Zero export to CT"
+    """
     slots: list[SlotConfig]
     reason_log: list[str] = field(default_factory=list)
+    work_mode: Optional[str] = None
 
     @classmethod
     def default(cls, min_soc: int = 20) -> ProgrammeState:
@@ -284,3 +296,13 @@ class SlotWrite:
     capacity_soc: int | None = None   # write only if changed
     time_point: str | None = None     # write only if changed ("HH:MM")
     grid_charge: bool | None = None   # write only if changed
+
+
+@dataclass
+class GlobalWrite:
+    """A pending MQTT write for a SPEC §2 global setting (work_mode,
+    energy_pattern, etc.). Per-slot writes use `SlotWrite`; this is
+    the equivalent for non-per-slot inverter settings.
+    """
+    setting: str  # e.g. "work_mode"
+    value: str

--- a/custom_components/heo2/mqtt_writer.py
+++ b/custom_components/heo2/mqtt_writer.py
@@ -23,7 +23,7 @@ from dataclasses import dataclass, field
 from datetime import time
 from typing import Any, Awaitable, Callable, Protocol
 
-from .models import ProgrammeState, SlotConfig, SlotWrite
+from .models import GlobalWrite, ProgrammeState, SlotConfig, SlotWrite
 from .const import MQTT_WRITE_TIMEOUT_SECONDS, MQTT_MAX_RETRIES
 
 logger = logging.getLogger(__name__)
@@ -170,6 +170,24 @@ class MqttWriter:
 
     # --- diff -----------------------------------------------------------
 
+    def diff_globals(
+        self, current: ProgrammeState, new: ProgrammeState,
+    ) -> list[GlobalWrite]:
+        """Diff the SPEC §2 global settings between two programmes.
+
+        Currently only `work_mode` is wired. `None` on the new side
+        means "don't touch", so older callers that don't set
+        work_mode never trigger a write. Equality check ignores case
+        and trailing whitespace to be defensive about SA renderings.
+        """
+        out: list[GlobalWrite] = []
+        if new.work_mode is not None:
+            cur = (current.work_mode or "").strip()
+            nw = new.work_mode.strip()
+            if cur.casefold() != nw.casefold():
+                out.append(GlobalWrite(setting="work_mode", value=nw))
+        return out
+
     def diff(self, current: ProgrammeState, new: ProgrammeState) -> list[SlotWrite]:
         """Compare two programmes and return a list of register writes.
 
@@ -235,6 +253,67 @@ class MqttWriter:
 
 
     # --- the actual write orchestration --------------------------------
+
+    def _global_set_topic(self, setting: str) -> str:
+        return f"{self._base_topic}/{self._inverter}/{setting}/set"
+
+    async def write_globals(
+        self, writes: list[GlobalWrite],
+    ) -> MqttWriteResult:
+        """Sequentially publish each GlobalWrite to its `<setting>/set`
+        topic and wait for SA's bare 'Saved' / 'Error: ...' response.
+        Same FIFO-queue correlation as `write_registers` (HEO-32).
+
+        Sequential by design: SA confirms one set at a time and we
+        want to fail fast on the first error rather than firing all
+        globals and trying to figure out which one SA rejected.
+        """
+        result = MqttWriteResult(writes_attempted=0)
+
+        if self._dry_run:
+            for w in writes:
+                result.writes_attempted += 1
+                result.dry_run_log.append(
+                    f"Would publish {self._global_set_topic(w.setting)} "
+                    f"= {w.value}"
+                )
+                result.writes_confirmed += 1
+            result.success = True
+            return result
+
+        if not writes:
+            result.success = True
+            return result
+
+        self._response_queue: asyncio.Queue[str] = asyncio.Queue()
+
+        async def _on_response(topic: str, payload: str) -> None:
+            await self._response_queue.put(payload)
+
+        unsubscribe = await self._transport.subscribe(
+            self._response_topic(), _on_response,
+        )
+        try:
+            while not self._response_queue.empty():
+                self._response_queue.get_nowait()
+
+            for w in writes:
+                topic = self._global_set_topic(w.setting)
+                result.writes_attempted += 1
+                ok, reason = await self._publish_and_confirm(
+                    topic, w.value, w.setting,
+                )
+                if ok:
+                    result.writes_confirmed += 1
+                else:
+                    result.success = False
+                    result.failed_param = w.setting
+                    result.failed_reason = reason
+                    return result
+            result.success = True
+            return result
+        finally:
+            unsubscribe()
 
     async def write_registers(self, writes: list[SlotWrite]) -> MqttWriteResult:
         """Publish each setting change and wait for SA to confirm each
@@ -370,13 +449,38 @@ async def apply_programme_diff(
     Pure async, no HA imports. Callable from the coordinator with real
     HAMqttTransport-backed writer, or from tests with FakeTransport.
     """
-    writes = writer.diff(last_known, new_programme)
-    if not writes:
-        # Fabricate a success result for the "no work" case
+    # Globals first so per-slot writes happen under the intended
+    # work_mode (e.g. SavingSession switches to "Selling first"; we
+    # want the inverter in selling mode before its slot caps drop).
+    global_writes = writer.diff_globals(last_known, new_programme)
+    slot_writes = writer.diff(last_known, new_programme)
+
+    if not global_writes and not slot_writes:
         result = MqttWriteResult(success=True, writes_attempted=0, writes_confirmed=0)
         return result, last_known
 
-    result = await writer.write_registers(writes)
-    if result.success:
-        return result, new_programme
-    return result, last_known
+    combined = MqttWriteResult(success=True)
+    if global_writes:
+        g_result = await writer.write_globals(global_writes)
+        combined.writes_attempted += g_result.writes_attempted
+        combined.writes_confirmed += g_result.writes_confirmed
+        combined.dry_run_log.extend(g_result.dry_run_log)
+        if not g_result.success:
+            combined.success = False
+            combined.failed_param = g_result.failed_param
+            combined.failed_reason = g_result.failed_reason
+            return combined, last_known
+
+    if slot_writes:
+        s_result = await writer.write_registers(slot_writes)
+        combined.writes_attempted += s_result.writes_attempted
+        combined.writes_confirmed += s_result.writes_confirmed
+        combined.dry_run_log.extend(s_result.dry_run_log)
+        if not s_result.success:
+            combined.success = False
+            combined.failed_slot = s_result.failed_slot
+            combined.failed_param = s_result.failed_param
+            combined.failed_reason = s_result.failed_reason
+            return combined, last_known
+
+    return combined, new_programme

--- a/custom_components/heo2/rules/baseline.py
+++ b/custom_components/heo2/rules/baseline.py
@@ -46,9 +46,15 @@ class BaselineRule(Rule):
             SlotConfig(time(23, 58), time(0, 0), min_soc, False),
         ]
 
+        # SPEC §2 work_mode default. SavingSessionRule overrides to
+        # "Selling first" while a session is active; once the session
+        # ends, BaselineRule re-runs and resets here so the inverter
+        # stops exporting.
+        state.work_mode = "Zero export to CT"
+
         state.reason_log.append(
             f"Baseline: overnight charge to 100% until {self.off_peak_end}, "
             f"solar day until {self.evening_start}, "
-            f"evening drain to {min_soc}%"
+            f"evening drain to {min_soc}%; work_mode=Zero export to CT"
         )
         return state

--- a/custom_components/heo2/rules/saving_session.py
+++ b/custom_components/heo2/rules/saving_session.py
@@ -57,16 +57,25 @@ class SavingSessionRule(Rule):
         slot.grid_charge = False
         after = (slot.capacity_soc, slot.grid_charge)
 
+        # SPEC §9 row 3: "Selling first" lets the inverter export to
+        # grid at the published Outgoing Octopus rate. Without this the
+        # current "Zero export to CT" mode would just hold load coverage,
+        # not export, and the £3+/kWh saving-session price wouldn't be
+        # captured. Reset is handled by BaselineRule when the session
+        # ends (saving_session=False).
+        state.work_mode = "Selling first"
+
         if before != after:
             state.reason_log.append(
                 f"SavingSession: drain slot {current_idx + 1} "
                 f"({slot.start_time.strftime('%H:%M')}-"
                 f"{slot.end_time.strftime('%H:%M')}) "
-                f"to {floor}% (was cap={before[0]}% gc={before[1]})"
+                f"to {floor}% (was cap={before[0]}% gc={before[1]}); "
+                f"work_mode -> Selling first"
             )
         else:
             state.reason_log.append(
                 f"SavingSession: active but slot {current_idx + 1} "
-                f"already at floor"
+                f"already at floor; work_mode -> Selling first"
             )
         return state

--- a/tests/test_mqtt_writer.py
+++ b/tests/test_mqtt_writer.py
@@ -13,7 +13,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from heo2.models import SlotConfig, ProgrammeState, SlotWrite
+from heo2.models import SlotConfig, ProgrammeState, SlotWrite, GlobalWrite
 from heo2.mqtt_writer import (
     MqttWriter,
     MqttWriteResult,
@@ -569,3 +569,120 @@ class TestApplyProgrammeDiff:
         # last_known still reflects the PRE-write world
         assert returned_last_known is current
         assert returned_last_known.slots[0].capacity_soc == 100  # unchanged
+
+
+class TestDiffGlobals:
+    def test_no_change_when_work_mode_matches(self):
+        cur = _baseline_programme()
+        cur.work_mode = "Zero export to CT"
+        new = _baseline_programme()
+        new.work_mode = "Zero export to CT"
+        writer = MqttWriter(client=MagicMock())
+        assert writer.diff_globals(cur, new) == []
+
+    def test_work_mode_change_detected(self):
+        cur = _baseline_programme()
+        cur.work_mode = "Zero export to CT"
+        new = _baseline_programme()
+        new.work_mode = "Selling first"
+        writer = MqttWriter(client=MagicMock())
+        out = writer.diff_globals(cur, new)
+        assert len(out) == 1
+        assert out[0].setting == "work_mode"
+        assert out[0].value == "Selling first"
+
+    def test_none_work_mode_on_new_does_not_trigger_write(self):
+        """When the new programme leaves work_mode unset (None) we
+        don't write anything - older callers and tests don't
+        accidentally clobber the inverter setting."""
+        cur = _baseline_programme()
+        cur.work_mode = "Selling first"
+        new = _baseline_programme()
+        new.work_mode = None
+        writer = MqttWriter(client=MagicMock())
+        assert writer.diff_globals(cur, new) == []
+
+    def test_case_insensitive_match(self):
+        """Be defensive about SA vs HEO casing on the same value."""
+        cur = _baseline_programme()
+        cur.work_mode = "Zero Export To CT"
+        new = _baseline_programme()
+        new.work_mode = "zero export to ct"
+        writer = MqttWriter(client=MagicMock())
+        assert writer.diff_globals(cur, new) == []
+
+
+class TestWriteGlobals:
+    @pytest.mark.asyncio
+    async def test_happy_path_work_mode_publish_confirmed(self):
+        transport = FakeTransport()
+        transport.script_responses(["Saved"])
+        writer = MqttWriter(transport=transport)
+
+        result = await writer.write_globals([
+            GlobalWrite(setting="work_mode", value="Selling first"),
+        ])
+        assert result.success is True
+        assert result.writes_confirmed == 1
+        assert transport.published[0] == (
+            "solar_assistant/inverter_1/work_mode/set",
+            "Selling first",
+        )
+
+    @pytest.mark.asyncio
+    async def test_dry_run_logs_without_publishing(self):
+        transport = FakeTransport()
+        writer = MqttWriter(transport=transport, dry_run=True)
+        result = await writer.write_globals([
+            GlobalWrite(setting="work_mode", value="Selling first"),
+        ])
+        assert result.success is True
+        assert result.writes_confirmed == 1
+        assert len(transport.published) == 0
+        assert any("work_mode" in line for line in result.dry_run_log)
+
+
+class TestApplyProgrammeDiffGlobals:
+    @pytest.mark.asyncio
+    async def test_global_write_first_then_slots(self):
+        """SPEC §2: globals (work_mode) flush before per-slot writes
+        so the inverter is in the right mode when its slot caps drop."""
+        transport = FakeTransport()
+        transport.script_responses(["Saved", "Saved"])  # work_mode + slot
+        writer = MqttWriter(transport=transport)
+
+        cur = _baseline_programme()
+        cur.work_mode = "Zero export to CT"
+        new = _baseline_programme()
+        new.work_mode = "Selling first"
+        new.slots[0] = SlotConfig(time(0, 0), time(5, 30), 30, True)
+
+        result, last = await apply_programme_diff(writer, cur, new)
+        assert result.success is True
+        assert result.writes_attempted == 2
+        # Global was published first
+        assert "work_mode" in transport.published[0][0]
+        assert "capacity_point_1" in transport.published[1][0]
+        assert last is new
+
+    @pytest.mark.asyncio
+    async def test_global_failure_aborts_before_slot_writes(self):
+        transport = FakeTransport()
+        transport.script_responses([
+            "Error: Invalid value 'Bogus' for 'Work mode'.",
+            # no second response - shouldn't get here
+        ])
+        writer = MqttWriter(transport=transport)
+
+        cur = _baseline_programme()
+        cur.work_mode = "Zero export to CT"
+        new = _baseline_programme()
+        new.work_mode = "Bogus"
+        new.slots[0] = SlotConfig(time(0, 0), time(5, 30), 30, True)
+
+        result, last = await apply_programme_diff(writer, cur, new)
+        assert result.success is False
+        assert result.failed_param == "work_mode"
+        # slot writes never happened
+        assert len(transport.published) == 1
+        assert last is cur

--- a/tests/test_rules/test_baseline.py
+++ b/tests/test_rules/test_baseline.py
@@ -87,3 +87,13 @@ class TestBaselineRule:
         state = ProgrammeState.default(min_soc=20)
         result = rule.apply(state, default_inputs)
         assert result.slots[0].end_time == time(4, 30)
+
+    def test_sets_default_work_mode(self, default_inputs):
+        """SPEC §2: BaselineRule resets work_mode to the safe default
+        every tick. SavingSessionRule overrides to 'Selling first'
+        when active; once the session ends, baseline runs again on
+        the next tick and resets here so the inverter stops exporting."""
+        rule = BaselineRule()
+        state = ProgrammeState.default(min_soc=20)
+        result = rule.apply(state, default_inputs)
+        assert result.work_mode == "Zero export to CT"

--- a/tests/test_rules/test_saving_session.py
+++ b/tests/test_rules/test_saving_session.py
@@ -124,6 +124,30 @@ class TestSavingSessionRule:
         assert result.slots[1].capacity_soc == 10
         assert any("already at floor" in r for r in result.reason_log)
 
+    def test_active_session_sets_work_mode_selling_first(self):
+        """SPEC §2 / §9 row 3: drain via 'Selling first' work mode so
+        the inverter actually exports during the session.
+        """
+        rule = SavingSessionRule()
+        prog = _spec_programme()
+        result = rule.apply(prog, _inputs(
+            now_utc=datetime(2026, 5, 2, 16, 0, tzinfo=timezone.utc),
+            saving=True,
+            tz=ZoneInfo("Europe/London"),
+        ))
+        assert result.work_mode == "Selling first"
+
+    def test_inactive_session_leaves_work_mode_unset(self):
+        rule = SavingSessionRule()
+        prog = _spec_programme()
+        # work_mode is None at construction; the rule shouldn't touch it.
+        prog.work_mode = "Zero export to CT"
+        result = rule.apply(prog, _inputs(
+            now_utc=datetime(2026, 5, 2, 16, 0, tzinfo=timezone.utc),
+            saving=False,
+        ))
+        assert result.work_mode == "Zero export to CT"
+
     def test_overnight_slot_correctly_resolved_through_local_tz(self):
         """A session at 00:30 BST = 23:30 UTC. Without tz, lookup uses
         UTC 23:30 which falls in slot 4 (23:30-23:55). With tz, we


### PR DESCRIPTION
## Summary
SPEC §2 listed 5 global inverter settings on top of the per-slot programme; none were wired pre-PR. This lands `work_mode` end-to-end — the one needed for the Octoplus saving-session story to actually drain to the grid (HEO-10 was setting cap=0/gc=False but the inverter stayed on 'Zero export to CT', so it never exported).

* `ProgrammeState.work_mode` (None = don't touch).
* `GlobalWrite` + `MqttWriter.diff_globals` / `write_globals` mirror the per-slot pattern with HEO-32 bare-Saved response handling.
* `apply_programme_diff` flushes globals BEFORE per-slot writes (right work_mode then matching caps).
* `inverter_state_reader` reads `select.sa_inverter_1_work_mode`.
* `BaselineRule` sets default `Zero export to CT`; `SavingSessionRule` overrides to `Selling first` when active.

Valid SA values confirmed via mosquitto probe of `homeassistant/select/.../work_mode/config`: `["Selling first", "Zero export to load", "Zero export to CT"]`.

## Test plan
- [x] 412 tests pass (+11 new across diff_globals, write_globals, apply_programme_diff, BaselineRule, SavingSessionRule)
- [ ] Deploy + watch first tick log: should write work_mode once (current is 'Zero export to CT', BaselineRule writes the same so probably no diff initially)
- [ ] Trigger a saving session via developer-tools, verify work_mode flips to 'Selling first' on the inverter

🤖 Generated with [Claude Code](https://claude.com/claude-code)