### PR TITLE
fix(cheap_charge): size overnight target to bridge until PV takes over

### DIFF
--- a/custom_components/heo2/rules/cheap_rate_charge.py
+++ b/custom_components/heo2/rules/cheap_rate_charge.py
@@ -1,133 +1,122 @@
-"""CheapRateChargeRule -- rank-based overnight/cheap-window charge target."""
+"""CheapRateChargeRule -- size overnight charge to bridge until PV takes over."""
 
 from __future__ import annotations
 
-from ..const import (
-    DEFAULT_CHEAP_CHARGE_BOTTOM_PCT,
-    DEFAULT_HIGH_SOC_THRESHOLD,
-    DEFAULT_IGO_OFF_PEAK_PENCE,
-    DEFAULT_LOW_SOC_THRESHOLD,
-    DEFAULT_MAX_DISCHARGE_KW,
-    DEFAULT_SELL_TOP_PCT,
-    DEFAULT_SELL_TOP_PCT_HIGH_SOC,
-    DEFAULT_SELL_TOP_PCT_LOW_SOC,
-    ROUND_TRIP_EFFICIENCY,
-)
 from ..models import ProgrammeInputs, ProgrammeState
-from ..rank_pricing import (
-    estimate_profitable_export_kwh,
-    filter_today,
-    select_export_top_pct,
-    select_worth_selling_windows,
-)
 from ..rule_engine import Rule
 
 
 class CheapRateChargeRule(Rule):
-    """Set the SOC target on grid_charge slots based on expected demand,
-    expected solar, and rank-based profitable-export volume.
+    """Size the overnight grid_charge target so the battery has just
+    enough capacity to bridge from end-of-cheap-window through to the
+    point tomorrow when PV generation overtakes load.
 
-    Implements SPEC §5a charging-from-grid logic generalised:
-    `worth_charging_kwh = expected_demand - expected_solar + expected_export`,
-    where `expected_export` is derived from today's published export rates
-    and the rank-based "worth selling" filter rather than a fixed
-    pence threshold.
+    The previous incarnation of this rule sized the charge target as
+    `expected_demand + profitable_export - expected_solar`. With Octopus
+    Outgoing peaks well below the IGO arbitrage threshold, that maths
+    pushed the overnight target to 100% even when tomorrow's PV would
+    fully refill the battery anyway -- giving up free solar to instead
+    cycle through grid-charged kWh paid for at IGO off-peak.
 
-    Replaces the legacy version's `>7.86p effective stored cost` test.
-    The legacy version over-charged when winter Agile distributions sat
-    above 7.86p (looked profitable everywhere) and under-charged when
-    summer distributions stayed below.
+    The new strategy (what the user actually wants from a self-supply
+    install):
+
+      target_soc = min_soc
+                 + morning_bridge_kwh / battery_capacity_kwh * 100
+                 + safety_buffer
+
+    where `morning_bridge_kwh` is the cumulative deficit between
+    tomorrow's hourly load forecast and tomorrow's hourly PV forecast,
+    summed from the end of the cheap window until the first hour where
+    `solar >= load` (the "PV takeover" hour). Beyond that hour PV
+    covers load and any surplus charges the battery -- so the overnight
+    grid charge only needs to cover the morning gap.
+
+    Edge cases:
+      * No tomorrow PV forecast -> fall back to filling battery
+        completely (we have no signal of when PV would take over).
+      * PV never overtakes load (deep winter) -> sum the whole day's
+        deficit; clamps to max_target_soc.
+      * Very small bridge (PV takeover early morning) -> safety buffer
+        keeps target above min_soc so a forecast miss doesn't strand
+        us at floor.
+
+    Implements the SPEC §5 priority 2: "Avoid grid use generally --
+    cover load from battery+solar where economical."
     """
 
     name = "cheap_rate_charge"
-    description = "Calculate cheap-window charge target from expected demand and rank-worthy export"
+    description = "Size overnight charge to bridge from cheap-window end to PV takeover"
 
     def __init__(
         self,
         max_target_soc: int = 100,
         *,
-        replacement_cost_pence: float = DEFAULT_IGO_OFF_PEAK_PENCE,
-        round_trip_efficiency: float = ROUND_TRIP_EFFICIENCY,
-        max_discharge_kw: float = DEFAULT_MAX_DISCHARGE_KW,
-        low_soc_threshold: float = DEFAULT_LOW_SOC_THRESHOLD,
-        high_soc_threshold: float = DEFAULT_HIGH_SOC_THRESHOLD,
-        n_low: int = DEFAULT_SELL_TOP_PCT_LOW_SOC,
-        n_med: int = DEFAULT_SELL_TOP_PCT,
-        n_high: int = DEFAULT_SELL_TOP_PCT_HIGH_SOC,
-        cheap_bottom_pct: int = DEFAULT_CHEAP_CHARGE_BOTTOM_PCT,
+        cheap_window_end_hour: int = 5,  # IGO off-peak ends 05:30; we use whole hour 5
+        safety_buffer_pct: int = 10,
     ):
         self.max_target_soc = max_target_soc
-        self.replacement_cost_pence = replacement_cost_pence
-        self.round_trip_efficiency = round_trip_efficiency
-        self.max_discharge_kw = max_discharge_kw
-        self.low_soc_threshold = low_soc_threshold
-        self.high_soc_threshold = high_soc_threshold
-        self.n_low = n_low
-        self.n_med = n_med
-        self.n_high = n_high
-        self.cheap_bottom_pct = cheap_bottom_pct
+        self.cheap_window_end_hour = cheap_window_end_hour
+        self.safety_buffer_pct = safety_buffer_pct
 
     def apply(self, state: ProgrammeState, inputs: ProgrammeInputs) -> ProgrammeState:
-        expected_demand_kwh = sum(inputs.load_forecast_kwh)
-        expected_solar_kwh = sum(inputs.solar_forecast_kwh)
-        daily_load_kwh = expected_demand_kwh or 1.0
+        # Tomorrow's solar forecast drives the calculation. Without it
+        # we can't know when PV takes over - default to filling the
+        # battery completely.
+        tomorrow_solar = inputs.solar_forecast_kwh_tomorrow
+        load = inputs.load_forecast_kwh
 
-        # Rank-based estimate of how much we can profitably sell today.
-        # Driven by today's live export rates; falls back to zero when
-        # BD hasn't returned anything (writes are H4-blocked anyway).
-        today_export_rates = filter_today(inputs.export_rates, inputs.now)
-
-        tomorrow_solar_kwh = sum(inputs.solar_forecast_kwh_tomorrow) if (
-            inputs.solar_forecast_kwh_tomorrow
-        ) else expected_solar_kwh
-
-        n_pct, n_reason = select_export_top_pct(
-            current_soc=inputs.current_soc,
-            tomorrow_solar_kwh=tomorrow_solar_kwh,
-            daily_load_kwh=daily_load_kwh,
-            low_soc_threshold=self.low_soc_threshold,
-            high_soc_threshold=self.high_soc_threshold,
-            n_low=self.n_low,
-            n_med=self.n_med,
-            n_high=self.n_high,
-        )
-
-        worth_windows = select_worth_selling_windows(
-            today_export_rates,
-            n_pct=n_pct,
-            replacement_cost_pence=self.replacement_cost_pence,
-            round_trip_efficiency=self.round_trip_efficiency,
-        )
-        expected_profitable_export_kwh = estimate_profitable_export_kwh(
-            worth_windows,
-            max_discharge_kw=self.max_discharge_kw,
-        )
-
-        worth_charging_kwh = (
-            expected_demand_kwh
-            + expected_profitable_export_kwh
-            - expected_solar_kwh
-        )
-
-        if worth_charging_kwh <= 0:
-            target_soc = int(inputs.min_soc)
-        else:
-            target_soc = int(
-                inputs.min_soc
-                + (worth_charging_kwh / inputs.battery_capacity_kwh * 100)
+        if not tomorrow_solar or len(tomorrow_solar) < 24:
+            target_soc = self.max_target_soc
+            reason = (
+                "no tomorrow PV forecast available; "
+                f"defaulting to {target_soc}%"
             )
-        target_soc = max(int(inputs.min_soc), min(self.max_target_soc, target_soc))
+        else:
+            # Walk forward from end-of-cheap-window. Accumulate the
+            # cumulative deficit (load - solar) until solar finally
+            # overtakes load at the "PV takeover" hour.
+            bridge_kwh = 0.0
+            takeover_hour: int | None = None
+            for h in range(self.cheap_window_end_hour, 24):
+                solar = tomorrow_solar[h]
+                load_h = load[h]
+                if solar >= load_h and h > self.cheap_window_end_hour:
+                    # First hour where PV covers load - we're done
+                    # bridging. The `h > cheap_window_end_hour` guard
+                    # avoids declaring takeover at the literal start
+                    # hour when both happen to be ~0 (pre-dawn).
+                    takeover_hour = h
+                    break
+                bridge_kwh += max(0.0, load_h - solar)
+
+            bridge_pct = bridge_kwh / inputs.battery_capacity_kwh * 100
+            min_soc_int = int(inputs.min_soc)
+            target_soc = int(
+                min_soc_int + bridge_pct + self.safety_buffer_pct
+            )
+            target_soc = max(
+                min_soc_int, min(self.max_target_soc, target_soc),
+            )
+
+            if takeover_hour is None:
+                reason = (
+                    f"no PV takeover within forecast horizon "
+                    f"(deep winter); target {target_soc}% covers "
+                    f"the day's full {bridge_kwh:.1f} kWh deficit"
+                )
+            else:
+                reason = (
+                    f"target {target_soc}% bridges "
+                    f"{bridge_kwh:.1f} kWh from "
+                    f"{self.cheap_window_end_hour:02d}:00 to PV takeover "
+                    f"at {takeover_hour:02d}:00 "
+                    f"(+{self.safety_buffer_pct}% safety buffer)"
+                )
 
         for slot in state.slots:
             if slot.grid_charge:
                 slot.capacity_soc = target_soc
 
-        state.reason_log.append(
-            f"CheapRateCharge: target {target_soc}% via {n_reason} "
-            f"(demand {expected_demand_kwh:.1f} kWh, "
-            f"solar {expected_solar_kwh:.1f} kWh, "
-            f"profitable export {expected_profitable_export_kwh:.1f} kWh "
-            f"from {len(worth_windows)} slots, "
-            f"worth charging {worth_charging_kwh:.1f} kWh)"
-        )
+        state.reason_log.append(f"CheapRateCharge: {reason}")
         return state

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -123,15 +123,34 @@ A window is "worth selling in" if it's in `top_export_windows` AND
 `export_rate * round_trip_efficiency > replacement_cost` where
 replacement_cost = next available IGO off-peak rate (typically 4.95p).
 
-### Charging from grid (cheap-rate decision)
+### Charging from grid (bridge-to-PV-takeover)
+
+The overnight charge target is sized to bridge from end-of-cheap-window
+through to the first hour where tomorrow's PV forecast covers tomorrow's
+load. After "PV takeover" the battery refills from solar at no cost; we
+don't want to fill it overnight and lose tomorrow's solar to a full
+battery.
 
 ```
-bottom_import_windows = bottom 25% of import_rates_today (or all IGO off-peak)
-charge target = enough to cover (load - solar) until next bottom window
+target_soc = min_soc
+           + morning_bridge_kwh / battery_capacity_kwh * 100
+           + safety_buffer_pct (default 10%)
+
+morning_bridge_kwh = sum max(0, load[h] - solar_tomorrow[h])
+                     for h in [cheap_window_end_hour, pv_takeover_hour)
 ```
 
-For IGO this is straightforward (off-peak windows are explicitly cheap).
-For variable tariffs the same logic generalises.
+Edge cases:
+- No tomorrow PV forecast -> default to filling battery (no signal).
+- PV never overtakes load (deep winter) -> sum the whole day's deficit;
+  target clamps to `max_target_soc`.
+- Tiny bridge (very early PV takeover) -> safety buffer keeps target a
+  comfortable margin above min_soc to absorb forecast misses.
+
+This replaces the legacy SPEC §5a "demand + profitable export - solar"
+formula, which over-charged when Octopus Outgoing peaks looked
+arbitrage-worthy and let the battery sit full while next-day solar was
+exporting at lower live rates.
 
 ### Why rank not absolute
 

--- a/tests/test_rules/test_cheap_rate_charge.py
+++ b/tests/test_rules/test_cheap_rate_charge.py
@@ -1,4 +1,4 @@
-"""Tests for CheapRateChargeRule."""
+"""Tests for CheapRateChargeRule (bridge-to-PV strategy)."""
 
 from datetime import time, datetime, timezone
 
@@ -12,31 +12,62 @@ def _make_baseline(inputs: ProgrammeInputs) -> ProgrammeState:
     return BaselineRule().apply(ProgrammeState.default(min_soc=20), inputs)
 
 
-class TestCheapRateChargeRule:
-    def test_reduces_overnight_target_when_solar_covers_demand(self, default_inputs):
-        """Sunny day: lots of solar, low demand -> don't charge much."""
-        default_inputs.solar_forecast_kwh = [0.0] * 6 + [2.0] * 12 + [0.0] * 6  # 24 kWh
-        default_inputs.load_forecast_kwh = [1.0] * 24  # 24 kWh total
-        state = _make_baseline(default_inputs)
-        rule = CheapRateChargeRule()
-        result = rule.apply(state, default_inputs)
-        # Solar covers all demand, so overnight target should be near min_soc
-        overnight = result.slots[0]
-        assert overnight.capacity_soc < 100
+def _sunny_tomorrow() -> list[float]:
+    """Plausible UK May tomorrow: PV ramps from 06:00, peaks midday,
+    falls off by 19:00. Total ~25 kWh."""
+    pv = [0.0] * 24
+    curve = [0.1, 0.5, 1.5, 2.5, 3.0, 3.5, 3.5, 3.0, 2.5, 1.5, 0.5, 0.1]
+    for i, v in enumerate(curve):
+        pv[6 + i] = v
+    return pv
 
-    def test_charges_fully_when_no_solar(self, default_inputs):
-        """Dark winter day: no solar, high demand -> charge to max."""
-        default_inputs.solar_forecast_kwh = [0.0] * 24
-        default_inputs.load_forecast_kwh = [2.0] * 24  # 48 kWh (exceeds battery)
+
+class TestCheapRateChargeRule:
+    def test_short_morning_bridge_when_pv_takes_over_early(
+        self, default_inputs,
+    ):
+        """Sunny tomorrow + low pre-dawn load: PV overtakes load early
+        morning, so the overnight charge only needs a small bridge."""
+        default_inputs.solar_forecast_kwh_tomorrow = _sunny_tomorrow()
+        default_inputs.load_forecast_kwh = [0.3] * 24  # very low
+        default_inputs.battery_capacity_kwh = 20.0
         state = _make_baseline(default_inputs)
         rule = CheapRateChargeRule()
         result = rule.apply(state, default_inputs)
+        # Bridge is hour 5 = 0.3 - 0 = 0.3 kWh; PV takeover hour 6
+        # (load=0.3, PV=0.1 - PV doesn't yet exceed load) ... actually
+        # depends on the curve. Just assert target is well under 100.
         overnight = result.slots[0]
-        assert overnight.capacity_soc == 100
+        assert overnight.capacity_soc < 50, (
+            f"expected small bridge target, got {overnight.capacity_soc}"
+        )
+
+    def test_charges_fully_when_no_tomorrow_pv_forecast(self, default_inputs):
+        """Without tomorrow's forecast we can't compute the bridge -
+        default to filling the battery so we don't strand at floor."""
+        default_inputs.solar_forecast_kwh_tomorrow = []
+        default_inputs.load_forecast_kwh = [1.0] * 24
+        state = _make_baseline(default_inputs)
+        rule = CheapRateChargeRule()
+        result = rule.apply(state, default_inputs)
+        assert result.slots[0].capacity_soc == 100
+
+    def test_charges_fully_when_pv_never_overtakes_load(self, default_inputs):
+        """Deep winter: PV never exceeds load all day - bridge is the
+        whole day's deficit, target clamps to max."""
+        # Tomorrow: tiny PV, big load - PV never overtakes load
+        default_inputs.solar_forecast_kwh_tomorrow = [0.05] * 24
+        default_inputs.load_forecast_kwh = [2.0] * 24
+        default_inputs.battery_capacity_kwh = 20.0
+        state = _make_baseline(default_inputs)
+        rule = CheapRateChargeRule()
+        result = rule.apply(state, default_inputs)
+        assert result.slots[0].capacity_soc == 100
 
     def test_never_below_min_soc(self, default_inputs):
-        """Even with massive solar, target never drops below min_soc."""
-        default_inputs.solar_forecast_kwh = [5.0] * 24  # 120 kWh
+        """Even with massive PV and tiny load, target stays >= min_soc."""
+        # Tomorrow: solar floods from hour 0 (unrealistic but tests floor)
+        default_inputs.solar_forecast_kwh_tomorrow = [5.0] * 24
         default_inputs.load_forecast_kwh = [0.1] * 24
         state = _make_baseline(default_inputs)
         rule = CheapRateChargeRule()
@@ -46,7 +77,7 @@ class TestCheapRateChargeRule:
 
     def test_max_target_soc_respected(self, default_inputs):
         """max_target_soc caps the overnight charge."""
-        default_inputs.solar_forecast_kwh = [0.0] * 24
+        default_inputs.solar_forecast_kwh_tomorrow = [0.0] * 24  # never overtakes
         default_inputs.load_forecast_kwh = [2.0] * 24
         state = _make_baseline(default_inputs)
         rule = CheapRateChargeRule(max_target_soc=80)
@@ -54,25 +85,41 @@ class TestCheapRateChargeRule:
         overnight = result.slots[0]
         assert overnight.capacity_soc <= 80
 
-    def test_accounts_for_profitable_export(self, default_inputs):
-        """If export rates are good, charge more to export later."""
-        default_inputs.solar_forecast_kwh = [0.0] * 24
-        default_inputs.load_forecast_kwh = [0.5] * 24  # 12 kWh -- small
-        default_inputs.export_rates = [
-            RateSlot(
-                start=datetime(2026, 4, 13, 12, 0, tzinfo=timezone.utc),
-                end=datetime(2026, 4, 13, 16, 0, tzinfo=timezone.utc),
-                rate_pence=15.0,  # well above 7.86p effective cost
-            ),
-        ]
+    def test_safety_buffer_keeps_target_above_floor(
+        self, default_inputs,
+    ):
+        """Even when bridge is essentially zero, the safety buffer
+        keeps target a comfortable margin above min_soc to absorb
+        forecast misses."""
+        default_inputs.solar_forecast_kwh_tomorrow = _sunny_tomorrow()
+        default_inputs.load_forecast_kwh = [0.0] * 24  # zero load = zero bridge
         state = _make_baseline(default_inputs)
-        rule = CheapRateChargeRule()
+        rule = CheapRateChargeRule(safety_buffer_pct=15)
         result = rule.apply(state, default_inputs)
-        overnight = result.slots[0]
-        # Should charge extra for profitable export
-        assert overnight.capacity_soc > int(default_inputs.min_soc) + 10
+        # Target should be at least min_soc + 15%
+        assert result.slots[0].capacity_soc >= int(default_inputs.min_soc) + 14
+
+    def test_bigger_load_means_bigger_bridge_target(self, default_inputs):
+        """Same PV curve, larger load -> bridge larger -> target higher."""
+        default_inputs.solar_forecast_kwh_tomorrow = _sunny_tomorrow()
+        default_inputs.battery_capacity_kwh = 20.0
+        rule = CheapRateChargeRule()
+
+        default_inputs.load_forecast_kwh = [0.2] * 24
+        s1 = _make_baseline(default_inputs)
+        target_low_load = rule.apply(s1, default_inputs).slots[0].capacity_soc
+
+        default_inputs.load_forecast_kwh = [1.0] * 24
+        s2 = _make_baseline(default_inputs)
+        target_high_load = rule.apply(s2, default_inputs).slots[0].capacity_soc
+
+        assert target_high_load > target_low_load, (
+            f"expected high-load target ({target_high_load}) > "
+            f"low-load ({target_low_load})"
+        )
 
     def test_reason_log_entry(self, default_inputs):
+        default_inputs.solar_forecast_kwh_tomorrow = _sunny_tomorrow()
         state = _make_baseline(default_inputs)
         rule = CheapRateChargeRule()
         result = rule.apply(state, default_inputs)
@@ -80,7 +127,7 @@ class TestCheapRateChargeRule:
 
     def test_also_sets_late_night_slot(self, default_inputs):
         """The 23:30 slot (slot 4) should get the same target as overnight slot 1."""
-        default_inputs.solar_forecast_kwh = [0.0] * 24
+        default_inputs.solar_forecast_kwh_tomorrow = _sunny_tomorrow()
         default_inputs.load_forecast_kwh = [1.0] * 24
         state = _make_baseline(default_inputs)
         rule = CheapRateChargeRule()


### PR DESCRIPTION
## Summary
Reworks `CheapRateChargeRule` to size the overnight grid-charge target as the morning bridge between end-of-cheap-window and PV takeover, rather than the legacy "fill for forecast demand + arbitrage" formula. With strong tomorrow-PV days, the old rule charged to 100% overnight at IGO rate even though the same kWh would arrive free from solar a few hours later.

```
target_soc = min_soc + morning_bridge_kwh / capacity * 100 + safety_buffer
where morning_bridge_kwh = sum max(0, load[h] - solar_tomorrow[h])
                         for h in [cheap_window_end_hour, pv_takeover_hour)
```

PV takeover = first hour where solar_tomorrow >= load.

## Test plan
- [x] 449 tests pass (8 rewritten for new contract + 1 new for bigger-load=>bigger-bridge invariant)
- [ ] Deploy + watch tonight's tick: overnight cap should be < 100% if tomorrow's solar > daily load
- [ ] Tomorrow morning: battery should fill from solar after takeover hour, evening export should draw from solar-charged battery rather than grid-arbitrage cycles

🤖 Generated with [Claude Code](https://claude.com/claude-code)