### PR TITLE
fix: project UTC→local hour in three latent aliasing sites

### DIFF
--- a/custom_components/heo2/coordinator.py
+++ b/custom_components/heo2/coordinator.py
@@ -297,8 +297,12 @@ class HEO2Coordinator(DataUpdateCoordinator):
                 appliance_name=name,
             )
 
-        from datetime import datetime, timezone
-        current_hour = datetime.now(timezone.utc).hour
+        # Forecast arrays are LOCAL-hour indexed (`solar_forecast_from_hacs`
+        # builds them aligned to local midnight). Pre-fix used
+        # `datetime.now(timezone.utc).hour` which is UTC-hour - in BST
+        # the SOC trajectory's hour-0 point would be 1 hour off,
+        # mis-attributing solar/load to the wrong slot.
+        current_hour = inputs.now_local().hour
         self.soc_trajectory = calculate_soc_trajectory(
             current_soc=inputs.current_soc,
             solar_forecast_kwh=inputs.solar_forecast_kwh,

--- a/custom_components/heo2/rules/ev_charging.py
+++ b/custom_components/heo2/rules/ev_charging.py
@@ -24,7 +24,12 @@ class EVChargingRule(Rule):
         if inputs.igo_dispatching:
             return state  # IGO dispatch takes precedence
 
-        now_time = inputs.now.time().replace(second=0, microsecond=0)
+        # Use local-tz-aware lookup. inputs.now is UTC; programme slots
+        # are local time-of-day. inputs.now.time() (UTC) was aliasing
+        # against local slots in DST - same bug class as HEO-31 PR2 #39.
+        now_time = inputs.now_local().time().replace(
+            second=0, microsecond=0,
+        )
         try:
             idx = state.find_slot_at(now_time)
         except ValueError:

--- a/custom_components/heo2/sensor.py
+++ b/custom_components/heo2/sensor.py
@@ -229,7 +229,8 @@ class SolarForecastHourlySensor(CoordinatorEntity, SensorEntity):
         inputs = self.coordinator.last_inputs
         if inputs is None:
             return None
-        hour = inputs.now.hour
+        # Forecast array is local-hour indexed; project UTC->local.
+        hour = inputs.now_local().hour
         return inputs.solar_forecast_kwh[hour]
 
     @property
@@ -255,7 +256,8 @@ class LoadForecastHourlySensor(CoordinatorEntity, SensorEntity):
         inputs = self.coordinator.last_inputs
         if inputs is None:
             return None
-        hour = inputs.now.hour
+        # Forecast array is local-hour indexed; project UTC->local.
+        hour = inputs.now_local().hour
         return round(inputs.load_forecast_kwh[hour] * 1000, 0)
 
     @property


### PR DESCRIPTION
## Summary
Three pre-PR2-tz-fix code paths still used UTC hour/time to index local-hour arrays or look up local time-of-day slots. Same class of bug as plan_validator #39, surfacing in BST corner cases.

- `EVChargingRule` slot lookup
- Coordinator's SOC trajectory `current_hour` arg
- Dashboard hourly forecast sensors

All three now go through `inputs.now_local()`.

## Test plan
- [x] 425 tests pass
- [ ] Deploy + check dashboard hourly forecast aligns with the actual current local hour during BST