### PR TITLE
feat(H7): cycle budget tracker + cycles_today sensor

### DIFF
--- a/custom_components/heo2/__init__.py
+++ b/custom_components/heo2/__init__.py
@@ -108,7 +108,8 @@ async def async_setup_entry(hass, entry) -> bool:
     def _daily_reset(_now) -> None:
         now = datetime.now(timezone.utc)
         coordinator.cost_accumulator.reset_daily(now)
-        logger.info("CostTracker: daily reset")
+        coordinator.cycle_tracker.reset_daily()
+        logger.info("CostTracker + CycleTracker: daily reset")
 
     unsub_callbacks.append(
         async_track_time_change(hass, _daily_reset, hour=0, minute=0, second=0)

--- a/custom_components/heo2/coordinator.py
+++ b/custom_components/heo2/coordinator.py
@@ -44,6 +44,7 @@ from .appliance_timing import ApplianceTimingCalculator, ApplianceSuggestion
 from .const import DEFAULT_APPLIANCES
 from .soc_trajectory import calculate_soc_trajectory
 from .cost_tracker import CostAccumulator
+from .cycle_tracker import CycleTracker
 from .octopus import OctopusBillingFetcher
 from .const import DEFAULT_FLAT_RATE_PENCE
 from .mqtt_writer import MqttWriter, apply_programme_diff
@@ -170,6 +171,11 @@ class HEO2Coordinator(DataUpdateCoordinator):
         # Dashboard state
         self.soc_trajectory: list[float] = [0.0] * 24
         self.cost_accumulator = CostAccumulator()
+        self.cycle_tracker = CycleTracker(
+            battery_capacity_kwh=self._config.get(
+                "battery_capacity_kwh", 20.0,
+            ),
+        )
         self.octopus: OctopusBillingFetcher | None = None
 
         # ROI state (seeded from config)
@@ -319,6 +325,19 @@ class HEO2Coordinator(DataUpdateCoordinator):
 
         flat_rate = self._config.get("flat_rate_pence", DEFAULT_FLAT_RATE_PENCE)
         self.cost_accumulator.calculate_savings_vs_flat(flat_rate)
+
+        # H7 cycle tracker: read SA's cumulative battery-out energy
+        # counter so the next cycles_today reflects what the inverter
+        # has actually drained today. Default entity ID matches Paddy's
+        # install; users with a different SA build can override via
+        # `battery_energy_out_entity` config.
+        bo_entity = self._config.get(
+            "battery_energy_out_entity",
+            "sensor.solar_assistant_solar_assistant_total_battery_energy_out_state",
+        )
+        bo_kwh = self._read_entity_float(bo_entity, default=-1.0)
+        if bo_kwh >= 0:
+            self.cycle_tracker.observe(bo_kwh)
 
     def _cfg_float(self, key: str, default: float) -> float:
         """Read a runtime-tunable knob from `_config` as float. Read

--- a/custom_components/heo2/cycle_tracker.py
+++ b/custom_components/heo2/cycle_tracker.py
@@ -1,0 +1,81 @@
+# custom_components/heo2/cycle_tracker.py
+"""H7 battery cycle budget tracking. No HA imports.
+
+A "cycle" is one full charge + discharge of the battery (so 1 kWh
+discharged from a 20 kWh battery = 0.05 cycles). The standard
+industry definition counts only discharge throughput -- charging is
+the means, discharging is what wears the cells.
+
+Inputs:
+  * Cumulative battery-out energy counter (kWh, monotonic since some
+    epoch). SA exposes
+    `sensor.solar_assistant_solar_assistant_total_battery_energy_out_state`
+    on Paddy's install.
+  * Battery capacity (kWh). From config.
+
+Daily reset records the value at local midnight; today's cycles is
+`(current - midnight_snapshot) / capacity`. Coordinator owns the
+midnight snapshot via the existing daily_reset hook used by
+`cost_accumulator`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class CycleTracker:
+    """Track battery cycles since the last daily reset.
+
+    `_midnight_total_out_kwh` is the cumulative battery-out value
+    captured at the most recent local midnight reset. None means
+    "first ever observation" - the next observation seeds it without
+    counting cycles since boot, avoiding a misleading huge spike
+    after first install.
+    """
+
+    battery_capacity_kwh: float
+    _midnight_total_out_kwh: float | None = None
+    _last_observed_total_out_kwh: float | None = None
+
+    def observe(self, total_out_kwh: float) -> None:
+        """Record the latest cumulative battery-out reading.
+
+        First call seeds the midnight snapshot. Subsequent calls
+        update the running observation; `cycles_today` reads the
+        delta. Out-of-order or counter-reset values (current < snapshot)
+        re-seed the snapshot to keep the result non-negative.
+        """
+        if self._midnight_total_out_kwh is None:
+            self._midnight_total_out_kwh = total_out_kwh
+        if total_out_kwh < self._midnight_total_out_kwh:
+            # Counter reset (e.g. SA restart wiped totals) - re-seed.
+            self._midnight_total_out_kwh = total_out_kwh
+        self._last_observed_total_out_kwh = total_out_kwh
+
+    def reset_daily(self) -> None:
+        """Snapshot today's running total as the new midnight baseline.
+        Called by the coordinator's existing daily_reset hook at 00:00.
+        """
+        if self._last_observed_total_out_kwh is not None:
+            self._midnight_total_out_kwh = self._last_observed_total_out_kwh
+
+    @property
+    def cycles_today(self) -> float:
+        """Battery cycles since last daily reset.
+
+        Returns 0.0 before the first observation lands. A "cycle" is
+        defined as one full battery_capacity_kwh of discharge.
+        """
+        if (
+            self._midnight_total_out_kwh is None
+            or self._last_observed_total_out_kwh is None
+            or self.battery_capacity_kwh <= 0
+        ):
+            return 0.0
+        delta_kwh = max(
+            0.0,
+            self._last_observed_total_out_kwh - self._midnight_total_out_kwh,
+        )
+        return delta_kwh / self.battery_capacity_kwh

--- a/custom_components/heo2/sensor.py
+++ b/custom_components/heo2/sensor.py
@@ -45,6 +45,7 @@ async def async_setup_entry(
     entities.append(ActiveRulesSensor(coordinator, entry))
     entities.append(ProjectionTodaySensor(coordinator, entry))
     entities.append(GranularitySnapSensor(coordinator, entry))
+    entities.append(CyclesTodaySensor(coordinator, entry))
 
     # Dashboard sensors (Group 2: Cost Accumulator)
     entities.append(DailyImportCostSensor(coordinator, entry))
@@ -492,6 +493,24 @@ class ProjectionTodaySensor(CoordinatorEntity, SensorEntity):
             "peak_import_kwh": round(p.peak_import_kwh, 2),
             "warnings": self.coordinator.validation_warnings,
         }
+
+
+class CyclesTodaySensor(CoordinatorEntity, SensorEntity):
+    """SPEC H7: cycles consumed since the last local-midnight reset.
+    Soft target is <=2 cycles/day; a follow-up binary_sensor can fire
+    when 3 consecutive days breach. Native value is float (e.g. 1.42)."""
+
+    _attr_native_unit_of_measurement = "cycles"
+    _attr_state_class = SensorStateClass.MEASUREMENT
+
+    def __init__(self, coordinator: HEO2Coordinator, entry: ConfigEntry):
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{entry.entry_id}_cycles_today"
+        self._attr_name = "HEO II Cycles Today"
+
+    @property
+    def native_value(self) -> float:
+        return round(self.coordinator.cycle_tracker.cycles_today, 3)
 
 
 class GranularitySnapSensor(CoordinatorEntity, SensorEntity):

--- a/tests/test_cycle_tracker.py
+++ b/tests/test_cycle_tracker.py
@@ -1,0 +1,59 @@
+# tests/test_cycle_tracker.py
+"""Tests for the H7 cycle budget tracker."""
+
+from __future__ import annotations
+
+import pytest
+
+from heo2.cycle_tracker import CycleTracker
+
+
+class TestCycleTracker:
+    def test_no_observation_yet_reports_zero_cycles(self):
+        t = CycleTracker(battery_capacity_kwh=20.0)
+        assert t.cycles_today == 0.0
+
+    def test_first_observation_seeds_baseline_and_reports_zero(self):
+        t = CycleTracker(battery_capacity_kwh=20.0)
+        t.observe(150.0)
+        # Same value is still our baseline; no cycles yet.
+        assert t.cycles_today == 0.0
+
+    def test_subsequent_observation_reports_cycles(self):
+        t = CycleTracker(battery_capacity_kwh=20.0)
+        t.observe(150.0)
+        t.observe(160.0)  # +10 kWh out -> 0.5 cycles
+        assert t.cycles_today == pytest.approx(0.5, abs=0.001)
+
+    def test_daily_reset_zeroes_cycles_today(self):
+        t = CycleTracker(battery_capacity_kwh=20.0)
+        t.observe(150.0)
+        t.observe(170.0)  # 1.0 cycles before reset
+        assert t.cycles_today == pytest.approx(1.0)
+
+        t.reset_daily()
+        # New baseline = last observation; cycles_today now 0.
+        assert t.cycles_today == pytest.approx(0.0)
+
+        # Further observation shows fresh cycles since reset.
+        t.observe(180.0)
+        assert t.cycles_today == pytest.approx(0.5, abs=0.001)
+
+    def test_counter_reset_reseeds_without_negative_cycles(self):
+        """If SA restarts and the cumulative counter drops to a lower
+        value, the tracker should re-seed rather than report negative
+        cycles."""
+        t = CycleTracker(battery_capacity_kwh=20.0)
+        t.observe(150.0)
+        t.observe(155.0)  # 0.25 cycles
+        # Counter reset to 5 (e.g. SA storage wiped)
+        t.observe(5.0)
+        assert t.cycles_today == 0.0
+        t.observe(10.0)  # 5 kWh after the reset
+        assert t.cycles_today == pytest.approx(0.25, abs=0.001)
+
+    def test_zero_capacity_does_not_divide_by_zero(self):
+        t = CycleTracker(battery_capacity_kwh=0.0)
+        t.observe(100.0)
+        t.observe(200.0)
+        assert t.cycles_today == 0.0


### PR DESCRIPTION
## Summary
SPEC §1/§4/H7 minimum-viable slice. Reads SA's cumulative `total_battery_energy_out_state`, computes today's discharge throughput as a fraction of `battery_capacity_kwh`, exposes `sensor.heo_ii_cycles_today` (float, 'cycles' unit).

Reset hook reuses the existing 00:00 UTC daily_reset that drives `cost_accumulator`. Counter-reset detection re-seeds rather than going negative when SA wipes its totals.

## Test plan
- [x] 431 tests pass (+6 new in test_cycle_tracker)
- [ ] Deploy + verify `sensor.heo_ii_cycles_today` shows current day's cycles after first tick (will be ~ today-so-far given midnight baseline gets seeded on first observation post-deploy)

## Follow-up
- Persistence (Store) so the midnight baseline survives HA restart
- Rolling 3-day history + `binary_sensor.heo_ii_cycle_budget_exceeded`