### PR TITLE
fix(export_window): flip work_mode to Selling first inside export windows

### DIFF
--- a/custom_components/heo2/rules/export_window.py
+++ b/custom_components/heo2/rules/export_window.py
@@ -162,6 +162,31 @@ class ExportWindowRule(Rule):
                 slot.capacity_soc = drain_target
                 modified = True
 
+        # Critical: setting slot.capacity_soc=10 alone doesn't make
+        # the inverter EXPORT - it just authorises the battery to
+        # drain. With BaselineRule's default work_mode="Zero export to
+        # CT", the inverter only discharges to cover house load and
+        # never sells surplus to the grid. To actually capture peak
+        # export rates, flip work_mode to "Selling first" while we're
+        # currently INSIDE a worth-selling window. Outside the window
+        # we leave the default (BaselineRule sets it back next tick).
+        local_now = inputs.now_local().time()
+        currently_in_export_window = any(
+            (
+                (r.start.astimezone(tz).time()
+                 if tz is not None and r.start.tzinfo is not None
+                 else r.start.time())
+                <= local_now
+                <
+                (r.end.astimezone(tz).time()
+                 if tz is not None and r.end.tzinfo is not None
+                 else r.end.time())
+            )
+            for r in worth_windows
+        )
+        if currently_in_export_window:
+            state.work_mode = "Selling first"
+
         sorted_hours = sorted(worth_hours)
         rate_summary = (
             f"{worth_windows[0].rate_pence:.2f}-"
@@ -176,6 +201,10 @@ class ExportWindowRule(Rule):
                 f"{len(worth_windows)} slots @ {rate_summary} "
                 f"covering hours {sorted_hours} "
                 f"(evening floor from {evening_demand_kwh:.1f} kWh demand)"
+                + (
+                    "; work_mode -> Selling first (in export window now)"
+                    if currently_in_export_window else ""
+                )
             )
         else:
             state.reason_log.append(

--- a/tests/test_rules/test_export_window.py
+++ b/tests/test_rules/test_export_window.py
@@ -129,6 +129,55 @@ class TestExportWindowRule:
         result = rule.apply(state, default_inputs)
         assert any("ExportWindow" in r for r in result.reason_log)
 
+    def test_work_mode_flips_to_selling_first_when_inside_export_window(
+        self, default_inputs,
+    ):
+        """When current local time falls inside a worth-selling rate
+        window, the rule MUST set work_mode='Selling first' so the
+        inverter actually exports to grid - not just drains to cover
+        house load. Without this the slot.capacity_soc=10 drain target
+        is ineffectual under the default 'Zero export to CT' mode."""
+        # Build a single high-export rate slot covering noon (now=12:00 UTC
+        # in the default fixture)
+        from heo2.models import RateSlot
+        default_inputs.export_rates = [
+            RateSlot(
+                start=datetime(2026, 4, 13, 11, 30, tzinfo=timezone.utc),
+                end=datetime(2026, 4, 13, 12, 30, tzinfo=timezone.utc),
+                rate_pence=25.0,
+            ),
+        ]
+        default_inputs.current_soc = 90.0
+        default_inputs.solar_forecast_kwh_tomorrow = [3.0] * 24
+        state = _make_baseline(default_inputs)
+        result = ExportWindowRule().apply(state, default_inputs)
+        assert result.work_mode == "Selling first"
+        assert any(
+            "Selling first" in r for r in result.reason_log
+        ), f"reason_log missing work_mode flip: {result.reason_log}"
+
+    def test_work_mode_left_default_outside_export_window(
+        self, default_inputs,
+    ):
+        """At a time when no worth-selling rate covers `now`, the rule
+        leaves work_mode unchanged (None or whatever Baseline set)."""
+        from heo2.models import RateSlot
+        # High export rate at 17:00 UTC; default_inputs.now is 12:00.
+        default_inputs.export_rates = [
+            RateSlot(
+                start=datetime(2026, 4, 13, 17, 0, tzinfo=timezone.utc),
+                end=datetime(2026, 4, 13, 18, 0, tzinfo=timezone.utc),
+                rate_pence=25.0,
+            ),
+        ]
+        default_inputs.current_soc = 90.0
+        default_inputs.solar_forecast_kwh_tomorrow = [3.0] * 24
+        state = _make_baseline(default_inputs)
+        # Force a known starting work_mode so we can detect non-change
+        state.work_mode = "Zero export to CT"
+        result = ExportWindowRule().apply(state, default_inputs)
+        assert result.work_mode == "Zero export to CT"
+
     def test_heo7_half_hour_slot_within_programme_slot_drains(
         self, default_inputs,
     ):


### PR DESCRIPTION
## Summary
Setting `slot.capacity_soc=10` only authorises the battery to drain - it doesn't command the inverter to export. With the default work_mode of "Zero export to CT", evening battery drain covers house load only; we lose the peak-rate arbitrage we explicitly identified as worth-selling.

Fix: ExportWindowRule sets `state.work_mode="Selling first"` when current local time falls inside any worth-selling rate window. Outside the window, work_mode is left at BaselineRule's default.

## Test plan
- [x] 446 tests pass (+2 new)
- [ ] Deploy + watch the next tick at evening: work_mode should flip to "Selling first" while we are in 16:00-19:00 BST export hours, then revert at slot transition

## Followup
User also wants the drain target sized as "load until cheap-rate starts" rather than the fixed evening_demand floor. Separate change; this PR is just the work_mode flip.