### PR TITLE
feat(spec2): wire energy_pattern + fix work_mode entity ID

### DIFF
--- a/custom_components/heo2/inverter_state_reader.py
+++ b/custom_components/heo2/inverter_state_reader.py
@@ -26,10 +26,13 @@ logger = logging.getLogger(__name__)
 _CAPACITY_FMT = "sensor.sa_inverter_{inv}_capacity_point_{n}"
 _GRID_CHARGE_FMT = "sensor.sa_inverter_{inv}_grid_charge_point_{n}"
 _TIME_FMT = "sensor.sa_inverter_{inv}_time_point_{n}"
-# SPEC §2 globals. Currently only work_mode is wired (HEO follow-up
-# PRs will extend to energy_pattern / charge_rate / discharge_rate /
-# zero_export_to_CT).
-_WORK_MODE_FMT = "select.sa_inverter_{inv}_work_mode"
+# SPEC §2 globals. SA's discovery publishes work_mode / energy_pattern
+# as `select` platform entries but HA registers the state under the
+# `sensor.sa_inverter_*` namespace (verified via REST at deploy time).
+# `select.sa_inverter_1_work_mode` returns 404; `sensor.sa_inverter_1_work_mode`
+# returns the current value.
+_WORK_MODE_FMT = "sensor.sa_inverter_{inv}_work_mode"
+_ENERGY_PATTERN_FMT = "sensor.sa_inverter_{inv}_energy_pattern"
 
 
 # Fallback defaults when an entity is missing or unparseable. Chosen to
@@ -132,8 +135,15 @@ def read_programme_state(
 
     work_mode_raw = state_lookup(_WORK_MODE_FMT.format(inv=inv))
     work_mode = work_mode_raw.strip() if work_mode_raw else None
+    energy_pattern_raw = state_lookup(_ENERGY_PATTERN_FMT.format(inv=inv))
+    energy_pattern = energy_pattern_raw.strip() if energy_pattern_raw else None
 
-    return ProgrammeState(slots=slots, reason_log=[], work_mode=work_mode)
+    return ProgrammeState(
+        slots=slots,
+        reason_log=[],
+        work_mode=work_mode,
+        energy_pattern=energy_pattern,
+    )
 
 
 def read_from_hass(

--- a/custom_components/heo2/models.py
+++ b/custom_components/heo2/models.py
@@ -67,19 +67,19 @@ _FILLER_THRESHOLD_MINUTES = 30
 class ProgrammeState:
     """The 6-slot programme produced by the rule engine.
 
-    `work_mode` is a SPEC §2 global setting that overrides the
-    inverter's behaviour across slots (e.g. "Selling first" during a
-    saving session, "Zero export to CT" in normal operation). None
-    means "don't touch" so older callers and tests built before the
-    work_mode wiring still produce valid programmes that don't
-    accidentally write the field.
+    `work_mode` and `energy_pattern` are SPEC §2 global settings that
+    override the inverter's behaviour across slots. None means "don't
+    touch" so older callers and tests built before SPEC §2 wiring
+    still produce valid programmes that don't clobber inverter state.
 
     Valid values per SA discovery:
-      "Selling first" | "Zero export to load" | "Zero export to CT"
+      work_mode: "Selling first" | "Zero export to load" | "Zero export to CT"
+      energy_pattern: "Battery first" | "Load first"
     """
     slots: list[SlotConfig]
     reason_log: list[str] = field(default_factory=list)
     work_mode: Optional[str] = None
+    energy_pattern: Optional[str] = None
 
     @classmethod
     def default(cls, min_soc: int = 20) -> ProgrammeState:

--- a/custom_components/heo2/mqtt_writer.py
+++ b/custom_components/heo2/mqtt_writer.py
@@ -175,17 +175,31 @@ class MqttWriter:
     ) -> list[GlobalWrite]:
         """Diff the SPEC §2 global settings between two programmes.
 
-        Currently only `work_mode` is wired. `None` on the new side
-        means "don't touch", so older callers that don't set
-        work_mode never trigger a write. Equality check ignores case
-        and trailing whitespace to be defensive about SA renderings.
+        `None` on the new side means "don't touch", so older callers
+        that don't set the field never trigger a write. Equality check
+        ignores case and trailing whitespace to be defensive about SA
+        renderings.
+
+        Currently wired: `work_mode`, `energy_pattern`. Future PRs can
+        extend the same pattern to charge/discharge rate and zero-
+        export-to-CT. Order matters: work_mode is applied first because
+        downstream rules may depend on it (e.g. cannot export under
+        Zero-Export work_mode regardless of energy_pattern).
         """
         out: list[GlobalWrite] = []
-        if new.work_mode is not None:
-            cur = (current.work_mode or "").strip()
-            nw = new.work_mode.strip()
-            if cur.casefold() != nw.casefold():
-                out.append(GlobalWrite(setting="work_mode", value=nw))
+
+        def _check(field_name: str, topic_name: str) -> None:
+            new_val = getattr(new, field_name)
+            if new_val is None:
+                return
+            cur_val = getattr(current, field_name) or ""
+            if str(cur_val).strip().casefold() != new_val.strip().casefold():
+                out.append(GlobalWrite(
+                    setting=topic_name, value=new_val.strip(),
+                ))
+
+        _check("work_mode", "work_mode")
+        _check("energy_pattern", "energy_pattern")
         return out
 
     def diff(self, current: ProgrammeState, new: ProgrammeState) -> list[SlotWrite]:

--- a/custom_components/heo2/rules/baseline.py
+++ b/custom_components/heo2/rules/baseline.py
@@ -46,15 +46,19 @@ class BaselineRule(Rule):
             SlotConfig(time(23, 58), time(0, 0), min_soc, False),
         ]
 
-        # SPEC §2 work_mode default. SavingSessionRule overrides to
-        # "Selling first" while a session is active; once the session
-        # ends, BaselineRule re-runs and resets here so the inverter
-        # stops exporting.
+        # SPEC §2 globals. SavingSessionRule overrides work_mode to
+        # "Selling first" while a session is active; BaselineRule re-
+        # runs once the session ends and resets to defaults here.
+        # `Load first` energy_pattern means the inverter prioritises
+        # supplying load before charging the battery from solar - the
+        # right default for a UK house with day load + Octopus IGO.
         state.work_mode = "Zero export to CT"
+        state.energy_pattern = "Load first"
 
         state.reason_log.append(
             f"Baseline: overnight charge to 100% until {self.off_peak_end}, "
             f"solar day until {self.evening_start}, "
-            f"evening drain to {min_soc}%; work_mode=Zero export to CT"
+            f"evening drain to {min_soc}%; "
+            f"work_mode=Zero export to CT, energy_pattern=Load first"
         )
         return state

--- a/tests/test_mqtt_writer.py
+++ b/tests/test_mqtt_writer.py
@@ -611,6 +611,32 @@ class TestDiffGlobals:
         writer = MqttWriter(client=MagicMock())
         assert writer.diff_globals(cur, new) == []
 
+    def test_energy_pattern_change_detected(self):
+        cur = _baseline_programme()
+        cur.work_mode = "Zero export to CT"
+        cur.energy_pattern = "Load first"
+        new = _baseline_programme()
+        new.work_mode = "Zero export to CT"
+        new.energy_pattern = "Battery first"
+        writer = MqttWriter(client=MagicMock())
+        out = writer.diff_globals(cur, new)
+        assert len(out) == 1
+        assert out[0].setting == "energy_pattern"
+        assert out[0].value == "Battery first"
+
+    def test_both_globals_change_returns_both_writes_in_order(self):
+        """work_mode comes before energy_pattern (rules may depend on
+        work_mode being applied first)."""
+        cur = _baseline_programme()
+        cur.work_mode = "Zero export to CT"
+        cur.energy_pattern = "Load first"
+        new = _baseline_programme()
+        new.work_mode = "Selling first"
+        new.energy_pattern = "Battery first"
+        writer = MqttWriter(client=MagicMock())
+        out = writer.diff_globals(cur, new)
+        assert [w.setting for w in out] == ["work_mode", "energy_pattern"]
+
 
 class TestWriteGlobals:
     @pytest.mark.asyncio

--- a/tests/test_rules/test_baseline.py
+++ b/tests/test_rules/test_baseline.py
@@ -97,3 +97,11 @@ class TestBaselineRule:
         state = ProgrammeState.default(min_soc=20)
         result = rule.apply(state, default_inputs)
         assert result.work_mode == "Zero export to CT"
+
+    def test_sets_default_energy_pattern(self, default_inputs):
+        """SPEC §2: 'Load first' is the right default for a UK house -
+        prioritise covering load before topping the battery."""
+        rule = BaselineRule()
+        state = ProgrammeState.default(min_soc=20)
+        result = rule.apply(state, default_inputs)
+        assert result.energy_pattern == "Load first"


### PR DESCRIPTION
## Summary
1. **Bug fix for #49**: work_mode seed read was looking at `select.sa_inverter_1_work_mode` which returns 404 in production. The actual entity is `sensor.sa_inverter_1_work_mode` (verified post-deploy). Without this, the seed always returned None and we'd write work_mode redundantly every tick.
2. **New global**: energy_pattern, mirror of work_mode plumbing. BaselineRule sets default 'Load first'.

## Test plan
- [x] 415 tests pass (+3 new)
- [ ] Deploy + watch first tick: should NOT write work_mode (seed now matches plan), and should write energy_pattern only if it differs from current 'Load first'

🤖 Generated with [Claude Code](https://claude.com/claude-code)