### PR TITLE
fix: SOC fallback cache + trajectory indexed by clock hour

### DIFF
--- a/custom_components/heo2/coordinator.py
+++ b/custom_components/heo2/coordinator.py
@@ -150,6 +150,13 @@ class HEO2Coordinator(DataUpdateCoordinator):
         # shutoffs once on the False -> True transition rather than
         # spamming switch.turn_off every tick.
         self._eps_active: bool = False
+        # Last successfully-read SOC. Used as a fallback when the SOC
+        # entity is briefly unavailable during HA startup. Without
+        # this, `_read_entity_float` returns its hard-coded default
+        # (50.0) which is a misleading magic number that shows up on
+        # the dashboard as "current_soc=50%" even when the battery is
+        # at 11%. None means "no good read yet" (cold boot only).
+        self._last_known_soc: float | None = None
         # SPEC §12 EV deferral: track previous-tick state so the
         # zappi `select.select_option` -> Stopped service call fires
         # ONCE on False->True. On True->False, restore the captured
@@ -606,9 +613,29 @@ class HEO2Coordinator(DataUpdateCoordinator):
 
         now = datetime.now(timezone.utc)
 
-        current_soc = self._read_entity_float(
-            self._config.get("soc_entity", ""), default=50.0
-        )
+        # SOC fallback ladder: live entity > last-known cache >
+        # 50% as ultimate cold-boot fallback. The cache fixes the
+        # restart race where SA's SOC entity is briefly unavailable
+        # post-boot and we'd otherwise serve 50% on the dashboard
+        # for one tick.
+        soc_entity_id = self._config.get("soc_entity", "")
+        live_soc = self._read_entity_float(soc_entity_id, default=-1.0)
+        if live_soc >= 0:
+            current_soc = live_soc
+            self._last_known_soc = live_soc
+        elif self._last_known_soc is not None:
+            current_soc = self._last_known_soc
+            logger.warning(
+                "SOC entity %s unavailable; using last-known %.1f%%",
+                soc_entity_id, current_soc,
+            )
+        else:
+            current_soc = 50.0
+            logger.warning(
+                "SOC entity %s unavailable and no prior reading; "
+                "using cold-boot fallback 50%%",
+                soc_entity_id,
+            )
         igo_dispatching = self._read_entity_bool(
             self._config.get("igo_dispatch_entity", ""), default=False
         )

--- a/custom_components/heo2/sensor.py
+++ b/custom_components/heo2/sensor.py
@@ -387,19 +387,11 @@ class SOCTrajectorySensor(CoordinatorEntity, SensorEntity):
 
     @property
     def extra_state_attributes(self) -> dict:
-        # `trajectory[i]` is the projected SOC `i` hours from the
-        # tick-time (NOT clock hour i). `start_hour` is the LOCAL
-        # clock hour at index 0 so the dashboard chart can place each
-        # point at its correct wall-clock time. Without it the chart
-        # would label e.g. trajectory[18] at "18:00" when it actually
-        # represents start_hour+18 mod 24 - in BST evening, that's
-        # tomorrow morning's solar charge.
-        inputs = self.coordinator.last_inputs
-        start_hour = inputs.now_local().hour if inputs is not None else 0
-        return {
-            "trajectory": self.coordinator.soc_trajectory,
-            "start_hour": start_hour,
-        }
+        # `trajectory[h]` is the projected SOC AT clock hour `h`
+        # local time (0..23). Hours before now hold current_soc as a
+        # neutral fill (we don't have actuals); hours from now
+        # onward are simulated. Chart can plot index directly.
+        return {"trajectory": self.coordinator.soc_trajectory}
 
 
 class ProgrammeSlotsSensor(CoordinatorEntity, SensorEntity):

--- a/custom_components/heo2/soc_trajectory.py
+++ b/custom_components/heo2/soc_trajectory.py
@@ -20,18 +20,30 @@ def calculate_soc_trajectory(
     max_soc: float,
     current_hour: int,
 ) -> list[float]:
-    """Forward-simulate battery SOC for the next 24 hours."""
-    trajectory: list[float] = []
+    """Project SOC for each clock hour of today, indexed 0-23.
+
+    `trajectory[h]` is the projected SOC AT clock hour `h` local
+    time. Hours BEFORE `current_hour` are filled with `current_soc`
+    (we don't have actuals; this is the best we can do without
+    history). Hours from `current_hour` onward are simulated forward
+    using the programme slots and forecast arrays (which are also
+    local-hour indexed).
+
+    The chart x-axis can therefore plot `trajectory[h]` at clock hour
+    `h` directly, without any anchor offset. Pre-2026-05-03 the
+    function returned `trajectory[i] = SOC i hours from now` which
+    required the chart to know `current_hour` to place each point
+    correctly; an off-by-current_hour bug surfaced for evening users.
+    """
+    trajectory: list[float] = [current_soc] * 24
+
     soc = current_soc
+    for h in range(current_hour, 24):
+        trajectory[h] = soc
+        hour_time = time(h, 0)
 
-    for step in range(24):
-        trajectory.append(soc)
-
-        hour_idx = (current_hour + step) % 24
-        hour_time = time(hour_idx, 0)
-
-        solar_kwh = solar_forecast_kwh[hour_idx]
-        load_kwh = load_forecast_kwh[hour_idx]
+        solar_kwh = solar_forecast_kwh[h]
+        load_kwh = load_forecast_kwh[h]
 
         net_kwh = (solar_kwh * charge_efficiency) - (load_kwh / discharge_efficiency)
 

--- a/docs/dashboard/forecast-plan.yaml
+++ b/docs/dashboard/forecast-plan.yaml
@@ -39,15 +39,17 @@ cards:
         stroke_width: 2
         stroke_dash: 4
 
-  # SOC trajectory chart. trajectory[i] is the projected SOC i hours
-  # FROM TICK TIME, not at clock hour i. Use the start_hour attribute
-  # to anchor the x-axis to the correct wall-clock hour, otherwise
-  # tomorrow morning's solar charge plots on today's evening axis.
+  # SOC trajectory chart. trajectory[h] is the projected SOC AT
+  # clock hour h LOCAL time (not relative to "now"). Past hours are
+  # filled with current_soc as a flat back-fill. Chart shows the
+  # full day 00:00-24:00.
   - type: custom:apexcharts-card
     header:
       title: Battery SOC Trajectory
       show: true
     graph_span: 24h
+    span:
+      start: day
     yaxis:
       - min: 0
         max: 100
@@ -55,11 +57,9 @@ cards:
       - entity: sensor.heo2_soc_trajectory
         data_generator: |
           const trajectory = entity.attributes.trajectory || [];
-          const startHour = entity.attributes.start_hour ?? 0;
-          const base = new Date();
-          base.setHours(startHour, 0, 0, 0);
           return trajectory.map((val, i) => {
-            const d = new Date(base.getTime() + i * 3600 * 1000);
+            const d = new Date();
+            d.setHours(i, 0, 0, 0);
             return [d.getTime(), val];
           });
         name: SOC (%)

--- a/tests/test_soc_trajectory.py
+++ b/tests/test_soc_trajectory.py
@@ -42,12 +42,16 @@ class TestSOCTrajectory:
             discharge_efficiency=0.95,
             min_soc=20.0,
             max_soc=100.0,
-            current_hour=12,
+            current_hour=0,
         )
         assert len(result) == 24
         assert all(isinstance(v, float) for v in result)
 
-    def test_first_value_is_current_soc(self, flat_load, default_slots):
+    def test_value_at_current_hour_is_current_soc(
+        self, flat_load, default_slots,
+    ):
+        """trajectory[current_hour] holds the starting SOC before any
+        simulation step; later hours integrate net load/solar."""
         result = calculate_soc_trajectory(
             current_soc=65.0,
             solar_forecast_kwh=[0.0] * 24,
@@ -61,7 +65,32 @@ class TestSOCTrajectory:
             max_soc=100.0,
             current_hour=12,
         )
-        assert result[0] == 65.0
+        assert result[12] == 65.0
+
+    def test_past_hours_filled_with_current_soc(
+        self, flat_load, default_slots,
+    ):
+        """Hours BEFORE current_hour have no actuals; we fill them
+        with current_soc so the chart shows a flat back-fill rather
+        than a gap or arbitrary number."""
+        result = calculate_soc_trajectory(
+            current_soc=42.0,
+            solar_forecast_kwh=[0.0] * 24,
+            load_forecast_kwh=flat_load,
+            programme_slots=default_slots,
+            battery_capacity_kwh=20.0,
+            max_charge_kw=5.0,
+            charge_efficiency=0.95,
+            discharge_efficiency=0.95,
+            min_soc=20.0,
+            max_soc=100.0,
+            current_hour=15,
+        )
+        # Hours 0-14 are past, should all equal current_soc.
+        for h in range(15):
+            assert result[h] == 42.0, (
+                f"hour {h} expected 42 (past fill), got {result[h]}"
+            )
 
     def test_soc_decreases_with_load_no_solar(self, flat_load, default_slots):
         result = calculate_soc_trajectory(
@@ -75,8 +104,9 @@ class TestSOCTrajectory:
             discharge_efficiency=0.95,
             min_soc=20.0,
             max_soc=100.0,
-            current_hour=12,
+            current_hour=0,
         )
+        # Later simulated hour < earlier simulated hour
         assert result[5] < result[0]
 
     def test_soc_clamped_to_min(self, flat_load, default_slots):
@@ -91,7 +121,7 @@ class TestSOCTrajectory:
             discharge_efficiency=0.95,
             min_soc=20.0,
             max_soc=100.0,
-            current_hour=12,
+            current_hour=0,
         )
         assert all(v >= 20.0 for v in result)
 
@@ -107,7 +137,7 @@ class TestSOCTrajectory:
             discharge_efficiency=0.95,
             min_soc=20.0,
             max_soc=100.0,
-            current_hour=12,
+            current_hour=0,
         )
         assert all(v <= 100.0 for v in result)
 
@@ -149,4 +179,6 @@ class TestSOCTrajectory:
             max_soc=100.0,
             current_hour=6,
         )
-        assert result[6] > result[0]
+        # After several solar hours past current_hour=6, SOC should
+        # have climbed above the starting value (40%).
+        assert result[15] > result[6]


### PR DESCRIPTION
## Summary
Two dashboard issues observed today:

1. After HA restart, `_read_entity_float` returned its hard-coded `50.0` default for SOC because the SA entity is briefly `unknown`. The whole rule engine ran against bad current_soc for one tick. **Fix**: cache last-known SOC in the coordinator; fall back to it when the live entity drops out, only use the 50% magic on cold-boot.

2. SOC trajectory chart x-axis was mis-anchored (PR #61 partially fixed via start_hour attribute but only showed +24h forward, hiding morning hours). **Fix**: index trajectory by LOCAL clock hour 0-23; past hours flat-filled with current_soc; chart maps `i -> clock hour i` directly with `span: { start: day }`.

## Test plan
- [x] 446 tests pass (+1 new for past-fill semantics)
- [ ] After restart, dashboard shows current_soc matching SA's reported value (not 50%)
- [ ] SOC trajectory chart spans 00:00-24:00 with flat current_soc back-fill before the current hour, then real simulation