### PR TITLE
fix(winter): don't pin non-GC slots at 100%, EveningProtect's job

### DIFF
--- a/custom_components/heo2/rules/winter_low_pv.py
+++ b/custom_components/heo2/rules/winter_low_pv.py
@@ -43,35 +43,29 @@ class WinterLowPVRule(Rule):
             return state
 
         max_target = 100
-        # The non-GC daytime floor: enough to cover the day's load
-        # without dropping below min_soc. Same maths as EveningProtect
-        # but applied to the WHOLE day, not just evening hours.
-        if inputs.battery_capacity_kwh > 0:
-            day_load_kwh = sum(inputs.load_forecast_kwh) or 0.0
-            day_floor = int(
-                inputs.min_soc
-                + (day_load_kwh / inputs.battery_capacity_kwh * 100)
-            )
-        else:
-            day_floor = int(inputs.min_soc)
-        day_floor = min(day_floor, max_target)
-
         modified: list[str] = []
+        # Winter mode raises ONLY grid_charge=True (overnight) slot
+        # caps to 100%. CheapRateChargeRule may have picked a smarter
+        # partial target based on tomorrow's solar; in winter that's
+        # wrong - the cheap window is the only meaningful charge
+        # opportunity, so use it fully.
+        #
+        # Pre-2026-05-03 the rule ALSO raised non-GC slot floors to a
+        # day-load-sized number (often clamped to 100). That was wrong:
+        # it pinned the inverter at 100% during the day AND evening,
+        # so the battery never discharged and the grid covered all
+        # load. EveningProtectRule already handles the legitimate
+        # "raise pre-evening floor for evening reserve" need; this
+        # rule deliberately does NOT touch non-GC slots.
         for i, slot in enumerate(state.slots):
-            if slot.grid_charge:
-                if slot.capacity_soc < max_target:
-                    modified.append(
-                        f"slot {i + 1} GC cap "
-                        f"{slot.capacity_soc}->{max_target}"
-                    )
-                    slot.capacity_soc = max_target
-            else:
-                if slot.capacity_soc < day_floor:
-                    modified.append(
-                        f"slot {i + 1} non-GC floor "
-                        f"{slot.capacity_soc}->{day_floor}"
-                    )
-                    slot.capacity_soc = day_floor
+            if not slot.grid_charge:
+                continue
+            if slot.capacity_soc < max_target:
+                modified.append(
+                    f"slot {i + 1} GC cap "
+                    f"{slot.capacity_soc}->{max_target}"
+                )
+                slot.capacity_soc = max_target
 
         daily_solar = sum(inputs.solar_forecast_kwh)
         daily_load = sum(inputs.load_forecast_kwh)
@@ -84,6 +78,6 @@ class WinterLowPVRule(Rule):
         else:
             state.reason_log.append(
                 f"WinterLowPV: solar {daily_solar:.1f} < load "
-                f"{daily_load:.1f} kWh; no change needed"
+                f"{daily_load:.1f} kWh; GC slots already at 100%"
             )
         return state

--- a/tests/test_rules/test_winter_low_pv.py
+++ b/tests/test_rules/test_winter_low_pv.py
@@ -56,35 +56,36 @@ class TestWinterLowPVRule:
         assert result.slots[0].capacity_soc == 100  # overnight
         assert result.slots[4].capacity_soc == 100  # late-night
 
-    def test_active_raises_non_gc_floor_to_day_load(self, default_inputs):
-        """Non-GC slots get a floor sized for the day's load demand."""
-        default_inputs.solar_forecast_kwh = [0.5] * 24  # 12 kWh
-        default_inputs.load_forecast_kwh = [1.0] * 24   # 24 kWh, full day
+    def test_active_does_not_touch_non_gc_slots(self, default_inputs):
+        """Regression for 2026-05-03: pre-fix the rule raised every
+        non-GC slot's cap to a day-load-sized floor (often 100). That
+        pinned the battery at 100% through the evening and the grid
+        carried all load. Now the rule deliberately skips non-GC slots
+        - EveningProtectRule handles the evening reserve floor."""
+        default_inputs.solar_forecast_kwh = [0.5] * 24
+        default_inputs.load_forecast_kwh = [1.0] * 24
         default_inputs.is_winter_low_pv = True
-        default_inputs.battery_capacity_kwh = 20.0
-        # Day floor = min_soc(20) + (24 / 20 * 100) = 20 + 120 = clamped to 100
         prog = _spec_programme()
+        evening_drain_cap_before = prog.slots[2].capacity_soc  # 18:30-23:30 cap=10
         result = WinterLowPVRule().apply(prog, default_inputs)
-        for i, slot in enumerate(result.slots):
-            if not slot.grid_charge:
-                assert slot.capacity_soc >= 20, (
-                    f"slot {i + 1} non-GC floor not raised: "
-                    f"{slot.capacity_soc}"
-                )
+        # Evening drain slot stays at 10 - WinterLowPV no longer
+        # raises it. The battery is free to discharge through evening.
+        assert result.slots[2].capacity_soc == evening_drain_cap_before
 
-    def test_active_does_not_lower_existing_high_soc(self, default_inputs):
-        """The rule only raises floors, never lowers them."""
-        # Pick light load so day_floor is low, then verify a slot
-        # already above that floor stays put.
-        default_inputs.solar_forecast_kwh = [0.5] * 24  # 12 kWh
-        default_inputs.load_forecast_kwh = [0.1] * 24   # 2.4 kWh
+    def test_active_does_not_change_already_complete_overnight(
+        self, default_inputs,
+    ):
+        """If overnight slots are already at 100, rule logs no-change."""
+        default_inputs.solar_forecast_kwh = [0.5] * 24
+        default_inputs.load_forecast_kwh = [1.0] * 24
         default_inputs.is_winter_low_pv = True
-        default_inputs.battery_capacity_kwh = 20.0
-        # day_floor = 20 + (2.4/20*100) = 32
         prog = _spec_programme()
-        prog.slots[2].capacity_soc = 75  # already above day_floor=32
+        for s in prog.slots:
+            if s.grid_charge:
+                s.capacity_soc = 100
         result = WinterLowPVRule().apply(prog, default_inputs)
-        assert result.slots[2].capacity_soc == 75
+        assert all(s.capacity_soc == 100 for s in result.slots if s.grid_charge)
+        assert any("already at 100%" in r for r in result.reason_log)
 
     def test_reason_log_records_changes(self, default_inputs):
         default_inputs.solar_forecast_kwh = [0.5] * 24


### PR DESCRIPTION
## Summary
PROD observed today: WinterLowPVRule raised every non-GC slot to 100%, pinning the battery full through the evening drain window. Grid carried all load instead of the battery discharging.

Root cause: `day_floor` formula sized for the WHOLE day's load (~142%, clamped to 100). Wrong intent - we want preserve-for-evening, not battery-replaces-load-all-day.

Fix: WinterLowPVRule now only raises grid_charge=True slot caps to 100 (overnight is the only meaningful charge window in winter). Non-GC slot floors are EveningProtectRule's already-correct job.

## Test plan
- [x] 445 tests pass; new explicit regression `test_active_does_not_touch_non_gc_slots`
- [ ] Deploy + watch next tick - evening drain slot (18:30-23:30) should hold its low cap, battery actually discharges through evening