### PR TITLE
feat: PeakExportArbitrageRule - sell genuine spare at day's best price

### DIFF
--- a/custom_components/heo2/rules/__init__.py
+++ b/custom_components/heo2/rules/__init__.py
@@ -14,11 +14,12 @@ from .ev_charging import EVChargingRule
 from .saving_session import SavingSessionRule
 from .ev_deferral import EVDeferralRule
 from .eps_mode import EPSModeRule
+from .peak_export_arbitrage import PeakExportArbitrageRule
 from .safety import SafetyRule
 
 
 def default_rules() -> list[Rule]:
-    """Return the 11 default rules in priority order.
+    """Return the 12 default rules in priority order.
 
     SafetyRule is always last and cannot be disabled. EPSModeRule sits
     JUST before SafetyRule because it must override every other rule's
@@ -42,6 +43,7 @@ def default_rules() -> list[Rule]:
         SolarSurplusRule(),
         ExportWindowRule(),
         EveningProtectRule(),
+        PeakExportArbitrageRule(),
         SavingSessionRule(),
         IGODispatchRule(),
         EVDeferralRule(),

--- a/custom_components/heo2/rules/export_window.py
+++ b/custom_components/heo2/rules/export_window.py
@@ -162,30 +162,14 @@ class ExportWindowRule(Rule):
                 slot.capacity_soc = drain_target
                 modified = True
 
-        # Critical: setting slot.capacity_soc=10 alone doesn't make
-        # the inverter EXPORT - it just authorises the battery to
-        # drain. With BaselineRule's default work_mode="Zero export to
-        # CT", the inverter only discharges to cover house load and
-        # never sells surplus to the grid. To actually capture peak
-        # export rates, flip work_mode to "Selling first" while we're
-        # currently INSIDE a worth-selling window. Outside the window
-        # we leave the default (BaselineRule sets it back next tick).
-        local_now = inputs.now_local().time()
-        currently_in_export_window = any(
-            (
-                (r.start.astimezone(tz).time()
-                 if tz is not None and r.start.tzinfo is not None
-                 else r.start.time())
-                <= local_now
-                <
-                (r.end.astimezone(tz).time()
-                 if tz is not None and r.end.tzinfo is not None
-                 else r.end.time())
-            )
-            for r in worth_windows
-        )
-        if currently_in_export_window:
-            state.work_mode = "Selling first"
+        # NOTE: setting slot.capacity_soc=N alone authorises the
+        # battery to drain to N - it doesn't command export to grid.
+        # work_mode + max_discharge_a are managed by
+        # `PeakExportArbitrageRule` further down the chain, sized to
+        # actual spare and only during the day's TOP-priced window(s).
+        # An earlier version flipped work_mode here for *any*
+        # worth-selling window, but that sold during second-best slots
+        # too rather than concentrating on the genuine peak.
 
         sorted_hours = sorted(worth_hours)
         rate_summary = (
@@ -201,10 +185,6 @@ class ExportWindowRule(Rule):
                 f"{len(worth_windows)} slots @ {rate_summary} "
                 f"covering hours {sorted_hours} "
                 f"(evening floor from {evening_demand_kwh:.1f} kWh demand)"
-                + (
-                    "; work_mode -> Selling first (in export window now)"
-                    if currently_in_export_window else ""
-                )
             )
         else:
             state.reason_log.append(

--- a/custom_components/heo2/rules/peak_export_arbitrage.py
+++ b/custom_components/heo2/rules/peak_export_arbitrage.py
@@ -1,0 +1,255 @@
+# custom_components/heo2/rules/peak_export_arbitrage.py
+"""PeakExportArbitrageRule -- sell our genuine spare at the day's
+best-priced export slots, throttled to match the spare amount.
+
+This is the *arbitrage* rule. Buy at IGO off-peak (~7p), sell at
+Octopus Outgoing peak (~20p), pocket the spread on every kWh we
+genuinely don't need ourselves.
+
+Driven by the user's spec (verbatim, 2026-05-04):
+
+  * "Literally the best price for export that day - as set by
+    Octopus" -> we rank today's remaining export slots by
+    rate_pence DESC and allocate from the top down.
+  * "spare_kwh = current_soc - cumulative_load_now_to_2330
+    + remaining_pv_forecast_today" -> the kWh we can lose without
+    needing to import at peak before the cheap window starts.
+  * "the amount and rate of sale can be managed using max discharge
+    current along with selling first" -> we set both
+    `work_mode = Selling first` AND `max_discharge_a` for the
+    active slot so the inverter sells at exactly the rate we want.
+    Outside the allocated slot the BaselineRule default
+    ("Zero export to CT") suppresses any further export.
+
+Allocation:
+  * For each ranked slot, allocate up to
+    `max_discharge_kw * slot_duration_hours` (=2.5 kWh per 30-min
+    slot at 5 kW). Continue down the rank until `spare_kwh` is fully
+    allocated or no more remaining slots today.
+  * If `spare_kwh < per_slot_max`, the FIRST slot's amp rate is
+    throttled so we deliver exactly `spare_kwh` over the slot
+    duration - no need to switch off mid-slot.
+
+Outside any allocated slot, the rule does nothing - BaselineRule's
+`Zero export to CT` default suppresses export and the battery
+covers house load only (which is what the user wanted: "must make
+sure not to use peak rate electric").
+"""
+
+from __future__ import annotations
+
+import math
+from datetime import datetime, time, timedelta
+from zoneinfo import ZoneInfo
+
+from ..models import ProgrammeInputs, ProgrammeState, RateSlot
+from ..rule_engine import Rule
+
+
+def _local(dt: datetime, tz: ZoneInfo | None) -> datetime:
+    if tz is not None and dt.tzinfo is not None:
+        return dt.astimezone(tz)
+    return dt
+
+
+class PeakExportArbitrageRule(Rule):
+    """Sell genuine spare battery at the day's best export prices."""
+
+    name = "peak_export_arbitrage"
+    description = (
+        "Sell battery surplus at top-priced export slots, sized to "
+        "available spare, throttled via discharge rate"
+    )
+
+    def __init__(
+        self,
+        *,
+        cheap_window_start: time = time(23, 30),
+        max_discharge_kw: float = 5.0,
+        battery_voltage_nominal: float = 51.2,
+        max_discharge_a_default: float = 100.0,
+    ):
+        self.cheap_window_start = cheap_window_start
+        self.max_discharge_kw = max_discharge_kw
+        self.battery_voltage_nominal = battery_voltage_nominal
+        self.max_discharge_a_default = max_discharge_a_default
+
+    # --- helpers ---------------------------------------------------
+
+    def _hours_until_cheap(
+        self, now_local: datetime,
+    ) -> tuple[datetime, float]:
+        """Return the (datetime, hours) of the next cheap-window
+        start. Wraps to tomorrow if today's cheap window already
+        started before `now`."""
+        cheap_start = now_local.replace(
+            hour=self.cheap_window_start.hour,
+            minute=self.cheap_window_start.minute,
+            second=0, microsecond=0,
+        )
+        if cheap_start <= now_local:
+            cheap_start += timedelta(days=1)
+        hours = (cheap_start - now_local).total_seconds() / 3600.0
+        return cheap_start, hours
+
+    def _sum_forecast_until(
+        self,
+        forecast_hourly: list[float],
+        now_local: datetime,
+        until_local: datetime,
+    ) -> float:
+        """Pro-rate hourly forecast values from `now_local` to
+        `until_local`. First and last hours partial-summed."""
+        if not forecast_hourly or len(forecast_hourly) < 24:
+            return 0.0
+        total = 0.0
+        cursor = now_local
+        # First partial hour from cursor to next-hour boundary
+        while cursor < until_local:
+            hour_idx = cursor.hour
+            next_boundary = (cursor + timedelta(hours=1)).replace(
+                minute=0, second=0, microsecond=0,
+            )
+            slice_end = min(next_boundary, until_local)
+            fraction = (slice_end - cursor).total_seconds() / 3600.0
+            total += forecast_hourly[hour_idx] * fraction
+            cursor = slice_end
+        return total
+
+    def _sum_pv_remaining_today(
+        self,
+        forecast_hourly: list[float],
+        now_local: datetime,
+    ) -> float:
+        """PV forecast from `now` until end of today's local day
+        (23:59)."""
+        end_of_day = now_local.replace(
+            hour=23, minute=59, second=59, microsecond=0,
+        )
+        return self._sum_forecast_until(
+            forecast_hourly, now_local, end_of_day,
+        )
+
+    def _today_remaining_export_slots(
+        self,
+        export_rates: list[RateSlot],
+        now_local: datetime,
+        cheap_start: datetime,
+        tz: ZoneInfo | None,
+    ) -> list[RateSlot]:
+        """Filter to export slots that haven't started yet AND start
+        before the cheap window. Selling at 23:00 still counts; selling
+        post-23:30 is moot because we'd be drawing from a battery
+        we're then refilling."""
+        out = []
+        for r in export_rates:
+            start_local = _local(r.start, tz)
+            if start_local < now_local or start_local >= cheap_start:
+                continue
+            out.append(r)
+        return out
+
+    # --- main ------------------------------------------------------
+
+    def apply(self, state: ProgrammeState, inputs: ProgrammeInputs) -> ProgrammeState:
+        if not inputs.export_rates:
+            return state
+
+        tz = inputs.local_tz
+        now_local = inputs.now_local()
+        cheap_start, hours_to_cheap = self._hours_until_cheap(now_local)
+
+        future_slots = self._today_remaining_export_slots(
+            inputs.export_rates, now_local, cheap_start, tz,
+        )
+        if not future_slots:
+            return state
+
+        # Spare = (current SOC above floor) - load_to_cheap + pv_remaining.
+        # Above-floor because we never sell into the min_soc reserve.
+        floor_kwh = inputs.min_soc / 100.0 * inputs.battery_capacity_kwh
+        current_kwh = inputs.current_soc / 100.0 * inputs.battery_capacity_kwh
+        usable_kwh = max(0.0, current_kwh - floor_kwh)
+
+        load_to_cheap = self._sum_forecast_until(
+            inputs.load_forecast_kwh, now_local, cheap_start,
+        )
+        pv_remaining = self._sum_pv_remaining_today(
+            inputs.solar_forecast_kwh, now_local,
+        )
+
+        spare_kwh = usable_kwh - load_to_cheap + pv_remaining
+        if spare_kwh <= 0.05:
+            state.reason_log.append(
+                f"PeakArbitrage: no spare to sell "
+                f"(usable {usable_kwh:.2f} kWh - load_to_2330 "
+                f"{load_to_cheap:.2f} + pv_remaining "
+                f"{pv_remaining:.2f} = {spare_kwh:.2f} kWh)"
+            )
+            return state
+
+        # Rank slots by rate desc, ties by sooner-is-better
+        sorted_slots = sorted(
+            future_slots,
+            key=lambda r: (-r.rate_pence, _local(r.start, tz)),
+        )
+
+        # Allocate spare to top slots, max 2.5 kWh per 30-min slot
+        per_slot_max = self.max_discharge_kw * 0.5
+        allocations: list[tuple[RateSlot, float]] = []
+        remaining = spare_kwh
+        for slot in sorted_slots:
+            if remaining <= 0.001:
+                break
+            slot_duration_h = (slot.end - slot.start).total_seconds() / 3600.0
+            slot_max = self.max_discharge_kw * slot_duration_h
+            kwh = min(remaining, slot_max)
+            allocations.append((slot, kwh))
+            remaining -= kwh
+
+        # Find the allocated slot covering NOW (if any)
+        active_slot: RateSlot | None = None
+        active_kwh: float = 0.0
+        for slot, kwh in allocations:
+            slot_start = _local(slot.start, tz)
+            slot_end = _local(slot.end, tz)
+            if slot_start <= now_local < slot_end:
+                active_slot = slot
+                active_kwh = kwh
+                break
+
+        if active_slot is None:
+            future_str = ", ".join(
+                f"{_local(s.start, tz).strftime('%H:%M')}@{s.rate_pence:.2f}p "
+                f"({k:.2f} kWh)"
+                for s, k in allocations[:3]
+            )
+            state.reason_log.append(
+                f"PeakArbitrage: spare {spare_kwh:.2f} kWh; "
+                f"sell scheduled in {future_str or 'no future slots'}"
+            )
+            return state
+
+        # We are INSIDE an allocated slot - sell now.
+        slot_duration_h = (
+            active_slot.end - active_slot.start
+        ).total_seconds() / 3600.0
+        # Throttle amp rate so we deliver exactly active_kwh over the
+        # slot's duration. Defensive minimum 1A so the inverter keeps
+        # selling at SOMETHING rather than silently halting.
+        kw_for_slot = active_kwh / slot_duration_h
+        amps_target = kw_for_slot * 1000.0 / self.battery_voltage_nominal
+        amps = max(1.0, min(amps_target, self.max_discharge_a_default))
+
+        state.work_mode = "Selling first"
+        state.max_discharge_a = round(amps, 1)
+
+        slot_local_start = _local(active_slot.start, tz).strftime("%H:%M")
+        state.reason_log.append(
+            f"PeakArbitrage: ACTIVE - selling {active_kwh:.2f} kWh "
+            f"in slot {slot_local_start} "
+            f"@ {active_slot.rate_pence:.2f}p "
+            f"(spare {spare_kwh:.2f} kWh, throttle {amps:.0f}A); "
+            f"work_mode -> Selling first"
+        )
+        return state

--- a/tests/test_rules/test_export_window.py
+++ b/tests/test_rules/test_export_window.py
@@ -129,16 +129,16 @@ class TestExportWindowRule:
         result = rule.apply(state, default_inputs)
         assert any("ExportWindow" in r for r in result.reason_log)
 
-    def test_work_mode_flips_to_selling_first_when_inside_export_window(
+    def test_export_window_does_not_set_work_mode(
         self, default_inputs,
     ):
-        """When current local time falls inside a worth-selling rate
-        window, the rule MUST set work_mode='Selling first' so the
-        inverter actually exports to grid - not just drains to cover
-        house load. Without this the slot.capacity_soc=10 drain target
-        is ineffectual under the default 'Zero export to CT' mode."""
-        # Build a single high-export rate slot covering noon (now=12:00 UTC
-        # in the default fixture)
+        """ExportWindowRule no longer touches work_mode. That
+        responsibility moved to PeakExportArbitrageRule, which sizes
+        the work_mode flip to actual spare and only fires in the
+        TOP-priced slot rather than every worth-selling slot. This
+        test pins that ExportWindow's job is now JUST slot-cap
+        drain authorisation - work_mode stays at whatever Baseline
+        / earlier rules set."""
         from heo2.models import RateSlot
         default_inputs.export_rates = [
             RateSlot(
@@ -150,32 +150,9 @@ class TestExportWindowRule:
         default_inputs.current_soc = 90.0
         default_inputs.solar_forecast_kwh_tomorrow = [3.0] * 24
         state = _make_baseline(default_inputs)
+        state.work_mode = "Zero export to CT"  # pre-set
         result = ExportWindowRule().apply(state, default_inputs)
-        assert result.work_mode == "Selling first"
-        assert any(
-            "Selling first" in r for r in result.reason_log
-        ), f"reason_log missing work_mode flip: {result.reason_log}"
-
-    def test_work_mode_left_default_outside_export_window(
-        self, default_inputs,
-    ):
-        """At a time when no worth-selling rate covers `now`, the rule
-        leaves work_mode unchanged (None or whatever Baseline set)."""
-        from heo2.models import RateSlot
-        # High export rate at 17:00 UTC; default_inputs.now is 12:00.
-        default_inputs.export_rates = [
-            RateSlot(
-                start=datetime(2026, 4, 13, 17, 0, tzinfo=timezone.utc),
-                end=datetime(2026, 4, 13, 18, 0, tzinfo=timezone.utc),
-                rate_pence=25.0,
-            ),
-        ]
-        default_inputs.current_soc = 90.0
-        default_inputs.solar_forecast_kwh_tomorrow = [3.0] * 24
-        state = _make_baseline(default_inputs)
-        # Force a known starting work_mode so we can detect non-change
-        state.work_mode = "Zero export to CT"
-        result = ExportWindowRule().apply(state, default_inputs)
+        # Unchanged - PeakExportArbitrage will handle the flip later
         assert result.work_mode == "Zero export to CT"
 
     def test_heo7_half_hour_slot_within_programme_slot_drains(

--- a/tests/test_rules/test_peak_export_arbitrage.py
+++ b/tests/test_rules/test_peak_export_arbitrage.py
@@ -1,0 +1,201 @@
+# tests/test_rules/test_peak_export_arbitrage.py
+"""Tests for PeakExportArbitrageRule (the day's-best-price arbitrage)."""
+
+from __future__ import annotations
+
+from datetime import datetime, time, timedelta, timezone
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from heo2.models import ProgrammeInputs, ProgrammeState, RateSlot, SlotConfig
+from heo2.rules.peak_export_arbitrage import PeakExportArbitrageRule
+
+
+_LON = ZoneInfo("Europe/London")
+
+
+def _slot(start_h, start_m, end_h, end_m, soc=50, gc=False):
+    return SlotConfig(
+        start_time=time(start_h, start_m),
+        end_time=time(end_h, end_m),
+        capacity_soc=soc,
+        grid_charge=gc,
+    )
+
+
+def _empty_programme():
+    return ProgrammeState(slots=[
+        _slot(0, 0, 5, 30, 50, True),
+        _slot(5, 30, 18, 30, 50, False),
+        _slot(18, 30, 23, 30, 10, False),
+        _slot(23, 30, 23, 55, 50, True),
+        _slot(23, 55, 23, 55, 10, False),
+        _slot(23, 55, 0, 0, 10, False),
+    ], reason_log=[])
+
+
+def _half_hour_rate(date: datetime, hour: int, minute: int, p: float) -> RateSlot:
+    """Helper: a 30-min export rate slot at a specific local time."""
+    start_local = date.replace(hour=hour, minute=minute, second=0, microsecond=0)
+    return RateSlot(
+        start=start_local.astimezone(timezone.utc),
+        end=(start_local + timedelta(minutes=30)).astimezone(timezone.utc),
+        rate_pence=p,
+    )
+
+
+def _inputs(
+    *,
+    now_local: datetime,
+    current_soc: float = 80.0,
+    capacity: float = 20.0,
+    min_soc: float = 10.0,
+    export_rates: list[RateSlot] | None = None,
+    load_24: list[float] | None = None,
+    solar_24: list[float] | None = None,
+):
+    """Build ProgrammeInputs with `now` derived from a London-local
+    datetime. Coordinator does the same in production."""
+    return ProgrammeInputs(
+        now=now_local.astimezone(timezone.utc),
+        current_soc=current_soc,
+        battery_capacity_kwh=capacity,
+        min_soc=min_soc,
+        import_rates=[],
+        export_rates=export_rates or [],
+        solar_forecast_kwh=solar_24 or [0.0] * 24,
+        load_forecast_kwh=load_24 or [0.5] * 24,
+        igo_dispatching=False,
+        saving_session=False,
+        saving_session_start=None,
+        saving_session_end=None,
+        ev_charging=False,
+        grid_connected=True,
+        active_appliances=[],
+        appliance_expected_kwh=0.0,
+        local_tz=_LON,
+    )
+
+
+class TestPeakExportArbitrageRule:
+    def test_no_export_rates_is_noop(self):
+        now = datetime(2026, 5, 4, 17, 0, tzinfo=_LON)
+        inputs = _inputs(now_local=now, export_rates=[])
+        result = PeakExportArbitrageRule().apply(_empty_programme(), inputs)
+        assert result.work_mode is None
+
+    def test_no_spare_when_load_consumes_battery(self):
+        """Battery 50%, load until 23:30 needs 8 kWh = 40% drain.
+        Above min_soc we have only 8 kWh -> spare is 0 -> rule is no-op."""
+        today = datetime(2026, 5, 4, 17, 0, tzinfo=_LON)
+        rates = [_half_hour_rate(today, 18, 0, 25.0)]
+        # 6.5h * 1.23 kWh/h ≈ 8 kWh load before 23:30
+        load = [1.23] * 24
+        inputs = _inputs(
+            now_local=today, current_soc=50.0, capacity=20.0, min_soc=10.0,
+            export_rates=rates, load_24=load,
+        )
+        result = PeakExportArbitrageRule().apply(_empty_programme(), inputs)
+        assert result.work_mode is None
+        assert any("no spare" in r for r in result.reason_log)
+
+    def test_active_when_in_top_priced_slot_with_spare(self):
+        """Battery full, currently inside the top-priced 30-min slot,
+        light load -> rule fires Selling first + sized discharge."""
+        today = datetime(2026, 5, 4, 18, 0, tzinfo=_LON)
+        rates = [
+            _half_hour_rate(today, 18, 0, 25.0),  # active now (best)
+            _half_hour_rate(today, 17, 30, 22.0),  # in past
+            _half_hour_rate(today, 18, 30, 21.0),  # later, lower
+        ]
+        inputs = _inputs(
+            now_local=today, current_soc=100.0, capacity=20.0, min_soc=10.0,
+            export_rates=rates,
+            load_24=[0.3] * 24,  # very light
+        )
+        result = PeakExportArbitrageRule().apply(_empty_programme(), inputs)
+        assert result.work_mode == "Selling first"
+        assert result.max_discharge_a is not None
+        assert result.max_discharge_a > 0
+        assert any("ACTIVE" in r for r in result.reason_log)
+
+    def test_inactive_outside_allocated_slot(self):
+        """Battery full, top-priced slot is 18:00-18:30, but we're at
+        17:00 (between rates with no allocation) -> work_mode left
+        alone."""
+        today = datetime(2026, 5, 4, 17, 0, tzinfo=_LON)
+        rates = [
+            _half_hour_rate(today, 18, 0, 25.0),  # later, best
+            _half_hour_rate(today, 17, 0, 5.0),   # active now, low rate
+        ]
+        inputs = _inputs(
+            now_local=today, current_soc=100.0, capacity=20.0, min_soc=10.0,
+            export_rates=rates, load_24=[0.3] * 24,
+        )
+        result = PeakExportArbitrageRule().apply(_empty_programme(), inputs)
+        # Even though spare exists, we're not in the BEST slot - 5p
+        # might still be allocated if spare > 5kW*0.5h, otherwise
+        # no allocation reaches 17:00. With ~17 kWh spare and only
+        # 2 worth-sell slots, allocation: best=2.5, second=2.5; 17:00
+        # might end up allocated if spare > 2.5. Let's check: spare
+        # ~= (100-10)/100*20 - 6.5*0.3 + 0 ≈ 18 - 1.95 ≈ 16 kWh.
+        # First slot gets 2.5, second gets 2.5; total 5 kWh. So 17:00
+        # IS allocated (it ranks 2nd by rate). work_mode WOULD be
+        # set. To assert the "outside allocation" path we need a
+        # scenario where the active slot got 0.
+        # Refine: drop the 17:00 slot from rates so 17:00 has no rate.
+        inputs2 = _inputs(
+            now_local=today, current_soc=100.0, capacity=20.0, min_soc=10.0,
+            export_rates=[_half_hour_rate(today, 18, 0, 25.0)],
+            load_24=[0.3] * 24,
+        )
+        result2 = PeakExportArbitrageRule().apply(
+            _empty_programme(), inputs2,
+        )
+        assert result2.work_mode is None
+        assert any("scheduled" in r for r in result2.reason_log)
+
+    def test_throttle_amps_when_spare_smaller_than_full_slot(self):
+        """Spare ~1 kWh and slot is 30 min: full rate = 5 kW would
+        empty spare in 12 min. Throttle to deliver 1 kWh over 30 min
+        = 2 kW = ~39A."""
+        today = datetime(2026, 5, 4, 18, 0, tzinfo=_LON)
+        rates = [_half_hour_rate(today, 18, 0, 25.0)]
+        # Compute conditions that yield spare ~= 1 kWh
+        # current_above_floor = (50-10)/100 * 20 = 8 kWh
+        # load_to_2330 = 5.5h * 1.27 = ~7 kWh => spare = 8 - 7 + 0 = 1 kWh
+        inputs = _inputs(
+            now_local=today, current_soc=50.0, capacity=20.0, min_soc=10.0,
+            export_rates=rates, load_24=[1.27] * 24,
+        )
+        result = PeakExportArbitrageRule().apply(_empty_programme(), inputs)
+        assert result.work_mode == "Selling first"
+        # 1 kWh / 0.5h = 2 kW => 2000 / 51.2 ≈ 39A
+        assert 30 < result.max_discharge_a < 50
+
+    def test_pv_remaining_added_to_spare(self):
+        """PV remaining today INCREASES spare - if there's still solar
+        coming, we have more to sell."""
+        today = datetime(2026, 5, 4, 16, 0, tzinfo=_LON)
+        rates = [_half_hour_rate(today, 16, 0, 25.0)]  # active now
+        # No PV: spare = 8 kWh - 7.5 kWh (load) = 0.5 kWh
+        # With PV: spare gets +5 kWh of late-day solar -> 5.5 kWh
+        no_pv = _inputs(
+            now_local=today, current_soc=50.0, capacity=20.0, min_soc=10.0,
+            export_rates=rates, load_24=[1.0] * 24,
+            solar_24=[0.0] * 24,
+        )
+        with_pv = _inputs(
+            now_local=today, current_soc=50.0, capacity=20.0, min_soc=10.0,
+            export_rates=rates, load_24=[1.0] * 24,
+            solar_24=[0.0] * 16 + [2.5, 2.0, 0.5] + [0.0] * 5,
+        )
+        r_no = PeakExportArbitrageRule().apply(
+            _empty_programme(), no_pv,
+        )
+        r_yes = PeakExportArbitrageRule().apply(
+            _empty_programme(), with_pv,
+        )
+        # With PV the throttle amp should be higher (more to sell)
+        assert (r_yes.max_discharge_a or 0) > (r_no.max_discharge_a or 0)


### PR DESCRIPTION
## Summary
Implements the user-spec'd arbitrage rule. Sells the kWh genuinely spare (current SOC above floor minus load_until_cheap plus PV remaining today) at today's literal-best-priced 30-min export slot, throttled via discharge rate to deliver exactly the spare amount over the slot. Outside the allocated slot, work_mode reverts to BaselineRule's 'Zero export to CT' so house load is covered without further export.

Replaces the blanket work_mode=Selling-first flip in ExportWindowRule (PR #68) which was too coarse - that sold at every worth-selling slot rather than concentrating on the day's peak.

## Test plan
- [x] 451 tests pass (+6 new for arbitrage, +1 rewritten for ExportWindow)
- [ ] Deploy + observe: work_mode flips to Selling first only during the day's best-priced slot, max_discharge_a throttled for spare amount
- [ ] Outside the peak slot, battery just covers load (not exporting)

🤖 Generated with [Claude Code](https://claude.com/claude-code)