### PR TITLE
fix(dashboard): SOC trajectory chart x-axis off by current_hour

### DIFF
--- a/custom_components/heo2/sensor.py
+++ b/custom_components/heo2/sensor.py
@@ -387,7 +387,19 @@ class SOCTrajectorySensor(CoordinatorEntity, SensorEntity):
 
     @property
     def extra_state_attributes(self) -> dict:
-        return {"trajectory": self.coordinator.soc_trajectory}
+        # `trajectory[i]` is the projected SOC `i` hours from the
+        # tick-time (NOT clock hour i). `start_hour` is the LOCAL
+        # clock hour at index 0 so the dashboard chart can place each
+        # point at its correct wall-clock time. Without it the chart
+        # would label e.g. trajectory[18] at "18:00" when it actually
+        # represents start_hour+18 mod 24 - in BST evening, that's
+        # tomorrow morning's solar charge.
+        inputs = self.coordinator.last_inputs
+        start_hour = inputs.now_local().hour if inputs is not None else 0
+        return {
+            "trajectory": self.coordinator.soc_trajectory,
+            "start_hour": start_hour,
+        }
 
 
 class ProgrammeSlotsSensor(CoordinatorEntity, SensorEntity):

--- a/docs/dashboard/forecast-plan.yaml
+++ b/docs/dashboard/forecast-plan.yaml
@@ -39,14 +39,15 @@ cards:
         stroke_width: 2
         stroke_dash: 4
 
-  # SOC trajectory chart
+  # SOC trajectory chart. trajectory[i] is the projected SOC i hours
+  # FROM TICK TIME, not at clock hour i. Use the start_hour attribute
+  # to anchor the x-axis to the correct wall-clock hour, otherwise
+  # tomorrow morning's solar charge plots on today's evening axis.
   - type: custom:apexcharts-card
     header:
       title: Battery SOC Trajectory
       show: true
     graph_span: 24h
-    span:
-      start: day
     yaxis:
       - min: 0
         max: 100
@@ -54,9 +55,11 @@ cards:
       - entity: sensor.heo2_soc_trajectory
         data_generator: |
           const trajectory = entity.attributes.trajectory || [];
+          const startHour = entity.attributes.start_hour ?? 0;
+          const base = new Date();
+          base.setHours(startHour, 0, 0, 0);
           return trajectory.map((val, i) => {
-            const d = new Date();
-            d.setHours(i, 0, 0, 0);
+            const d = new Date(base.getTime() + i * 3600 * 1000);
             return [d.getTime(), val];
           });
         name: SOC (%)


### PR DESCRIPTION
## Summary
Dashboard SOC trajectory chart was plotting `trajectory[18]` at "18:00 today" when it actually represents `start_hour + 18h` (in BST evening, that's tomorrow morning's solar charge). Looked like a phantom evening grid charge.

Fix: sensor exposes `start_hour` attribute (local clock hour at index 0); chart uses it to anchor the x-axis. Live `.storage/lovelace.heo_ii` patched + YAML reference updated.

## Test plan
- [x] 445 tests pass
- [ ] Refresh the dashboard - the trajectory line should now show evening drain (18:00-23:30 → low SOC) followed by overnight charge (00:00 → 100%) and tomorrow's solar climb in the morning hours, not a phantom evening fill