### PR TITLE
feat(SPEC §12): EV deferral - halt zappi during top export

### DIFF
--- a/custom_components/heo2/binary_sensor.py
+++ b/custom_components/heo2/binary_sensor.py
@@ -27,6 +27,7 @@ async def async_setup_entry(
         WritesBlockedSensor(coordinator, entry),
         EPSActiveSensor(coordinator, entry),
         CycleBudgetExceededSensor(coordinator, entry),
+        EVDeferralActiveSensor(coordinator, entry),
     ])
 
 
@@ -85,6 +86,24 @@ class EPSActiveSensor(CoordinatorEntity, BinarySensorEntity):
     @property
     def is_on(self) -> bool:
         return self.coordinator.eps_active
+
+
+class EVDeferralActiveSensor(CoordinatorEntity, BinarySensorEntity):
+    """SPEC §12 dashboard indicator. ON while HEO II has the zappi
+    charge halted so the battery can export at peak. Pairs with the
+    `switch.heo_ii_defer_ev_when_export_high` user toggle - the switch
+    is the user intent, this sensor is "is it actually happening right
+    now"."""
+    _attr_device_class = BinarySensorDeviceClass.RUNNING
+
+    def __init__(self, coordinator: HEO2Coordinator, entry: ConfigEntry):
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{entry.entry_id}_ev_deferral_active"
+        self._attr_name = "HEO II EV Deferral Active"
+
+    @property
+    def is_on(self) -> bool:
+        return self.coordinator.ev_deferral_active
 
 
 class CycleBudgetExceededSensor(CoordinatorEntity, BinarySensorEntity):

--- a/custom_components/heo2/coordinator.py
+++ b/custom_components/heo2/coordinator.py
@@ -150,6 +150,12 @@ class HEO2Coordinator(DataUpdateCoordinator):
         # shutoffs once on the False -> True transition rather than
         # spamming switch.turn_off every tick.
         self._eps_active: bool = False
+        # SPEC §12 EV deferral: track previous-tick state so the
+        # zappi `select.select_option` -> Stopped service call fires
+        # ONCE on False->True. On True->False, restore the captured
+        # pre-deferral charge_mode (if any).
+        self._ev_deferral_active: bool = False
+        self._zappi_pre_deferral_mode: str | None = None
 
         # SPEC §10 tunable knobs. Read fresh from `_config` each tick
         # via the `_pcfg`/`_icfg` helpers below so the OptionsFlow
@@ -287,6 +293,15 @@ class HEO2Coordinator(DataUpdateCoordinator):
             await self._apply_programme_to_inverter(effective)
         except Exception:
             logger.exception("HEO-27: apply_programme failed")
+
+        # SPEC §12 EV deferral: dispatch zappi service call on
+        # transition. Done AFTER inverter writes so the inverter is
+        # already in Selling-first mode by the time the EV stops
+        # drawing.
+        try:
+            await self._maybe_dispatch_ev_deferral(effective)
+        except Exception:
+            logger.exception("EVDeferral: maybe_dispatch raised")
 
         self._update_dashboard_secondary(inputs, fresh)
         return fresh
@@ -696,6 +711,11 @@ class HEO2Coordinator(DataUpdateCoordinator):
             # SPEC §9 row 5: implicit winter mode when daily PV
             # forecast is below daily load. Triggers WinterLowPVRule.
             is_winter_low_pv=sum(solar) < sum(load_forecast),
+            # SPEC §12 EV deferral signals.
+            defer_ev_eligible=bool(
+                self._config.get("defer_ev_when_export_high", False),
+            ),
+            current_export_rate_p=self._current_export_rate(now, export_rates),
         )
 
     def _read_eps_active(self) -> bool:
@@ -755,6 +775,76 @@ class HEO2Coordinator(DataUpdateCoordinator):
                 logger.exception(
                     "H3 EPS: failed to turn_off %s", entity_id,
                 )
+
+    def _current_export_rate(self, now, export_rates) -> float | None:
+        """Find the export rate covering `now`, or None if no slot covers it.
+        Used by SPEC §12 EV deferral to compare against the
+        `deferral_min_export_p` floor without walking the full list.
+        """
+        for r in export_rates:
+            if r.start <= now < r.end:
+                return float(r.rate_pence)
+        return None
+
+    async def _maybe_dispatch_ev_deferral(
+        self, programme: ProgrammeState,
+    ) -> None:
+        """SPEC §12: when the rule engine decides EV deferral is active,
+        ask the zappi to halt charging. On clear, restore the previous
+        charge_mode. Fires on transitions only - we don't spam the
+        select.select_option service every tick."""
+        new_active = bool(programme.ev_deferral_active)
+        if new_active == self._ev_deferral_active:
+            return  # no transition
+
+        zappi_entity = self._config.get(
+            "zappi_charge_mode_entity",
+            "select.myenergi_zappi_22752031_charge_mode",
+        )
+        if not zappi_entity:
+            self._ev_deferral_active = new_active
+            return
+
+        if new_active:
+            # Capture the current mode so we can restore on clear
+            current = self.hass.states.get(zappi_entity) if self.hass else None
+            self._zappi_pre_deferral_mode = (
+                current.state if current is not None else None
+            )
+            try:
+                await self.hass.services.async_call(
+                    "select", "select_option",
+                    {"entity_id": zappi_entity, "option": "Stopped"},
+                    blocking=False,
+                )
+                logger.warning(
+                    "EVDeferral: zappi -> Stopped (was %s); "
+                    "battery exporting at peak",
+                    self._zappi_pre_deferral_mode,
+                )
+            except Exception:
+                logger.exception(
+                    "EVDeferral: zappi Stopped service-call failed",
+                )
+        else:
+            # Restore the captured mode (or fall back to Eco+)
+            restore_to = self._zappi_pre_deferral_mode or "Eco+"
+            try:
+                await self.hass.services.async_call(
+                    "select", "select_option",
+                    {"entity_id": zappi_entity, "option": restore_to},
+                    blocking=False,
+                )
+                logger.warning(
+                    "EVDeferral: cleared; zappi restored to %s", restore_to,
+                )
+            except Exception:
+                logger.exception(
+                    "EVDeferral: zappi restore service-call failed",
+                )
+            self._zappi_pre_deferral_mode = None
+
+        self._ev_deferral_active = new_active
 
     def _read_planned_dispatches(self, entity_id: str) -> list:
         """HEO-8: read `planned_dispatches` from the BottlecapDave IGO
@@ -1145,6 +1235,12 @@ class HEO2Coordinator(DataUpdateCoordinator):
             eps_active=self._eps_active,
         )
         return reason
+
+    @property
+    def ev_deferral_active(self) -> bool:
+        """SPEC §12: True when the EV charge is currently being held
+        off so the battery can export at peak."""
+        return self._ev_deferral_active
 
     @property
     def eps_active(self) -> bool:

--- a/custom_components/heo2/models.py
+++ b/custom_components/heo2/models.py
@@ -77,6 +77,13 @@ class ProgrammeState:
       energy_pattern: "Battery first" | "Load first"
       max_charge_a / max_discharge_a: 0..350 A (Sunsynk 5kW limit ~100A
         at 51.2V battery nominal)
+
+    `ev_deferral_active`: SPEC §12. True when the EVDeferralRule has
+    decided this tick that conditions are right to stop the EV charge
+    so battery exports can capture top export rates instead.
+    Coordinator translates the False -> True transition into a one-shot
+    `select.select_option` for the zappi charge_mode (Stopped),
+    capturing the previous mode for restore on True -> False.
     """
     slots: list[SlotConfig]
     reason_log: list[str] = field(default_factory=list)
@@ -84,6 +91,7 @@ class ProgrammeState:
     energy_pattern: Optional[str] = None
     max_charge_a: Optional[float] = None
     max_discharge_a: Optional[float] = None
+    ev_deferral_active: bool = False
 
     @classmethod
     def default(cls, min_soc: int = 20) -> ProgrammeState:
@@ -259,6 +267,17 @@ class ProgrammeInputs:
     # WinterLowPVRule raises overnight charge target and tightens the
     # export-window selectivity (preserve cycles for own use).
     is_winter_low_pv: bool = False
+    # SPEC §12 EV deferral: True when the user has flagged
+    # `switch.heo_ii_defer_ev_when_export_high` ON, indicating the car
+    # doesn't need to be charged for tomorrow and HEO II is free to
+    # halt the EV charge during top-export windows. When the rule
+    # fires it switches the inverter to Selling first and signals the
+    # coordinator to set the zappi charge_mode = Stopped.
+    defer_ev_eligible: bool = False
+    # Current export rate (p/kWh) at the moment of evaluation. The EV
+    # deferral rule uses this directly rather than walking export_rates,
+    # so the "ridiculous low export" fallback is one comparison.
+    current_export_rate_p: Optional[float] = None
 
     def now_local(self) -> datetime:
         """Return `now` projected into the local timezone if known.

--- a/custom_components/heo2/rules/__init__.py
+++ b/custom_components/heo2/rules/__init__.py
@@ -13,20 +13,20 @@ from .igo_dispatch import IGODispatchRule
 from .ev_charging import EVChargingRule
 from .saving_session import SavingSessionRule
 from .winter_low_pv import WinterLowPVRule
+from .ev_deferral import EVDeferralRule
 from .eps_mode import EPSModeRule
 from .safety import SafetyRule
 
 
 def default_rules() -> list[Rule]:
-    """Return the 11 default rules in priority order.
+    """Return the 12 default rules in priority order.
 
     SafetyRule is always last and cannot be disabled. EPSModeRule sits
     JUST before SafetyRule because it must override every other rule's
     decisions (SPEC H3: drop SOC floor to 0% during grid loss).
-    WinterLowPVRule sits AFTER ExportWindow + EveningProtect so it can
-    raise floors that those rules may have lowered, but BEFORE
-    SavingSession / IGODispatch / EV / EPS so those event-triggered
-    rules can still override the seasonal default.
+    EVDeferralRule sits BEFORE EVChargingRule so the deferral signal
+    can override EVChargingRule's "hold SOC" behaviour (we WANT to
+    drain the battery to grid in deferral mode).
     """
     return [
         BaselineRule(),
@@ -37,6 +37,7 @@ def default_rules() -> list[Rule]:
         WinterLowPVRule(),
         SavingSessionRule(),
         IGODispatchRule(),
+        EVDeferralRule(),
         EVChargingRule(),
         EPSModeRule(),
         SafetyRule(),

--- a/custom_components/heo2/rules/ev_deferral.py
+++ b/custom_components/heo2/rules/ev_deferral.py
@@ -1,0 +1,89 @@
+# custom_components/heo2/rules/ev_deferral.py
+"""EVDeferralRule -- SPEC §12 EV charge deferral.
+
+When the user has flagged "car not needed tomorrow" via
+`switch.heo_ii_defer_ev_when_export_high`, AND the battery is high
+enough to ride out a non-charge interval, AND the current export rate
+is in a top-pay-back window, this rule switches the inverter to
+"Selling first" and flags the programme so the coordinator halts the
+zappi charge for the duration. The battery exports at peak rates
+instead of feeding the EV at the live published rate.
+
+Triggers (ALL must be true):
+
+* `inputs.defer_ev_eligible` (the user-facing dashboard switch).
+* `inputs.current_soc >= deferral_min_soc` (default 80%) - we won't
+  defer the EV charge if the battery itself is low.
+* `inputs.current_export_rate_p >= deferral_min_export_p` (default
+  15 p/kWh). Below that, the SPEC §12 "ridiculous low export" fallback
+  cancels the deferral so the car doesn't get stuck unable to charge
+  on a quiet pricing day.
+
+Outputs:
+
+* `state.work_mode = "Selling first"` so the inverter exports.
+* `state.ev_deferral_active = True` so the coordinator can dispatch
+  the zappi service-call (one-shot per transition).
+
+The actual zappi `charge_mode -> Stopped` write happens in the
+coordinator (HA service call out of scope for pure rule logic).
+"""
+
+from __future__ import annotations
+
+from ..models import ProgrammeInputs, ProgrammeState
+from ..rule_engine import Rule
+
+
+class EVDeferralRule(Rule):
+    """SPEC §12 EV charge deferral when conditions favour exporting."""
+
+    name = "ev_deferral"
+    description = "Stop EV charge during high export when car not needed"
+
+    def __init__(
+        self,
+        *,
+        deferral_min_soc: float = 80.0,
+        deferral_min_export_p: float = 15.0,
+    ):
+        self.deferral_min_soc = deferral_min_soc
+        self.deferral_min_export_p = deferral_min_export_p
+
+    def apply(self, state: ProgrammeState, inputs: ProgrammeInputs) -> ProgrammeState:
+        if not inputs.defer_ev_eligible:
+            return state
+
+        if inputs.current_soc < self.deferral_min_soc:
+            state.reason_log.append(
+                f"EVDeferral: eligible but SOC {inputs.current_soc:.0f}% "
+                f"below {self.deferral_min_soc:.0f}% threshold; not deferring"
+            )
+            return state
+
+        export_p = inputs.current_export_rate_p
+        if export_p is None:
+            state.reason_log.append(
+                "EVDeferral: eligible but no live export rate; not deferring"
+            )
+            return state
+
+        if export_p < self.deferral_min_export_p:
+            # SPEC §12 "ridiculous low export" fallback - let the car
+            # charge as normal, the export wouldn't be worth it.
+            state.reason_log.append(
+                f"EVDeferral: eligible but export {export_p:.2f}p below "
+                f"{self.deferral_min_export_p:.2f}p threshold; not deferring"
+            )
+            return state
+
+        # All triggers met. Flip work_mode to Selling first and signal
+        # the coordinator to halt the zappi.
+        state.work_mode = "Selling first"
+        state.ev_deferral_active = True
+        state.reason_log.append(
+            f"EVDeferral: ACTIVE (SOC {inputs.current_soc:.0f}%, "
+            f"export {export_p:.2f}p >= {self.deferral_min_export_p:.2f}p); "
+            f"work_mode -> Selling first, zappi -> Stopped"
+        )
+        return state

--- a/custom_components/heo2/switch.py
+++ b/custom_components/heo2/switch.py
@@ -19,7 +19,10 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     coordinator: HEO2Coordinator = hass.data[DOMAIN][entry.entry_id]
-    async_add_entities([EnabledSwitch(coordinator, entry)])
+    async_add_entities([
+        EnabledSwitch(coordinator, entry),
+        DeferEvWhenExportHighSwitch(coordinator, entry),
+    ])
 
 
 class EnabledSwitch(CoordinatorEntity, SwitchEntity):
@@ -39,3 +42,43 @@ class EnabledSwitch(CoordinatorEntity, SwitchEntity):
     async def async_turn_off(self, **kwargs) -> None:
         self.coordinator.enabled = False
         self.async_write_ha_state()
+
+
+class DeferEvWhenExportHighSwitch(CoordinatorEntity, SwitchEntity):
+    """SPEC §12 user-facing dashboard toggle. ON = "car not needed
+    tomorrow, feel free to halt EV charge during top export windows".
+
+    Persists via entry.options so the toggle survives HA restart -
+    the user typically flips it the night before they don't need the
+    car, and an unintentional revert at midnight would defeat the
+    purpose. Same `_persist_option` pattern as the NumberEntity sliders.
+    """
+
+    def __init__(self, coordinator: HEO2Coordinator, entry: ConfigEntry):
+        super().__init__(coordinator)
+        self._entry = entry
+        self._attr_unique_id = f"{entry.entry_id}_defer_ev_when_export_high"
+        self._attr_name = "HEO II Defer EV When Export High"
+
+    @property
+    def is_on(self) -> bool:
+        return bool(self.coordinator._config.get(
+            "defer_ev_when_export_high", False,
+        ))
+
+    async def _set(self, value: bool) -> None:
+        new_options = {
+            **(self._entry.options or {}),
+            "defer_ev_when_export_high": value,
+        }
+        self.hass.config_entries.async_update_entry(
+            self._entry, options=new_options,
+        )
+        self.coordinator._config["defer_ev_when_export_high"] = value
+        await self.coordinator.async_request_refresh()
+
+    async def async_turn_on(self, **kwargs) -> None:
+        await self._set(True)
+
+    async def async_turn_off(self, **kwargs) -> None:
+        await self._set(False)

--- a/tests/test_rules/test_ev_deferral.py
+++ b/tests/test_rules/test_ev_deferral.py
@@ -1,0 +1,93 @@
+# tests/test_rules/test_ev_deferral.py
+"""Tests for EVDeferralRule (SPEC §12)."""
+
+from __future__ import annotations
+
+from datetime import time
+
+from heo2.models import ProgrammeInputs, ProgrammeState, SlotConfig
+from heo2.rules.ev_deferral import EVDeferralRule
+
+
+def _slot(start_h, start_m, end_h, end_m, soc, gc):
+    return SlotConfig(
+        start_time=time(start_h, start_m),
+        end_time=time(end_h, end_m),
+        capacity_soc=soc,
+        grid_charge=gc,
+    )
+
+
+def _empty_programme():
+    return ProgrammeState(slots=[
+        _slot(0, 0, 5, 30, 80, True),
+        _slot(5, 30, 18, 30, 80, False),
+        _slot(18, 30, 23, 30, 10, False),
+        _slot(23, 30, 23, 55, 80, True),
+        _slot(23, 55, 23, 55, 10, False),
+        _slot(23, 55, 0, 0, 10, False),
+    ], reason_log=[])
+
+
+class TestEVDeferralRule:
+    def test_no_op_when_user_toggle_off(self, default_inputs):
+        default_inputs.defer_ev_eligible = False
+        default_inputs.current_soc = 90.0
+        default_inputs.current_export_rate_p = 25.0
+        prog = _empty_programme()
+        result = EVDeferralRule().apply(prog, default_inputs)
+        assert result.ev_deferral_active is False
+        assert result.work_mode is None  # untouched
+
+    def test_no_op_when_soc_below_threshold(self, default_inputs):
+        default_inputs.defer_ev_eligible = True
+        default_inputs.current_soc = 50.0  # below default 80
+        default_inputs.current_export_rate_p = 25.0
+        prog = _empty_programme()
+        result = EVDeferralRule().apply(prog, default_inputs)
+        assert result.ev_deferral_active is False
+        assert result.work_mode is None
+        assert any("SOC" in r and "below" in r for r in result.reason_log)
+
+    def test_no_op_when_no_export_rate(self, default_inputs):
+        default_inputs.defer_ev_eligible = True
+        default_inputs.current_soc = 90.0
+        default_inputs.current_export_rate_p = None
+        prog = _empty_programme()
+        result = EVDeferralRule().apply(prog, default_inputs)
+        assert result.ev_deferral_active is False
+        assert any("no live export rate" in r for r in result.reason_log)
+
+    def test_ridiculous_low_export_no_op(self, default_inputs):
+        """SPEC §12 fallback: don't defer when export is too low to
+        be worth it - let the car charge as normal."""
+        default_inputs.defer_ev_eligible = True
+        default_inputs.current_soc = 90.0
+        default_inputs.current_export_rate_p = 5.0  # below default 15
+        prog = _empty_programme()
+        result = EVDeferralRule().apply(prog, default_inputs)
+        assert result.ev_deferral_active is False
+        assert any("below" in r and "threshold" in r for r in result.reason_log)
+
+    def test_active_when_all_triggers_met(self, default_inputs):
+        default_inputs.defer_ev_eligible = True
+        default_inputs.current_soc = 90.0
+        default_inputs.current_export_rate_p = 25.0
+        prog = _empty_programme()
+        result = EVDeferralRule().apply(prog, default_inputs)
+        assert result.ev_deferral_active is True
+        assert result.work_mode == "Selling first"
+        assert any("ACTIVE" in r for r in result.reason_log)
+
+    def test_custom_thresholds(self, default_inputs):
+        """Allow operator to lower the SOC + export thresholds for
+        more aggressive deferral."""
+        default_inputs.defer_ev_eligible = True
+        default_inputs.current_soc = 65.0  # would fail default 80
+        default_inputs.current_export_rate_p = 8.0  # would fail default 15
+        rule = EVDeferralRule(
+            deferral_min_soc=60.0, deferral_min_export_p=7.0,
+        )
+        prog = _empty_programme()
+        result = rule.apply(prog, default_inputs)
+        assert result.ev_deferral_active is True


### PR DESCRIPTION
## Summary
SPEC §12 EV deferral. When the user flags "car not needed tomorrow" via a new dashboard switch, AND battery SOC is high, AND current export rate clears the worth-deferring floor, HEO II switches the inverter to Selling-first AND dispatches `select.select_option` to set the zappi `charge_mode = Stopped`. Restores the previous charge_mode on clear.

## Triggers
- `switch.heo_ii_defer_ev_when_export_high` ON (persisted via entry.options)
- SOC >= 80% (configurable)
- Export rate >= 15p (configurable; SPEC §12 "ridiculous low export" fallback below this)

## What landed
- `EVDeferralRule` (pure logic) sets work_mode=Selling-first and a new `ev_deferral_active` flag.
- `coordinator._maybe_dispatch_ev_deferral` translates the flag transition into a one-shot zappi service call. Captures pre-deferral mode for restore.
- `switch.heo_ii_defer_ev_when_export_high` (persistent dashboard toggle).
- `binary_sensor.heo_ii_ev_deferral_active` (status indicator).

Default `zappi_charge_mode_entity` matches Paddy's install. Override via config entry if your serial differs.

## Test plan
- [x] 444 tests pass (+6 new)
- [ ] Deploy + flip the new switch ON; verify the rule reason_log shows "EVDeferral: ACTIVE..."
- [ ] When export is in a top window: zappi visibly drops to Stopped, battery exports
- [ ] Toggle OFF or wait for export to drop: zappi restored to its previous mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)