### PR TITLE
feat: 30h trajectory horizon + Solcast restart-cache

### DIFF
--- a/custom_components/heo2/__init__.py
+++ b/custom_components/heo2/__init__.py
@@ -24,6 +24,14 @@ _CYCLE_STORE_KEY_FMT = "heo2_cycle_history_{entry_id}"
 _SOC_STORE_VERSION = 1
 _SOC_STORE_KEY_FMT = "heo2_last_known_soc_{entry_id}"
 
+# Solar forecast cache. Same restart-race pattern as SOC: HACS solcast
+# entity is briefly `unknown` post-boot. Persisting the last parsed
+# 24-bucket arrays lets the first tick after restart serve a
+# day-old (at most) forecast instead of [0]*24, which would mistrigger
+# WinterLowPVRule and produce a bad first plan.
+_SOLAR_STORE_VERSION = 1
+_SOLAR_STORE_KEY_FMT = "heo2_solar_forecast_{entry_id}"
+
 
 async def async_setup_entry(hass, entry) -> bool:
     """Set up HEO II from a config entry."""
@@ -68,6 +76,25 @@ async def async_setup_entry(hass, entry) -> bool:
     if isinstance(saved_soc, (int, float)) and 0 <= saved_soc <= 100:
         coordinator._last_known_soc = float(saved_soc)
     coordinator._soc_store = soc_store
+
+    # Solar forecast cache. Loaded BEFORE first_refresh so the live-
+    # entity unknown branch in `_read_solar_forecast` can fall back
+    # to the cached array. Coordinator's persist helper writes back
+    # whenever a fresh read succeeds (with the local date stamp;
+    # cache stale beyond a day is dropped).
+    solar_store = Store(
+        hass,
+        _SOLAR_STORE_VERSION,
+        _SOLAR_STORE_KEY_FMT.format(entry_id=entry.entry_id),
+    )
+    solar_stored = await solar_store.async_load() or {}
+    if isinstance(solar_stored.get("today"), list) and len(solar_stored["today"]) == 24:
+        coordinator._solar_cache_today = [float(v) for v in solar_stored["today"]]
+    if isinstance(solar_stored.get("tomorrow"), list) and len(solar_stored["tomorrow"]) == 24:
+        coordinator._solar_cache_tomorrow = [float(v) for v in solar_stored["tomorrow"]]
+    if isinstance(solar_stored.get("date"), str):
+        coordinator._solar_cache_date = solar_stored["date"]
+    coordinator._solar_store = solar_store
 
     await coordinator.async_config_entry_first_refresh()
 

--- a/custom_components/heo2/coordinator.py
+++ b/custom_components/heo2/coordinator.py
@@ -157,6 +157,14 @@ class HEO2Coordinator(DataUpdateCoordinator):
         # the dashboard as "current_soc=50%" even when the battery is
         # at 11%. None means "no good read yet" (cold boot only).
         self._last_known_soc: float | None = None
+        # Solar forecast cache. Same restart-race pattern as SOC.
+        # Stamped with the local date the cache was created on; on
+        # load, only used when the date matches today's local date
+        # (otherwise stale data from yesterday could mislead the
+        # winter trigger).
+        self._solar_cache_today: list[float] | None = None
+        self._solar_cache_tomorrow: list[float] | None = None
+        self._solar_cache_date: str | None = None
         # SPEC §12 EV deferral: track previous-tick state so the
         # zappi `select.select_option` -> Stopped service call fires
         # ONCE on False->True. On True->False, restore the captured
@@ -344,6 +352,10 @@ class HEO2Coordinator(DataUpdateCoordinator):
             min_soc=self._config.get("min_soc", 20.0),
             max_soc=self._config.get("max_soc", 100.0),
             current_hour=current_hour,
+            solar_forecast_kwh_tomorrow=(
+                inputs.solar_forecast_kwh_tomorrow or None
+            ),
+            horizon_hours=30,
         )
 
         flat_rate = self._config.get("flat_rate_pence", DEFAULT_FLAT_RATE_PENCE)
@@ -994,8 +1006,34 @@ class HEO2Coordinator(DataUpdateCoordinator):
         )
 
         entity = entity_override or self._solar_entity
+
+        def _serve_cache(reason: str) -> list[float] | None:
+            """Return the persisted forecast if today's local date
+            matches the cache's date stamp. Caller logs why we fell
+            back so missing-Solcast vs stale-cache are distinguishable
+            in the log."""
+            today_str = (
+                now.astimezone(tz).date() + timedelta(days=target_offset_days)
+            ).isoformat()
+            if self._solar_cache_date != today_str:
+                return None
+            cached = (
+                self._solar_cache_tomorrow if target_offset_days == 1
+                else self._solar_cache_today
+            )
+            if cached and len(cached) == 24:
+                logger.info(
+                    "Solar forecast %s using cache (%s): %.1f kWh total",
+                    entity, reason, sum(cached),
+                )
+                return list(cached)
+            return None
+
         state = self.hass.states.get(entity) if self.hass else None
         if state is None or state.state in ("unknown", "unavailable"):
+            cached = _serve_cache("entity unavailable")
+            if cached is not None:
+                return cached
             logger.warning(
                 "Solar forecast entity %s not available, using zero forecast",
                 entity,
@@ -1004,6 +1042,9 @@ class HEO2Coordinator(DataUpdateCoordinator):
 
         detailed = state.attributes.get("detailedHourly") or []
         if not detailed:
+            cached = _serve_cache("attribute missing")
+            if cached is not None:
+                return cached
             logger.warning(
                 "Solar forecast entity %s has no detailedHourly attribute",
                 entity,
@@ -1011,6 +1052,17 @@ class HEO2Coordinator(DataUpdateCoordinator):
             return [0.0] * 24
 
         result = solar_forecast_from_hacs(detailed, target_date=target_date)
+        if sum(result) > 0:
+            # Cache the parsed array stamped with today's local date.
+            # Only the today read drives the date stamp; the tomorrow
+            # read just refreshes its own slot of the cache.
+            today_str = now.astimezone(tz).date().isoformat()
+            if target_offset_days == 0:
+                self._solar_cache_today = list(result)
+                self._solar_cache_date = today_str
+            elif target_offset_days == 1:
+                self._solar_cache_tomorrow = list(result)
+            self._persist_solar_cache()
         # Sanity check: Solcast reports a non-zero day total but our
         # parsed array sums to zero. Flag the mismatch so the read
         # bug doesn't silently break the rule engine. Tolerance 0.1
@@ -1293,6 +1345,22 @@ class HEO2Coordinator(DataUpdateCoordinator):
             eps_active=self._eps_active,
         )
         return reason
+
+    def _persist_solar_cache(self) -> None:
+        """Fire-and-forget save of the solar forecast cache. Called
+        whenever a fresh successful read updates the in-memory cache."""
+        store = getattr(self, "_solar_store", None)
+        if store is None:
+            return
+        payload = {
+            "date": self._solar_cache_date,
+            "today": self._solar_cache_today,
+            "tomorrow": self._solar_cache_tomorrow,
+        }
+        try:
+            self.hass.async_create_task(store.async_save(payload))
+        except Exception:
+            logger.exception("solar_cache: persist save failed")
 
     async def persist_cycle_history(self) -> None:
         """Save the cycle tracker's rolling daily_history to disk so

--- a/custom_components/heo2/soc_trajectory.py
+++ b/custom_components/heo2/soc_trajectory.py
@@ -19,31 +19,45 @@ def calculate_soc_trajectory(
     min_soc: float,
     max_soc: float,
     current_hour: int,
+    *,
+    solar_forecast_kwh_tomorrow: list[float] | None = None,
+    horizon_hours: int = 30,
 ) -> list[float]:
-    """Project SOC for each clock hour of today, indexed 0-23.
+    """Project SOC for each clock hour, indexed 0..horizon_hours-1.
 
-    `trajectory[h]` is the projected SOC AT clock hour `h` local
-    time. Hours BEFORE `current_hour` are filled with `current_soc`
-    (we don't have actuals; this is the best we can do without
-    history). Hours from `current_hour` onward are simulated forward
-    using the programme slots and forecast arrays (which are also
-    local-hour indexed).
+    Indices 0..23 correspond to today's clock hours; indices 24..29
+    (default 30-hour horizon) project into tomorrow's first 6 hours
+    so the dashboard chart can show the overnight recharge. Hours
+    BEFORE `current_hour` are filled with `current_soc` (no history).
 
-    The chart x-axis can therefore plot `trajectory[h]` at clock hour
-    `h` directly, without any anchor offset. Pre-2026-05-03 the
-    function returned `trajectory[i] = SOC i hours from now` which
-    required the chart to know `current_hour` to place each point
-    correctly; an off-by-current_hour bug surfaced for evening users.
+    `solar_forecast_kwh_tomorrow` is optional: when present, indices
+    24+ use tomorrow's solar; when absent, they wrap today's array
+    (less accurate but better than nothing). Load forecast wraps
+    today's array since HEO-5's learned profile is shape-equivalent
+    across days.
+
+    The chart x-axis can plot `trajectory[h]` at clock hour `h`
+    (clamping h>=24 to tomorrow's hours): a 30h span shows the day's
+    drain plus tomorrow's morning charge.
     """
-    trajectory: list[float] = [current_soc] * 24
+    trajectory: list[float] = [current_soc] * horizon_hours
 
     soc = current_soc
-    for h in range(current_hour, 24):
+    for h in range(current_hour, horizon_hours):
         trajectory[h] = soc
-        hour_time = time(h, 0)
 
-        solar_kwh = solar_forecast_kwh[h]
-        load_kwh = load_forecast_kwh[h]
+        # Index into local-hour-indexed forecasts. h>=24 wraps to
+        # tomorrow's forecast for solar (preferred) or today's (fallback).
+        if h < 24:
+            solar_kwh = solar_forecast_kwh[h]
+        elif solar_forecast_kwh_tomorrow:
+            solar_kwh = solar_forecast_kwh_tomorrow[h - 24]
+        else:
+            solar_kwh = solar_forecast_kwh[h - 24]
+        load_kwh = load_forecast_kwh[h % 24]
+
+        # Slot lookup uses time-of-day (0..23) wrapped via mod 24.
+        hour_time = time(h % 24, 0)
 
         net_kwh = (solar_kwh * charge_efficiency) - (load_kwh / discharge_efficiency)
 

--- a/docs/dashboard/forecast-plan.yaml
+++ b/docs/dashboard/forecast-plan.yaml
@@ -40,14 +40,16 @@ cards:
         stroke_dash: 4
 
   # SOC trajectory chart. trajectory[h] is the projected SOC AT
-  # clock hour h LOCAL time (not relative to "now"). Past hours are
-  # filled with current_soc as a flat back-fill. Chart shows the
-  # full day 00:00-24:00.
+  # clock hour h LOCAL time. Past hours are flat-filled with
+  # current_soc; future hours are simulated. 30 hours of data so the
+  # chart spans today's full day plus tomorrow morning's overnight
+  # recharge - so the user can see the full charge cycle, not just
+  # the drain-to-floor portion.
   - type: custom:apexcharts-card
     header:
       title: Battery SOC Trajectory
       show: true
-    graph_span: 24h
+    graph_span: 30h
     span:
       start: day
     yaxis:
@@ -57,9 +59,10 @@ cards:
       - entity: sensor.heo2_soc_trajectory
         data_generator: |
           const trajectory = entity.attributes.trajectory || [];
+          const base = new Date();
+          base.setHours(0, 0, 0, 0);
           return trajectory.map((val, i) => {
-            const d = new Date();
-            d.setHours(i, 0, 0, 0);
+            const d = new Date(base.getTime() + i * 3600 * 1000);
             return [d.getTime(), val];
           });
         name: SOC (%)

--- a/tests/test_soc_trajectory.py
+++ b/tests/test_soc_trajectory.py
@@ -30,7 +30,8 @@ def default_slots() -> list[SlotConfig]:
 
 
 class TestSOCTrajectory:
-    def test_returns_24_floats(self, flat_load, default_slots):
+    def test_returns_horizon_floats(self, flat_load, default_slots):
+        """Default horizon is 30 hours (today + tomorrow morning)."""
         result = calculate_soc_trajectory(
             current_soc=50.0,
             solar_forecast_kwh=[0.0] * 24,
@@ -44,8 +45,48 @@ class TestSOCTrajectory:
             max_soc=100.0,
             current_hour=0,
         )
-        assert len(result) == 24
+        assert len(result) == 30
         assert all(isinstance(v, float) for v in result)
+
+    def test_horizon_extends_into_tomorrow_with_separate_solar(
+        self, flat_load, default_slots,
+    ):
+        """When solar_forecast_kwh_tomorrow is supplied, indices 24+
+        use tomorrow's solar values - lets the chart show overnight
+        recharge plus tomorrow's morning ramp."""
+        # Today: zero solar; tomorrow: 5 kWh per hour for first 6
+        solar_today = [0.0] * 24
+        solar_tomorrow = [5.0] * 24
+        slots = [
+            SlotConfig(time(0, 0), time(5, 30), capacity_soc=80, grid_charge=True),
+            SlotConfig(time(5, 30), time(8, 0), capacity_soc=20, grid_charge=False),
+            SlotConfig(time(8, 0), time(12, 0), capacity_soc=20, grid_charge=False),
+            SlotConfig(time(12, 0), time(16, 0), capacity_soc=20, grid_charge=False),
+            SlotConfig(time(16, 0), time(23, 59), capacity_soc=20, grid_charge=False),
+            SlotConfig(time(23, 59), time(0, 0), capacity_soc=20, grid_charge=False),
+        ]
+        result = calculate_soc_trajectory(
+            current_soc=50.0,
+            solar_forecast_kwh=solar_today,
+            load_forecast_kwh=flat_load,
+            programme_slots=slots,
+            battery_capacity_kwh=20.0,
+            max_charge_kw=5.0,
+            charge_efficiency=0.95,
+            discharge_efficiency=0.95,
+            min_soc=20.0,
+            max_soc=100.0,
+            current_hour=20,  # late evening
+            solar_forecast_kwh_tomorrow=solar_tomorrow,
+        )
+        assert len(result) == 30
+        # Tomorrow morning hours (24-29) should reflect the recharge
+        # from solar_tomorrow + slot 1's GC=True target (=80%)
+        # During hour 26 = 02:00 tomorrow we are in slot 1 with cap=80
+        # and tomorrow_solar[2]=5 - SOC should climb past current_soc.
+        assert result[26] > result[20], (
+            f"hour 26 ({result[26]}) expected > hour 20 ({result[20]})"
+        )
 
     def test_value_at_current_hour_is_current_soc(
         self, flat_load, default_slots,


### PR DESCRIPTION
## Summary
1. **30h trajectory**: SOC trajectory chart now covers today plus tomorrow's first 6 hours so the overnight recharge to 100% is visible (was cut off at 23:00). Uses `solar_forecast_kwh_tomorrow` for accurate cross-midnight projection.
2. **Solcast persists across restart**: same Store pattern as PR #63 last_known_soc and PR #57 cycle history. Entity-unavailable on first tick after restart no longer means [0]*24 - cache served if date stamp matches today's local date.

## Test plan
- [x] 447 tests pass (+1 new for cross-midnight trajectory)
- [ ] After restart, dashboard shows current_soc immediately + trajectory shows overnight recharge to 100% before midnight cutoff
- [ ] After restart with stale cache (e.g. across local midnight), cache is dropped and fresh read is required

🤖 Generated with [Claude Code](https://claude.com/claude-code)