### PR TITLE
feat(spec2): wire max_charge_current + max_discharge_current globals

### DIFF
--- a/custom_components/heo2/inverter_state_reader.py
+++ b/custom_components/heo2/inverter_state_reader.py
@@ -33,6 +33,12 @@ _TIME_FMT = "sensor.sa_inverter_{inv}_time_point_{n}"
 # returns the current value.
 _WORK_MODE_FMT = "sensor.sa_inverter_{inv}_work_mode"
 _ENERGY_PATTERN_FMT = "sensor.sa_inverter_{inv}_energy_pattern"
+# SA exposes charge/discharge limits as numeric current sensors in
+# Amps. ProgrammeState carries them as `max_charge_a` / `max_discharge_a`
+# floats; conversion to/from watts is the user's concern (multiply by
+# battery nominal voltage, ~51.2V for 4x BP51.2 in series).
+_MAX_CHARGE_CURRENT_FMT = "sensor.sa_inverter_{inv}_max_charge_current"
+_MAX_DISCHARGE_CURRENT_FMT = "sensor.sa_inverter_{inv}_max_discharge_current"
 
 
 # Fallback defaults when an entity is missing or unparseable. Chosen to
@@ -138,11 +144,28 @@ def read_programme_state(
     energy_pattern_raw = state_lookup(_ENERGY_PATTERN_FMT.format(inv=inv))
     energy_pattern = energy_pattern_raw.strip() if energy_pattern_raw else None
 
+    def _parse_amps(raw: str | None) -> float | None:
+        if raw is None:
+            return None
+        try:
+            return float(raw)
+        except (ValueError, TypeError):
+            return None
+
+    max_charge_a = _parse_amps(
+        state_lookup(_MAX_CHARGE_CURRENT_FMT.format(inv=inv))
+    )
+    max_discharge_a = _parse_amps(
+        state_lookup(_MAX_DISCHARGE_CURRENT_FMT.format(inv=inv))
+    )
+
     return ProgrammeState(
         slots=slots,
         reason_log=[],
         work_mode=work_mode,
         energy_pattern=energy_pattern,
+        max_charge_a=max_charge_a,
+        max_discharge_a=max_discharge_a,
     )
 
 

--- a/custom_components/heo2/models.py
+++ b/custom_components/heo2/models.py
@@ -75,11 +75,15 @@ class ProgrammeState:
     Valid values per SA discovery:
       work_mode: "Selling first" | "Zero export to load" | "Zero export to CT"
       energy_pattern: "Battery first" | "Load first"
+      max_charge_a / max_discharge_a: 0..350 A (Sunsynk 5kW limit ~100A
+        at 51.2V battery nominal)
     """
     slots: list[SlotConfig]
     reason_log: list[str] = field(default_factory=list)
     work_mode: Optional[str] = None
     energy_pattern: Optional[str] = None
+    max_charge_a: Optional[float] = None
+    max_discharge_a: Optional[float] = None
 
     @classmethod
     def default(cls, min_soc: int = 20) -> ProgrammeState:

--- a/custom_components/heo2/mqtt_writer.py
+++ b/custom_components/heo2/mqtt_writer.py
@@ -188,7 +188,7 @@ class MqttWriter:
         """
         out: list[GlobalWrite] = []
 
-        def _check(field_name: str, topic_name: str) -> None:
+        def _check_str(field_name: str, topic_name: str) -> None:
             new_val = getattr(new, field_name)
             if new_val is None:
                 return
@@ -198,8 +198,26 @@ class MqttWriter:
                     setting=topic_name, value=new_val.strip(),
                 ))
 
-        _check("work_mode", "work_mode")
-        _check("energy_pattern", "energy_pattern")
+        def _check_float(
+            field_name: str, topic_name: str, tol: float = 0.5,
+        ) -> None:
+            new_val = getattr(new, field_name)
+            if new_val is None:
+                return
+            cur_val = getattr(current, field_name)
+            if cur_val is None or abs(float(cur_val) - float(new_val)) > tol:
+                # SA accepts the value as a plain number string;
+                # %g trims trailing zeros without scientific notation
+                # for the typical 0..350 A range.
+                out.append(GlobalWrite(
+                    setting=topic_name,
+                    value=f"{float(new_val):g}",
+                ))
+
+        _check_str("work_mode", "work_mode")
+        _check_str("energy_pattern", "energy_pattern")
+        _check_float("max_charge_a", "max_charge_current")
+        _check_float("max_discharge_a", "max_discharge_current")
         return out
 
     def diff(self, current: ProgrammeState, new: ProgrammeState) -> list[SlotWrite]:

--- a/custom_components/heo2/rules/baseline.py
+++ b/custom_components/heo2/rules/baseline.py
@@ -52,13 +52,19 @@ class BaselineRule(Rule):
         # `Load first` energy_pattern means the inverter prioritises
         # supplying load before charging the battery from solar - the
         # right default for a UK house with day load + Octopus IGO.
+        # Charge / discharge limits at 100A match the Sunsynk 5kW
+        # nominal max (100A * ~51.2V = 5120W) - leaves the inverter
+        # free to use its full rate when needed.
         state.work_mode = "Zero export to CT"
         state.energy_pattern = "Load first"
+        state.max_charge_a = 100.0
+        state.max_discharge_a = 100.0
 
         state.reason_log.append(
             f"Baseline: overnight charge to 100% until {self.off_peak_end}, "
             f"solar day until {self.evening_start}, "
             f"evening drain to {min_soc}%; "
-            f"work_mode=Zero export to CT, energy_pattern=Load first"
+            f"work_mode=Zero export to CT, energy_pattern=Load first, "
+            f"max_charge=100A, max_discharge=100A"
         )
         return state

--- a/tests/test_mqtt_writer.py
+++ b/tests/test_mqtt_writer.py
@@ -637,6 +637,46 @@ class TestDiffGlobals:
         out = writer.diff_globals(cur, new)
         assert [w.setting for w in out] == ["work_mode", "energy_pattern"]
 
+    def test_max_charge_amp_change_detected(self):
+        cur = _baseline_programme()
+        cur.max_charge_a = 100.0
+        new = _baseline_programme()
+        new.max_charge_a = 50.0
+        writer = MqttWriter(client=MagicMock())
+        out = writer.diff_globals(cur, new)
+        assert len(out) == 1
+        assert out[0].setting == "max_charge_current"
+        assert out[0].value == "50"
+
+    def test_max_charge_amp_within_tolerance_skipped(self):
+        """SA reports floats with one decimal; small rounding shouldn't
+        re-write every tick."""
+        cur = _baseline_programme()
+        cur.max_charge_a = 100.0
+        new = _baseline_programme()
+        new.max_charge_a = 100.2  # within 0.5 A tolerance
+        writer = MqttWriter(client=MagicMock())
+        assert writer.diff_globals(cur, new) == []
+
+    def test_max_discharge_amp_change_detected(self):
+        cur = _baseline_programme()
+        cur.max_discharge_a = 100.0
+        new = _baseline_programme()
+        new.max_discharge_a = 25.0
+        writer = MqttWriter(client=MagicMock())
+        out = writer.diff_globals(cur, new)
+        assert len(out) == 1
+        assert out[0].setting == "max_discharge_current"
+        assert out[0].value == "25"
+
+    def test_none_amp_value_does_not_trigger_write(self):
+        cur = _baseline_programme()
+        cur.max_charge_a = 100.0
+        new = _baseline_programme()
+        new.max_charge_a = None
+        writer = MqttWriter(client=MagicMock())
+        assert writer.diff_globals(cur, new) == []
+
 
 class TestWriteGlobals:
     @pytest.mark.asyncio

--- a/tests/test_rules/test_baseline.py
+++ b/tests/test_rules/test_baseline.py
@@ -105,3 +105,13 @@ class TestBaselineRule:
         state = ProgrammeState.default(min_soc=20)
         result = rule.apply(state, default_inputs)
         assert result.energy_pattern == "Load first"
+
+    def test_sets_default_charge_discharge_rates(self, default_inputs):
+        """SPEC §2: leave the inverter free to use its full Sunsynk 5kW
+        nominal rate by default. Other rules can lower if needed
+        (e.g. Winter low-PV preserving cycles)."""
+        rule = BaselineRule()
+        state = ProgrammeState.default(min_soc=20)
+        result = rule.apply(state, default_inputs)
+        assert result.max_charge_a == 100.0
+        assert result.max_discharge_a == 100.0


### PR DESCRIPTION
## Summary
Last of the SPEC §2 globals: max_charge_current + max_discharge_current (in Amps to match SA's topic). Same diff_globals plumbing as work_mode and energy_pattern, plus a 0.5A tolerance to avoid spurious writes from SA's float rounding.

BaselineRule sets defaults at 100A (Sunsynk 5kW nominal). Future rules (EVChargingRule, Winter low-PV) can lower if needed.

SPEC §8 "Zero export to CT" is intentionally NOT a separate global - it's covered by `work_mode = "Zero export to CT"` already.

## Test plan
- [x] 420 tests pass (+5 new)
- [ ] Deploy + watch first tick log: should write max_charge_current=100 / max_discharge_current=100 if SA reports anything different (or skip if already at 100A)

🤖 Generated with [Claude Code](https://claude.com/claude-code)