### PR TITLE
fix(projection): use tomorrow solar array when horizon crosses midnight

### DIFF
--- a/custom_components/heo2/projection.py
+++ b/custom_components/heo2/projection.py
@@ -231,9 +231,24 @@ def project_day(
         if _step_in_planned_dispatch(step_start, inputs.planned_dispatches):
             imp_p = igo_off_peak_p
 
-        # Solar / load at this step. Forecasts are hourly; pro-rate to 30 min.
+        # Solar / load at this step. Forecasts are hourly, local-hour
+        # indexed (index 0 = local midnight). When the projection
+        # horizon crosses local midnight (e.g. an 18:00 daily-plan run
+        # forecasting through to 18:00 tomorrow) we look up tomorrow's
+        # solar in `solar_forecast_kwh_tomorrow` rather than wrapping
+        # today's array. Load forecast uses the same shape both days
+        # (HEO-5 learned profile), so for load we wrap today.
+        if (
+            inputs.local_tz is not None
+            and inputs.now.tzinfo is not None
+            and step_local.date() != inputs.now.astimezone(inputs.local_tz).date()
+            and inputs.solar_forecast_kwh_tomorrow
+        ):
+            solar_24 = inputs.solar_forecast_kwh_tomorrow
+        else:
+            solar_24 = inputs.solar_forecast_kwh
         hour_idx = step_local.hour
-        solar_kwh = inputs.solar_forecast_kwh[hour_idx] * _SLOT_HOURS
+        solar_kwh = solar_24[hour_idx] * _SLOT_HOURS
         load_kwh = inputs.load_forecast_kwh[hour_idx] * _SLOT_HOURS
 
         net_solar = solar_kwh - load_kwh

--- a/tests/test_projection.py
+++ b/tests/test_projection.py
@@ -179,6 +179,69 @@ class TestProjectDay:
         assert p.peak_import_kwh == pytest.approx(p.imports_kwh, abs=0.5)
         assert p.peak_import_kwh > 20.0
 
+    def test_horizon_crossing_midnight_uses_tomorrow_solar_array(self):
+        """Daily plan at 18:00 projects 24h forward, ending 18:00
+        tomorrow. The morning portion (00:00-18:00 tomorrow) must
+        read from `solar_forecast_kwh_tomorrow`. Pre-fix the projection
+        wrapped today's array (so today's overnight-zero solar was
+        attributed to tomorrow morning), making the projection too
+        pessimistic about tomorrow's potential."""
+        from zoneinfo import ZoneInfo
+        # Plan with cap=10 (drain) all day so the battery hits floor
+        # and tomorrow's solar matters - it's the only thing that
+        # can keep SOC off the floor and avoid grid imports.
+        prog = ProgrammeState(slots=[
+            _slot(0, 0, 5, 30, 10, False),
+            _slot(5, 30, 18, 30, 10, False),
+            _slot(18, 30, 23, 30, 10, False),
+            _slot(23, 30, 23, 55, 10, False),
+            _slot(23, 55, 23, 55, 10, False),
+            _slot(23, 55, 0, 0, 10, False),
+        ])
+        london = ZoneInfo("Europe/London")
+        # 18:00 BST = 17:00 UTC daily-plan run
+        now = datetime(2026, 5, 1, 17, 0, tzinfo=timezone.utc)
+        tomorrow_solar = [0.0] * 24
+        # Heavy morning generation: 8 kWh/h for 6 hours = 48 kWh
+        for h in range(8, 14):
+            tomorrow_solar[h] = 8.0
+        inputs = ProgrammeInputs(
+            now=now,
+            current_soc=10.0,  # start at floor so any deficit imports
+            battery_capacity_kwh=20.0,
+            min_soc=10.0,
+            import_rates=[],
+            export_rates=[],
+            solar_forecast_kwh=[0.0] * 24,
+            load_forecast_kwh=[1.0] * 24,
+            igo_dispatching=False,
+            saving_session=False,
+            saving_session_start=None,
+            saving_session_end=None,
+            ev_charging=False,
+            grid_connected=True,
+            active_appliances=[],
+            appliance_expected_kwh=0.0,
+            solar_forecast_kwh_tomorrow=tomorrow_solar,
+            local_tz=london,
+        )
+        p_with = project_day(
+            prog, inputs, battery_capacity_kwh=20.0, tz=london,
+        )
+        # Re-run without tomorrow's forecast - projection should wrap
+        # today's zero-solar array and import every load step.
+        inputs2 = ProgrammeInputs(
+            **{**inputs.__dict__, "solar_forecast_kwh_tomorrow": []}
+        )
+        p_without = project_day(
+            prog, inputs2, battery_capacity_kwh=20.0, tz=london,
+        )
+        # Tomorrow's PV should reduce imports vs. no-tomorrow forecast.
+        assert p_with.imports_kwh < p_without.imports_kwh, (
+            f"with tomorrow PV: {p_with.imports_kwh:.2f}; "
+            f"without: {p_without.imports_kwh:.2f}"
+        )
+
     def test_planned_dispatch_overrides_published_rate_to_off_peak(self):
         """Octopus retroactively bills any import inside a smart-charge
         dispatch at the IGO off-peak rate, regardless of what the


### PR DESCRIPTION
## Summary
Daily plan at 18:00 projects 24h forward. Pre-fix the projection wrapped today's solar array for the post-midnight portion; with today's overnight 0 kWh, tomorrow morning was being marked as zero-solar and the H5 peak-import warning came out too pessimistic.

Fix: when the step's local date differs from today's, read from `solar_forecast_kwh_tomorrow` (already populated by the coordinator from the second Solcast entity).

## Test plan
- [x] 445 tests pass
- [ ] Watch tonight's 18:00 daily plan - the "Today projection" card on the dashboard should show smaller `peak_import_kwh` than equivalent winter days where tomorrow's solar is genuinely low