### PR TITLE
fix: persist last_known_soc across HA restart

### DIFF
--- a/custom_components/heo2/__init__.py
+++ b/custom_components/heo2/__init__.py
@@ -18,6 +18,12 @@ PLATFORMS = ["sensor", "binary_sensor", "switch", "number"]
 _CYCLE_STORE_VERSION = 1
 _CYCLE_STORE_KEY_FMT = "heo2_cycle_history_{entry_id}"
 
+# Last-known SOC persistence. Survives HA restart so the SOC fallback
+# ladder (live > cache > 50% cold-boot) doesn't flunk to 50% just
+# because SA's SOC entity hasn't populated yet on first tick.
+_SOC_STORE_VERSION = 1
+_SOC_STORE_KEY_FMT = "heo2_last_known_soc_{entry_id}"
+
 
 async def async_setup_entry(hass, entry) -> bool:
     """Set up HEO II from a config entry."""
@@ -48,6 +54,20 @@ async def async_setup_entry(hass, entry) -> bool:
             float(c) for c in history if isinstance(c, (int, float))
         ]
     coordinator._cycle_store = cycle_store
+
+    # Last-known SOC: load BEFORE first_refresh so the SOC fallback
+    # ladder picks the persisted value over the 50% cold-boot when
+    # SA's entity is still `unknown` on the first tick after restart.
+    soc_store = Store(
+        hass,
+        _SOC_STORE_VERSION,
+        _SOC_STORE_KEY_FMT.format(entry_id=entry.entry_id),
+    )
+    soc_stored = await soc_store.async_load() or {}
+    saved_soc = soc_stored.get("last_known_soc")
+    if isinstance(saved_soc, (int, float)) and 0 <= saved_soc <= 100:
+        coordinator._last_known_soc = float(saved_soc)
+    coordinator._soc_store = soc_store
 
     await coordinator.async_config_entry_first_refresh()
 

--- a/custom_components/heo2/coordinator.py
+++ b/custom_components/heo2/coordinator.py
@@ -622,7 +622,15 @@ class HEO2Coordinator(DataUpdateCoordinator):
         live_soc = self._read_entity_float(soc_entity_id, default=-1.0)
         if live_soc >= 0:
             current_soc = live_soc
-            self._last_known_soc = live_soc
+            if self._last_known_soc != live_soc:
+                self._last_known_soc = live_soc
+                # Fire-and-forget persist; failure shouldn't fail the tick.
+                if hasattr(self, "_soc_store") and self._soc_store is not None:
+                    self.hass.async_create_task(
+                        self._soc_store.async_save(
+                            {"last_known_soc": live_soc}
+                        )
+                    )
         elif self._last_known_soc is not None:
             current_soc = self._last_known_soc
             logger.warning(


### PR DESCRIPTION
## Summary
Same restart-race that hit cycle_history (PR #57): in-memory `_last_known_soc` cache from PR #62 was empty on the first tick after a fresh HA restart, so SOC=11% misclassified as the 50% magic fallback. Persist to HA Store; load before first refresh.

## Test plan
- [x] 446 tests pass
- [ ] Deploy + restart; verify `current_soc` on dashboard matches SA's reported value from the very first tick
- [ ] After multiple restarts, verify `/config/.storage/heo2_last_known_soc_<entry_id>` exists and holds the most recent SOC

🤖 Generated with [Claude Code](https://claude.com/claude-code)