### PR TITLE
feat(H7): cycle budget alert binary_sensor + 3-day rolling history

### DIFF
--- a/custom_components/heo2/binary_sensor.py
+++ b/custom_components/heo2/binary_sensor.py
@@ -26,6 +26,7 @@ async def async_setup_entry(
         HealthySensor(coordinator, entry),
         WritesBlockedSensor(coordinator, entry),
         EPSActiveSensor(coordinator, entry),
+        CycleBudgetExceededSensor(coordinator, entry),
     ])
 
 
@@ -84,3 +85,27 @@ class EPSActiveSensor(CoordinatorEntity, BinarySensorEntity):
     @property
     def is_on(self) -> bool:
         return self.coordinator.eps_active
+
+
+class CycleBudgetExceededSensor(CoordinatorEntity, BinarySensorEntity):
+    """SPEC §1 / H7: ON when the battery has run > daily_budget cycles
+    on each of the last 3 finished days. Today's in-progress count
+    doesn't trip the alert until midnight seals the day's total."""
+    _attr_device_class = BinarySensorDeviceClass.PROBLEM
+
+    def __init__(self, coordinator: HEO2Coordinator, entry: ConfigEntry):
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{entry.entry_id}_cycle_budget_exceeded"
+        self._attr_name = "HEO II Cycle Budget Exceeded"
+
+    @property
+    def is_on(self) -> bool:
+        return self.coordinator.cycle_tracker.budget_exceeded
+
+    @property
+    def extra_state_attributes(self) -> dict:
+        t = self.coordinator.cycle_tracker
+        return {
+            "history": [round(c, 3) for c in t.history],
+            "daily_budget": t.daily_budget,
+        }

--- a/custom_components/heo2/config_flow.py
+++ b/custom_components/heo2/config_flow.py
@@ -208,6 +208,7 @@ _OPTIONS_RULE_KNOBS = (
     ("replan_soc_pct", 10, int),
     ("sell_top_pct_default", 30, int),
     ("cheap_charge_bottom_pct", 25, int),
+    ("cycle_budget", 2.0, float),  # H7 daily soft target
 )
 
 

--- a/custom_components/heo2/coordinator.py
+++ b/custom_components/heo2/coordinator.py
@@ -175,6 +175,7 @@ class HEO2Coordinator(DataUpdateCoordinator):
             battery_capacity_kwh=self._config.get(
                 "battery_capacity_kwh", 20.0,
             ),
+            daily_budget=float(self._config.get("cycle_budget", 2.0)),
         )
         self.octopus: OctopusBillingFetcher | None = None
 
@@ -338,6 +339,10 @@ class HEO2Coordinator(DataUpdateCoordinator):
         bo_kwh = self._read_entity_float(bo_entity, default=-1.0)
         if bo_kwh >= 0:
             self.cycle_tracker.observe(bo_kwh)
+        # Pick up live edits to daily_budget without restart
+        self.cycle_tracker.daily_budget = float(
+            self._config.get("cycle_budget", 2.0),
+        )
 
     def _cfg_float(self, key: str, default: float) -> float:
         """Read a runtime-tunable knob from `_config` as float. Read

--- a/custom_components/heo2/cycle_tracker.py
+++ b/custom_components/heo2/cycle_tracker.py
@@ -21,23 +21,41 @@ midnight snapshot via the existing daily_reset hook used by
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+
+
+# SPEC §1 / H7: soft target. 3 consecutive days above this triggers the
+# `cycle_budget_exceeded` alert. Tunable via OptionsFlow knob in a
+# follow-up; for now hard-coded to the SPEC default.
+_DEFAULT_DAILY_BUDGET = 2.0
+# Number of consecutive days that must breach to fire the alert.
+# SPEC §1: "alert if exceeded for 3 days running."
+_ALERT_WINDOW_DAYS = 3
 
 
 @dataclass
 class CycleTracker:
-    """Track battery cycles since the last daily reset.
+    """Track battery cycles since the last daily reset, plus a rolling
+    `_ALERT_WINDOW_DAYS`-day history for the H7 budget alert.
 
     `_midnight_total_out_kwh` is the cumulative battery-out value
     captured at the most recent local midnight reset. None means
     "first ever observation" - the next observation seeds it without
     counting cycles since boot, avoiding a misleading huge spike
     after first install.
+
+    `daily_history` is appended at each daily_reset with the cycles
+    consumed in the day just ending. Trimmed to the last
+    `_ALERT_WINDOW_DAYS` entries. NOT persisted across HA restarts in
+    this MVP - a follow-up PR can add Store-backed persistence so the
+    rolling window survives a restart.
     """
 
     battery_capacity_kwh: float
+    daily_budget: float = _DEFAULT_DAILY_BUDGET
     _midnight_total_out_kwh: float | None = None
     _last_observed_total_out_kwh: float | None = None
+    daily_history: list[float] = field(default_factory=list)
 
     def observe(self, total_out_kwh: float) -> None:
         """Record the latest cumulative battery-out reading.
@@ -56,10 +74,17 @@ class CycleTracker:
 
     def reset_daily(self) -> None:
         """Snapshot today's running total as the new midnight baseline.
+        Append the just-ending day's cycles to the rolling history
+        (trimmed to the alert window), then advance the baseline.
         Called by the coordinator's existing daily_reset hook at 00:00.
         """
-        if self._last_observed_total_out_kwh is not None:
-            self._midnight_total_out_kwh = self._last_observed_total_out_kwh
+        if self._last_observed_total_out_kwh is None:
+            return
+        finishing_cycles = self.cycles_today
+        self.daily_history.append(finishing_cycles)
+        if len(self.daily_history) > _ALERT_WINDOW_DAYS:
+            self.daily_history = self.daily_history[-_ALERT_WINDOW_DAYS:]
+        self._midnight_total_out_kwh = self._last_observed_total_out_kwh
 
     @property
     def cycles_today(self) -> float:
@@ -79,3 +104,20 @@ class CycleTracker:
             self._last_observed_total_out_kwh - self._midnight_total_out_kwh,
         )
         return delta_kwh / self.battery_capacity_kwh
+
+    @property
+    def budget_exceeded(self) -> bool:
+        """SPEC §1 / H7: True when the last `_ALERT_WINDOW_DAYS` finished
+        days each exceeded `daily_budget`. Today's in-progress count
+        does NOT count toward the breach until reset_daily seals it,
+        otherwise a heavy-use day would spike the alert before it's
+        complete (and a quiet evening could clear it).
+        """
+        if len(self.daily_history) < _ALERT_WINDOW_DAYS:
+            return False
+        return all(c > self.daily_budget for c in self.daily_history)
+
+    @property
+    def history(self) -> list[float]:
+        """Snapshot of the rolling daily history for sensor attributes."""
+        return list(self.daily_history)

--- a/tests/test_cycle_tracker.py
+++ b/tests/test_cycle_tracker.py
@@ -57,3 +57,70 @@ class TestCycleTracker:
         t.observe(100.0)
         t.observe(200.0)
         assert t.cycles_today == 0.0
+
+
+class TestBudgetExceededAlert:
+    """SPEC §1 / H7: alert ON when 3 consecutive days each > 2 cycles."""
+
+    def _three_days(self, t: CycleTracker, daily_kwh: list[float]) -> None:
+        """Simulate `len(daily_kwh)` days each draining `daily_kwh[i]`
+        kWh out of the battery."""
+        running_total = 0.0
+        t.observe(running_total)
+        for kwh in daily_kwh:
+            running_total += kwh
+            t.observe(running_total)
+            t.reset_daily()
+
+    def test_no_history_no_alert(self):
+        t = CycleTracker(battery_capacity_kwh=20.0)
+        assert t.budget_exceeded is False
+
+    def test_two_breaching_days_not_yet_alert(self):
+        """Only fires after 3 consecutive breaches; 2 isn't enough."""
+        t = CycleTracker(battery_capacity_kwh=20.0)
+        # 50 kWh out per day = 2.5 cycles
+        self._three_days(t, [50.0, 50.0])
+        assert t.budget_exceeded is False
+        assert t.history == pytest.approx([2.5, 2.5])
+
+    def test_three_breaching_days_fires_alert(self):
+        t = CycleTracker(battery_capacity_kwh=20.0)
+        self._three_days(t, [50.0, 50.0, 50.0])
+        assert t.budget_exceeded is True
+
+    def test_quiet_day_in_window_clears_alert(self):
+        """A single sub-budget day in the rolling window keeps alert off."""
+        t = CycleTracker(battery_capacity_kwh=20.0)
+        # day 1: 2.5 cycles (breach), day 2: 1 cycle (under), day 3: 2.5 (breach)
+        self._three_days(t, [50.0, 20.0, 50.0])
+        assert t.budget_exceeded is False
+
+    def test_history_trimmed_to_window(self):
+        """Only the last 3 finished days are kept."""
+        t = CycleTracker(battery_capacity_kwh=20.0)
+        self._three_days(t, [50.0, 50.0, 50.0, 50.0, 50.0])
+        # Five finished days; history should hold only last 3
+        assert len(t.history) == 3
+
+    def test_today_in_progress_does_not_count_toward_alert(self):
+        """A heavy-use day that hasn't finished should NOT spike the
+        alert; only completed days count, otherwise an evening export
+        would alert and a quiet morning would clear it."""
+        t = CycleTracker(battery_capacity_kwh=20.0)
+        # First two completed days each at 2.5 cycles
+        self._three_days(t, [50.0, 50.0])
+        # Today is in progress at 5 cycles - no third reset_daily yet
+        # so daily_history has only 2 entries.
+        running_total = 100.0  # cumulative after the 2 days
+        t.observe(running_total + 100.0)  # mid-day, +5 cycles today
+        assert t.cycles_today == 5.0
+        # Still only 2 finished days -> no alert despite today being heavy.
+        assert t.budget_exceeded is False
+
+    def test_custom_daily_budget(self):
+        """daily_budget is configurable per-install."""
+        t = CycleTracker(battery_capacity_kwh=20.0, daily_budget=1.0)
+        # Three days each at 1.5 cycles (>1.0 budget)
+        self._three_days(t, [30.0, 30.0, 30.0])
+        assert t.budget_exceeded is True


### PR DESCRIPTION
## Summary
Completes the H7 surface. CycleTracker keeps a 3-day rolling history of finished daily cycle counts; `binary_sensor.heo_ii_cycle_budget_exceeded` fires when each of the last 3 finished days exceeded `cycle_budget` (default 2.0, exposed via OptionsFlow).

Today's in-progress count doesn't trip the alert - only completed days count, otherwise an evening export spike would fire and a quiet morning clear.

## Test plan
- [x] 438 tests pass (+7 new)
- [ ] Deploy + after one full day verify history grows; after 3 heavy days verify alert fires

## TODO
Persistence so history survives HA restart (Store API). Until then, restart resets the rolling window.