### PR TITLE
feat(rules): decide/apply split with claims + arbitration (Phase 3 PR 2)

### DIFF
--- a/custom_components/heo2/models.py
+++ b/custom_components/heo2/models.py
@@ -92,6 +92,13 @@ class ProgrammeState:
     max_charge_a: Optional[float] = None
     max_discharge_a: Optional[float] = None
     ev_deferral_active: bool = False
+    # HEO-31 Phase 3: structured per-claim trace, parallel to
+    # `reason_log`. Each rule's claims (writes) are captured here with
+    # priority/reason/value/winning-status, so the dashboard can answer
+    # "why is slot 3 at 60%?" by walking the per-field claim list.
+    # `reason_log` keeps its original flat-string shape for back-compat
+    # with sensors and existing tests that grep its contents.
+    claims_log: list = field(default_factory=list)
 
     @classmethod
     def default(cls, min_soc: int = 20) -> ProgrammeState:

--- a/custom_components/heo2/rule_engine.py
+++ b/custom_components/heo2/rule_engine.py
@@ -1,36 +1,421 @@
-"""Rule engine for HEO II programme calculation. No Home Assistant imports."""
+"""Rule engine for HEO II programme calculation. No Home Assistant imports.
+
+Phase 3 (HEO-31) replaced the original "each rule mutates state, last
+writer wins" pipeline with a claims-and-arbitration model. Every
+proposed write is a `Claim` carrying `field`, `value`, `priority`, and
+`reason`. The arbiter picks the highest-priority claim per (field,
+slot). Two reasons:
+
+1. Removes the implicit "execution-order defines precedence" semantics
+   that made the matrix in `docs/rule_field_overlap.md` necessary in
+   the first place. Precedence is now an explicit number in the rule.
+2. Surfaces the reason chain. `state.claims_log` records every claim
+   each rule made and which one won, so the dashboard can answer
+   "why is slot 3 at 60%?" by walking the per-field claim list.
+
+`state.reason_log` is kept as the existing flat list of summary
+strings rules append via `builder.log()`. The structured per-claim
+trace lives in `state.claims_log` so existing tests / sensors that
+assert on `reason_log` shape keep working.
+
+`Rule.apply(state, inputs)` is preserved as a back-compat shim that
+funnels into `propose()` via a single-rule builder. Existing tests
+that call `rule.apply(...)` directly keep working without
+modification.
+
+`SafetyRule` does NOT participate in the propose phase - it's an
+invariant enforcer (clamping SOC ranges, snapping 5-min granularity,
+fixing contiguity) that runs as a final post-arbitration pass. Same
+shape as before.
+"""
 
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Any
 
 from .models import ProgrammeState, ProgrammeInputs
 
 
+# Standard priority bands. Use these or pick a value within the same
+# band rather than a free-floating int, so the registry is readable.
+# Higher wins. Bands chosen so per-rule fine-tuning has room without
+# bumping into adjacent rule classes.
+PRIO_BASELINE = 10           # scaffolder; anything overrides
+PRIO_CHEAP_RATE_CHARGE = 20
+PRIO_SOLAR_SURPLUS = 30
+PRIO_EXPORT_WINDOW = 40
+PRIO_EVENING_PROTECT = 50
+PRIO_PEAK_EXPORT_ARBITRAGE = 60
+PRIO_SAVING_SESSION = 70
+PRIO_IGO_DISPATCH = 80
+PRIO_EV_DEFERRAL = 90
+PRIO_EV_CHARGING = 100
+PRIO_EPS = 110               # second-to-last; overrides everything
+
+
+@dataclass
+class Claim:
+    """A proposed write by a rule.
+
+    `field` is one of the writable fields on `ProgrammeState` /
+    `SlotConfig`: `capacity_soc`, `grid_charge`, `work_mode`,
+    `energy_pattern`, `max_charge_a`, `max_discharge_a`,
+    `ev_deferral_active`. `slot_index` is None for global fields and
+    0..5 for per-slot.
+
+    `priority` decides arbitration: higher wins; ties broken by the
+    rule's order in `default_rules()` (later wins, matching legacy
+    last-writer-wins).
+    """
+    field: str
+    value: Any
+    priority: int
+    reason: str
+    rule_name: str
+    slot_index: int | None = None
+    insertion_order: int = 0
+
+
+class _RuleView:
+    """A builder view pre-bound to a rule. Returned by
+    `StateBuilder.view_for_rule()`. Rules call `claim_*` and `log` on
+    the view; the underlying builder records the rule_name for free.
+    """
+
+    def __init__(self, builder: StateBuilder, rule: Rule):
+        self._b = builder
+        self._rule = rule
+
+    def claim_slot(self, slot_index: int, field_name: str, value, *, reason: str, priority: int | None = None) -> None:
+        self._b._record_claim(
+            field_name=field_name,
+            value=value,
+            slot_index=slot_index,
+            priority=priority if priority is not None else self._rule.priority_class,
+            reason=reason,
+            rule_name=self._rule.name,
+        )
+
+    def claim_global(self, field_name: str, value, *, reason: str, priority: int | None = None) -> None:
+        self._b._record_claim(
+            field_name=field_name,
+            value=value,
+            slot_index=None,
+            priority=priority if priority is not None else self._rule.priority_class,
+            reason=reason,
+            rule_name=self._rule.name,
+        )
+
+    def get_slot(self, slot_index: int, field_name: str):
+        return self._b.get_slot(slot_index, field_name)
+
+    def get_global(self, field_name: str):
+        return self._b.get_global(field_name)
+
+    @property
+    def slots(self):
+        """Read-only view of the current winning per-slot values, as a
+        list of read-shaped objects with `.capacity_soc`, `.grid_charge`,
+        `.start_time`, `.end_time` attributes. Useful for `for slot in
+        view.slots:` patterns ported from the old apply-style code."""
+        return self._b.slot_views()
+
+    def find_slot_at(self, t):
+        """Mirror of `ProgrammeState.find_slot_at` over the slot views."""
+        return self._b.find_slot_at(t)
+
+    def log(self, message: str) -> None:
+        self._b._reason_log.append(message)
+
+
+class StateBuilder:
+    """Accumulates claims; rules read the highest-priority claim so far.
+
+    Reads return either:
+    1. The highest-priority claim's value for that (field, slot_index)
+       so far, or
+    2. The seeded value from the initial state if no rule has claimed
+       (seed priority is below all rule priorities so any claim wins).
+
+    `materialise()` folds claims into a final `ProgrammeState`.
+    """
+
+    SEED_PRIORITY = -1
+
+    def __init__(self, initial: ProgrammeState):
+        self._claims: list[Claim] = []
+        self._next_insertion = 0
+        self._reason_log: list[str] = list(initial.reason_log)
+        # Seed claims from the initial state so rules can read it.
+        # Seed priority is below any rule priority so the first claim
+        # made by any rule overrides the seed.
+        for i, slot in enumerate(initial.slots):
+            self._seed_slot(i, "capacity_soc", slot.capacity_soc)
+            self._seed_slot(i, "grid_charge", slot.grid_charge)
+            self._seed_slot(i, "start_time", slot.start_time)
+            self._seed_slot(i, "end_time", slot.end_time)
+        self._seed_global("work_mode", initial.work_mode)
+        self._seed_global("energy_pattern", initial.energy_pattern)
+        self._seed_global("max_charge_a", initial.max_charge_a)
+        self._seed_global("max_discharge_a", initial.max_discharge_a)
+        self._seed_global("ev_deferral_active", initial.ev_deferral_active)
+        self._initial = initial
+
+    @classmethod
+    def from_state(cls, state: ProgrammeState, *, seed_priority: int = SEED_PRIORITY) -> StateBuilder:
+        """Create a builder seeded from `state`. Used by the back-compat
+        `Rule.apply()` shim - tests calling rule.apply(state, inputs)
+        get a builder where reads return whatever is currently in state.
+        """
+        b = cls(state)
+        # Override seed priority if requested. The shim sets this so
+        # the rule's own claims (at priority_class) override the seeds
+        # from state but reads return state values until claimed.
+        if seed_priority != cls.SEED_PRIORITY:
+            for c in b._claims:
+                c.priority = seed_priority
+        return b
+
+    def _seed_slot(self, slot_index: int, field_name: str, value) -> None:
+        self._claims.append(Claim(
+            field=field_name,
+            value=value,
+            priority=self.SEED_PRIORITY,
+            reason="seed from initial state",
+            rule_name="<seed>",
+            slot_index=slot_index,
+            insertion_order=self._next_insertion,
+        ))
+        self._next_insertion += 1
+
+    def _seed_global(self, field_name: str, value) -> None:
+        self._claims.append(Claim(
+            field=field_name,
+            value=value,
+            priority=self.SEED_PRIORITY,
+            reason="seed from initial state",
+            rule_name="<seed>",
+            slot_index=None,
+            insertion_order=self._next_insertion,
+        ))
+        self._next_insertion += 1
+
+    def _record_claim(self, *, field_name, value, slot_index, priority, reason, rule_name) -> None:
+        self._claims.append(Claim(
+            field=field_name,
+            value=value,
+            priority=priority,
+            reason=reason,
+            rule_name=rule_name,
+            slot_index=slot_index,
+            insertion_order=self._next_insertion,
+        ))
+        self._next_insertion += 1
+
+    def view_for_rule(self, rule: Rule) -> _RuleView:
+        """Return a view pre-bound to `rule`. Rules use this view for
+        all claim writes / reads / log appends; rule_name is recorded
+        automatically."""
+        return _RuleView(self, rule)
+
+    # --- reads --------------------------------------------------------
+
+    def _winning(self, field_name: str, slot_index: int | None):
+        candidates = [
+            c for c in self._claims
+            if c.field == field_name and c.slot_index == slot_index
+        ]
+        if not candidates:
+            return None
+        # Highest priority wins; ties broken by insertion order
+        # (later insertion wins, matching legacy "last writer wins").
+        candidates.sort(key=lambda c: (c.priority, c.insertion_order))
+        return candidates[-1]
+
+    def get_slot(self, slot_index: int, field_name: str):
+        c = self._winning(field_name, slot_index)
+        return c.value if c is not None else None
+
+    def get_global(self, field_name: str):
+        c = self._winning(field_name, None)
+        return c.value if c is not None else None
+
+    def slot_views(self) -> list[_SlotView]:
+        return [_SlotView(self, i) for i in range(len(self._initial.slots))]
+
+    def find_slot_at(self, t):
+        for i, view in enumerate(self.slot_views()):
+            if view.contains_time(t):
+                return i
+        raise ValueError(f"No slot contains {t}")
+
+    # --- materialisation ---------------------------------------------
+
+    def materialise(self) -> ProgrammeState:
+        """Fold claims into a `ProgrammeState`."""
+        from copy import deepcopy
+        state = deepcopy(self._initial)
+        n_slots = len(state.slots)
+
+        for i in range(n_slots):
+            for f in ("capacity_soc", "grid_charge", "start_time", "end_time"):
+                c = self._winning(f, i)
+                if c is not None:
+                    setattr(state.slots[i], f, c.value)
+
+        for f in (
+            "work_mode",
+            "energy_pattern",
+            "max_charge_a",
+            "max_discharge_a",
+            "ev_deferral_active",
+        ):
+            c = self._winning(f, None)
+            if c is not None:
+                setattr(state, f, c.value)
+
+        # reason_log already accumulated during proposes via builder.log()
+        state.reason_log = list(self._reason_log)
+
+        # Structured per-field claim trace for the dashboard / debugging.
+        state.claims_log = [
+            c for c in self._claims if c.priority != self.SEED_PRIORITY
+        ]
+        return state
+
+
+class _SlotView:
+    """Read-only view of one slot's currently-winning values. Mirrors
+    the `SlotConfig` attribute surface so rule code ported from the
+    old `for slot in state.slots:` pattern reads naturally.
+    """
+
+    def __init__(self, builder: StateBuilder, slot_index: int):
+        self._b = builder
+        self._idx = slot_index
+
+    @property
+    def index(self) -> int:
+        return self._idx
+
+    @property
+    def capacity_soc(self) -> int:
+        return self._b.get_slot(self._idx, "capacity_soc")
+
+    @property
+    def grid_charge(self) -> bool:
+        return self._b.get_slot(self._idx, "grid_charge")
+
+    @property
+    def start_time(self):
+        return self._b.get_slot(self._idx, "start_time")
+
+    @property
+    def end_time(self):
+        return self._b.get_slot(self._idx, "end_time")
+
+    def contains_time(self, t) -> bool:
+        from datetime import time as _time
+        if self.start_time <= self.end_time:
+            return self.start_time <= t < self.end_time
+        return t >= self.start_time or t < self.end_time
+
+    def duration_minutes(self) -> int:
+        start_mins = self.start_time.hour * 60 + self.start_time.minute
+        end_mins = self.end_time.hour * 60 + self.end_time.minute
+        if end_mins <= start_mins:
+            end_mins += 1440
+        return end_mins - start_mins
+
+
 class Rule(ABC):
-    """Abstract base class for all programme rules."""
+    """Base class for all programme rules.
+
+    Rules implement `propose(view, inputs)` to add claims via the
+    `_RuleView` interface. The legacy `apply(state, inputs)` shim is
+    provided for back-compat with tests that call `rule.apply(...)`
+    directly - it builds a single-rule StateBuilder seeded from
+    `state`, runs `propose()`, materialises, and returns.
+    """
 
     name: str = "unnamed"
     description: str = ""
     enabled: bool = True
+    priority_class: int = 50
 
-    @abstractmethod
+    def propose(self, view: _RuleView, inputs: ProgrammeInputs) -> None:
+        """Default implementation falls through to `apply()` for any
+        rule that hasn't been ported yet. Newly-written rules should
+        override this directly.
+        """
+        # Materialise the current view into a synthetic state, run the
+        # legacy apply() against it, then re-emit the diff as claims.
+        # This bridge lets the engine support a mix of ported / legacy
+        # rules during the migration window.
+        snapshot = view._b.materialise()
+        snapshot.reason_log = []  # rules append; we'll capture only
+        snapshot.claims_log = []
+        post = self.apply(snapshot, inputs)
+        # Re-emit any deltas as claims.
+        for i, slot in enumerate(post.slots):
+            if slot.capacity_soc != view.get_slot(i, "capacity_soc"):
+                view.claim_slot(i, "capacity_soc", slot.capacity_soc, reason="legacy apply")
+            if slot.grid_charge != view.get_slot(i, "grid_charge"):
+                view.claim_slot(i, "grid_charge", slot.grid_charge, reason="legacy apply")
+            if slot.start_time != view.get_slot(i, "start_time"):
+                view.claim_slot(i, "start_time", slot.start_time, reason="legacy apply")
+            if slot.end_time != view.get_slot(i, "end_time"):
+                view.claim_slot(i, "end_time", slot.end_time, reason="legacy apply")
+        for f in ("work_mode", "energy_pattern", "max_charge_a", "max_discharge_a", "ev_deferral_active"):
+            new = getattr(post, f)
+            if new != view.get_global(f):
+                view.claim_global(f, new, reason="legacy apply")
+        for entry in post.reason_log:
+            view.log(entry)
+
     def apply(self, state: ProgrammeState, inputs: ProgrammeInputs) -> ProgrammeState:
-        """Modify programme state. Append reasoning to state.reason_log."""
+        """Back-compat: run this rule alone, seeded from `state`,
+        return materialised state. Rules ported to `propose()` use this
+        shim path automatically; legacy rules still implement `apply`
+        directly and the default `propose()` bridges them.
+        """
+        # Run propose against a builder seeded from `state` so rule
+        # reads return state values, and the rule's own claims (at
+        # priority_class) override the seeds.
+        builder = StateBuilder(state)
+        view = builder.view_for_rule(self)
+        self.propose(view, inputs)
+        return builder.materialise()
 
 
 class RuleEngine:
-    """Evaluates rules in priority order to produce a 6-slot programme."""
+    """Evaluates rules in priority order to produce a 6-slot programme.
+
+    The propose phase runs all enabled non-Safety rules in
+    `default_rules()` order, each adding claims via its view. Safety
+    runs as a final post-arbitration pass over the materialised state.
+    """
 
     def __init__(self, rules: list[Rule]):
         self._rules = rules
 
     def calculate(self, inputs: ProgrammeInputs) -> ProgrammeState:
-        """Run all enabled rules and return the final programme."""
-        state = ProgrammeState.default(min_soc=int(inputs.min_soc))
+        initial = ProgrammeState.default(min_soc=int(inputs.min_soc))
+        builder = StateBuilder(initial)
 
+        safety_rules: list[Rule] = []
         for rule in self._rules:
-            if rule.enabled:
-                state = rule.apply(state, inputs)
+            if not rule.enabled:
+                continue
+            if rule.name == "safety":
+                safety_rules.append(rule)
+                continue
+            view = builder.view_for_rule(rule)
+            rule.propose(view, inputs)
 
+        state = builder.materialise()
+        for safety in safety_rules:
+            state = safety.apply(state, inputs)
         return state

--- a/custom_components/heo2/rules/baseline.py
+++ b/custom_components/heo2/rules/baseline.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 from datetime import time
 
-from ..models import ProgrammeState, ProgrammeInputs, SlotConfig
-from ..rule_engine import Rule
+from ..models import ProgrammeInputs
+from ..rule_engine import PRIO_BASELINE, Rule
 
 
 class BaselineRule(Rule):
@@ -16,6 +16,7 @@ class BaselineRule(Rule):
 
     name = "baseline"
     description = "Default programme: cheap-rate overnight charge, solar day, evening drain"
+    priority_class = PRIO_BASELINE
 
     def __init__(
         self,
@@ -27,24 +28,29 @@ class BaselineRule(Rule):
         self.off_peak_end = off_peak_end
         self.evening_start = evening_start
 
-    def apply(self, state: ProgrammeState, inputs: ProgrammeInputs) -> ProgrammeState:
+    def propose(self, view, inputs: ProgrammeInputs) -> None:
         min_soc = int(inputs.min_soc)
 
-        # Build the 6-slot baseline layout:
-        # Slot 1: 00:00 -> off_peak_end       (overnight charge, grid_charge=True)
-        # Slot 2: off_peak_end -> evening_start (day -- let solar charge, SOC=100)
-        # Slot 3: evening_start -> off_peak_start (evening drain, SOC=min_soc)
-        # Slot 4: off_peak_start -> 23:57      (next overnight, grid_charge=True)
-        # Slot 5: 23:57 -> 23:58              (filler)
-        # Slot 6: 23:58 -> 00:00              (filler)
-        state.slots = [
-            SlotConfig(time(0, 0), self.off_peak_end, 100, True),
-            SlotConfig(self.off_peak_end, self.evening_start, 100, False),
-            SlotConfig(self.evening_start, self.off_peak_start, min_soc, False),
-            SlotConfig(self.off_peak_start, time(23, 57), 100, True),
-            SlotConfig(time(23, 57), time(23, 58), min_soc, False),
-            SlotConfig(time(23, 58), time(0, 0), min_soc, False),
+        # 6-slot baseline layout (start, end, capacity_soc, grid_charge):
+        # 1: 00:00 -> off_peak_end       (overnight charge, gc=True)
+        # 2: off_peak_end -> evening_start (day -- let solar charge, SOC=100)
+        # 3: evening_start -> off_peak_start (evening drain, SOC=min_soc)
+        # 4: off_peak_start -> 23:57      (next overnight, gc=True)
+        # 5: 23:57 -> 23:58              (filler)
+        # 6: 23:58 -> 00:00              (filler)
+        layout = [
+            (time(0, 0), self.off_peak_end, 100, True),
+            (self.off_peak_end, self.evening_start, 100, False),
+            (self.evening_start, self.off_peak_start, min_soc, False),
+            (self.off_peak_start, time(23, 57), 100, True),
+            (time(23, 57), time(23, 58), min_soc, False),
+            (time(23, 58), time(0, 0), min_soc, False),
         ]
+        for i, (start, end, cap, gc) in enumerate(layout):
+            view.claim_slot(i, "start_time", start, reason="baseline scaffold")
+            view.claim_slot(i, "end_time", end, reason="baseline scaffold")
+            view.claim_slot(i, "capacity_soc", cap, reason="baseline scaffold")
+            view.claim_slot(i, "grid_charge", gc, reason="baseline scaffold")
 
         # SPEC §2 globals. SavingSessionRule overrides work_mode to
         # "Selling first" while a session is active; BaselineRule re-
@@ -55,16 +61,15 @@ class BaselineRule(Rule):
         # Charge / discharge limits at 100A match the Sunsynk 5kW
         # nominal max (100A * ~51.2V = 5120W) - leaves the inverter
         # free to use its full rate when needed.
-        state.work_mode = "Zero export to CT"
-        state.energy_pattern = "Load first"
-        state.max_charge_a = 100.0
-        state.max_discharge_a = 100.0
+        view.claim_global("work_mode", "Zero export to CT", reason="baseline default")
+        view.claim_global("energy_pattern", "Load first", reason="baseline default")
+        view.claim_global("max_charge_a", 100.0, reason="baseline default")
+        view.claim_global("max_discharge_a", 100.0, reason="baseline default")
 
-        state.reason_log.append(
+        view.log(
             f"Baseline: overnight charge to 100% until {self.off_peak_end}, "
             f"solar day until {self.evening_start}, "
             f"evening drain to {min_soc}%; "
             f"work_mode=Zero export to CT, energy_pattern=Load first, "
             f"max_charge=100A, max_discharge=100A"
         )
-        return state

--- a/custom_components/heo2/rules/cheap_rate_charge.py
+++ b/custom_components/heo2/rules/cheap_rate_charge.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-from ..models import ProgrammeInputs, ProgrammeState
+from ..models import ProgrammeInputs
 from ..rank_pricing import next_cheap_window_end_local
-from ..rule_engine import Rule
+from ..rule_engine import PRIO_CHEAP_RATE_CHARGE, Rule
 
 
 class CheapRateChargeRule(Rule):
@@ -48,6 +48,7 @@ class CheapRateChargeRule(Rule):
 
     name = "cheap_rate_charge"
     description = "Size overnight charge to bridge from cheap-window end to PV takeover"
+    priority_class = PRIO_CHEAP_RATE_CHARGE
 
     def __init__(
         self,
@@ -60,16 +61,10 @@ class CheapRateChargeRule(Rule):
         self.cheap_window_end_hour_fallback = cheap_window_end_hour_fallback
         self.safety_buffer_pct = safety_buffer_pct
 
-    def apply(self, state: ProgrammeState, inputs: ProgrammeInputs) -> ProgrammeState:
-        # Tomorrow's solar forecast drives the calculation. Without it
-        # we can't know when PV takes over - default to filling the
-        # battery completely.
+    def propose(self, view, inputs: ProgrammeInputs) -> None:
         tomorrow_solar = inputs.solar_forecast_kwh_tomorrow
         load = inputs.load_forecast_kwh
 
-        # Prefer rate-derived cheap-window end (the contiguous bottom-25%
-        # block from import_rates). Falls back to the hardcoded hour
-        # only when no rates are loaded (early boot, BD outage).
         end_dt = next_cheap_window_end_local(
             inputs.import_rates, inputs.now_local(), inputs.local_tz,
         )
@@ -85,19 +80,12 @@ class CheapRateChargeRule(Rule):
                 f"defaulting to {target_soc}%"
             )
         else:
-            # Walk forward from end-of-cheap-window. Accumulate the
-            # cumulative deficit (load - solar) until solar finally
-            # overtakes load at the "PV takeover" hour.
             bridge_kwh = 0.0
             takeover_hour: int | None = None
             for h in range(cheap_end_hour, 24):
                 solar = tomorrow_solar[h]
                 load_h = load[h]
                 if solar >= load_h and h > cheap_end_hour:
-                    # First hour where PV covers load - we're done
-                    # bridging. The `h > cheap_end_hour` guard avoids
-                    # declaring takeover at the literal start hour when
-                    # both happen to be ~0 (pre-dawn).
                     takeover_hour = h
                     break
                 bridge_kwh += max(0.0, load_h - solar)
@@ -126,9 +114,11 @@ class CheapRateChargeRule(Rule):
                     f"(+{self.safety_buffer_pct}% safety buffer)"
                 )
 
-        for slot in state.slots:
+        for slot in view.slots:
             if slot.grid_charge:
-                slot.capacity_soc = target_soc
+                view.claim_slot(
+                    slot.index, "capacity_soc", target_soc,
+                    reason=f"cheap-charge target ({reason})",
+                )
 
-        state.reason_log.append(f"CheapRateCharge: {reason}")
-        return state
+        view.log(f"CheapRateCharge: {reason}")

--- a/custom_components/heo2/rules/eps_mode.py
+++ b/custom_components/heo2/rules/eps_mode.py
@@ -23,8 +23,8 @@ fresh baseline.
 
 from __future__ import annotations
 
-from ..models import ProgrammeInputs, ProgrammeState
-from ..rule_engine import Rule
+from ..models import ProgrammeInputs
+from ..rule_engine import PRIO_EPS, Rule
 
 
 class EPSModeRule(Rule):
@@ -32,17 +32,17 @@ class EPSModeRule(Rule):
 
     name = "eps_mode"
     description = "Override SOC floor + disable grid charge during EPS"
+    priority_class = PRIO_EPS
 
-    def apply(self, state: ProgrammeState, inputs: ProgrammeInputs) -> ProgrammeState:
+    def propose(self, view, inputs: ProgrammeInputs) -> None:
         if not inputs.eps_active:
-            return state
+            return
 
-        for slot in state.slots:
-            slot.capacity_soc = 0
-            slot.grid_charge = False
+        for slot in view.slots:
+            view.claim_slot(slot.index, "capacity_soc", 0, reason="EPS override")
+            view.claim_slot(slot.index, "grid_charge", False, reason="EPS override")
 
-        state.reason_log.append(
+        view.log(
             "EPSMode: grid down, all slots cap=0% gc=False "
             "(H3: allow battery drain to 0%)"
         )
-        return state

--- a/custom_components/heo2/rules/ev_charging.py
+++ b/custom_components/heo2/rules/ev_charging.py
@@ -1,10 +1,10 @@
 # custom_components/heo2/rules/ev_charging.py
-"""EVChargingRule — hold SOC during non-IGO EV charging."""
+"""EVChargingRule -- hold SOC during non-IGO EV charging."""
 
 from __future__ import annotations
 
-from ..models import ProgrammeState, ProgrammeInputs
-from ..rule_engine import Rule
+from ..models import ProgrammeInputs
+from ..rule_engine import PRIO_EV_CHARGING, Rule
 
 
 class EVChargingRule(Rule):
@@ -16,13 +16,14 @@ class EVChargingRule(Rule):
 
     name = "ev_charging"
     description = "Hold battery SOC during EV charging"
+    priority_class = PRIO_EV_CHARGING
 
-    def apply(self, state: ProgrammeState, inputs: ProgrammeInputs) -> ProgrammeState:
+    def propose(self, view, inputs: ProgrammeInputs) -> None:
         if not inputs.ev_charging:
-            return state
+            return
 
         if inputs.igo_dispatching:
-            return state  # IGO dispatch takes precedence
+            return  # IGO dispatch takes precedence
 
         # Use local-tz-aware lookup. inputs.now is UTC; programme slots
         # are local time-of-day. inputs.now.time() (UTC) was aliasing
@@ -31,16 +32,18 @@ class EVChargingRule(Rule):
             second=0, microsecond=0,
         )
         try:
-            idx = state.find_slot_at(now_time)
+            idx = view.find_slot_at(now_time)
         except ValueError:
-            return state
+            return
 
         hold_soc = max(int(inputs.current_soc), int(inputs.min_soc))
-        if state.slots[idx].capacity_soc < hold_soc:
-            state.slots[idx].capacity_soc = hold_soc
+        if view.get_slot(idx, "capacity_soc") < hold_soc:
+            view.claim_slot(
+                idx, "capacity_soc", hold_soc,
+                reason="hold during EV charge",
+            )
 
-        state.reason_log.append(
+        view.log(
             f"EVCharging: slot {idx + 1} SOC held at {hold_soc}% "
             f"(don't drain battery to feed car)"
         )
-        return state

--- a/custom_components/heo2/rules/ev_deferral.py
+++ b/custom_components/heo2/rules/ev_deferral.py
@@ -31,8 +31,8 @@ coordinator (HA service call out of scope for pure rule logic).
 
 from __future__ import annotations
 
-from ..models import ProgrammeInputs, ProgrammeState
-from ..rule_engine import Rule
+from ..models import ProgrammeInputs
+from ..rule_engine import PRIO_EV_DEFERRAL, Rule
 
 
 class EVDeferralRule(Rule):
@@ -40,6 +40,7 @@ class EVDeferralRule(Rule):
 
     name = "ev_deferral"
     description = "Stop EV charge during high export when car not needed"
+    priority_class = PRIO_EV_DEFERRAL
 
     def __init__(
         self,
@@ -50,40 +51,35 @@ class EVDeferralRule(Rule):
         self.deferral_min_soc = deferral_min_soc
         self.deferral_min_export_p = deferral_min_export_p
 
-    def apply(self, state: ProgrammeState, inputs: ProgrammeInputs) -> ProgrammeState:
+    def propose(self, view, inputs: ProgrammeInputs) -> None:
         if not inputs.defer_ev_eligible:
-            return state
+            return
 
         if inputs.current_soc < self.deferral_min_soc:
-            state.reason_log.append(
+            view.log(
                 f"EVDeferral: eligible but SOC {inputs.current_soc:.0f}% "
                 f"below {self.deferral_min_soc:.0f}% threshold; not deferring"
             )
-            return state
+            return
 
         export_p = inputs.current_export_rate_p
         if export_p is None:
-            state.reason_log.append(
+            view.log(
                 "EVDeferral: eligible but no live export rate; not deferring"
             )
-            return state
+            return
 
         if export_p < self.deferral_min_export_p:
-            # SPEC §12 "ridiculous low export" fallback - let the car
-            # charge as normal, the export wouldn't be worth it.
-            state.reason_log.append(
+            view.log(
                 f"EVDeferral: eligible but export {export_p:.2f}p below "
                 f"{self.deferral_min_export_p:.2f}p threshold; not deferring"
             )
-            return state
+            return
 
-        # All triggers met. Flip work_mode to Selling first and signal
-        # the coordinator to halt the zappi.
-        state.work_mode = "Selling first"
-        state.ev_deferral_active = True
-        state.reason_log.append(
+        view.claim_global("work_mode", "Selling first", reason="EV deferral active")
+        view.claim_global("ev_deferral_active", True, reason="EV deferral triggers met")
+        view.log(
             f"EVDeferral: ACTIVE (SOC {inputs.current_soc:.0f}%, "
             f"export {export_p:.2f}p >= {self.deferral_min_export_p:.2f}p); "
             f"work_mode -> Selling first, zappi -> Stopped"
         )
-        return state

--- a/custom_components/heo2/rules/evening_protect.py
+++ b/custom_components/heo2/rules/evening_protect.py
@@ -1,10 +1,12 @@
 # custom_components/heo2/rules/evening_protect.py
-"""EveningProtectRule — protect SOC for evening peak demand."""
+"""EveningProtectRule -- protect SOC for evening peak demand."""
 
 from __future__ import annotations
 
-from ..models import ProgrammeState, ProgrammeInputs
-from ..rule_engine import Rule
+from datetime import time
+
+from ..models import ProgrammeInputs
+from ..rule_engine import PRIO_EVENING_PROTECT, Rule
 
 
 class EveningProtectRule(Rule):
@@ -16,67 +18,53 @@ class EveningProtectRule(Rule):
 
     name = "evening_protect"
     description = "Protect SOC reserve for evening peak demand"
+    priority_class = PRIO_EVENING_PROTECT
 
     def __init__(self, evening_start_hour: int = 18, evening_end_hour: int = 24):
         self.evening_start_hour = evening_start_hour
         self.evening_end_hour = evening_end_hour
 
-    def apply(self, state: ProgrammeState, inputs: ProgrammeInputs) -> ProgrammeState:
+    def propose(self, view, inputs: ProgrammeInputs) -> None:
         evening_demand_kwh = inputs.load_kwh_between(
             self.evening_start_hour, self.evening_end_hour
         )
 
         if evening_demand_kwh <= 0:
-            return state
+            return
 
         required_soc = int(
             inputs.min_soc + (evening_demand_kwh / inputs.battery_capacity_kwh * 100)
         )
         required_soc = min(required_soc, 100)
 
-        from datetime import time
-
-        # HEO-6 fix: pre-fix logic only protected slots whose end_time
-        # was <= evening_start (e.g. a slot ending at 18:00 exactly).
-        # In Paddy's typical plan, slot 2 runs 05:30-18:30 - it spans
-        # evening_start at 18:00, so the old condition skipped it and
-        # no protection ever applied. The inverter could discharge
-        # slot 2 toward whatever low cap ExportWindow set, leaving
-        # the battery empty entering the evening window.
-        #
-        # New rule: any non-GC slot that overlaps the evening_start
-        # boundary (start_time < evening_start AND end_time > evening_start
-        # OR end_time == 00:00 wrap) gets its cap raised to required_soc.
-        # This is the slot whose `capacity_soc` is in effect AT the
-        # moment evening starts, so it determines the SOC the battery
-        # carries into the evening window.
         evening_t = time(self.evening_start_hour, 0)
 
         def _slot_covers_boundary(slot) -> bool:
             # Slot covers the evening boundary iff `evening_t` falls in
             # [slot.start_time, slot.end_time). end==00:00 wraps midnight.
             if slot.end_time == time(0, 0):
-                # Slot wraps; covers anything >= start_time
                 return slot.start_time <= evening_t
             return slot.start_time <= evening_t < slot.end_time
 
         modified = False
-        for slot in state.slots:
+        for slot in view.slots:
             if _slot_covers_boundary(slot) and not slot.grid_charge:
                 if slot.capacity_soc < required_soc:
-                    slot.capacity_soc = required_soc
+                    view.claim_slot(
+                        slot.index, "capacity_soc", required_soc,
+                        reason=f"evening demand {evening_demand_kwh:.1f} kWh",
+                    )
                     modified = True
 
         if modified:
-            state.reason_log.append(
+            view.log(
                 f"EveningProtect: raised SOC to {required_soc}% in slot "
                 f"covering {evening_t.strftime('%H:%M')} "
                 f"({evening_demand_kwh:.1f} kWh evening demand)"
             )
         else:
-            state.reason_log.append(
+            view.log(
                 f"EveningProtect: no change needed "
                 f"({evening_demand_kwh:.1f} kWh evening demand, "
                 f"required {required_soc}%)"
             )
-        return state

--- a/custom_components/heo2/rules/export_window.py
+++ b/custom_components/heo2/rules/export_window.py
@@ -11,31 +11,24 @@ from ..const import (
     DEFAULT_SELL_TOP_PCT_LOW_SOC,
     ROUND_TRIP_EFFICIENCY,
 )
-from ..models import ProgrammeInputs, ProgrammeState
+from ..models import ProgrammeInputs
 from ..rank_pricing import (
     filter_today,
     hours_covered_by,
     select_export_top_pct,
     select_worth_selling_windows,
 )
-from ..rule_engine import Rule
+from ..rule_engine import PRIO_EXPORT_WINDOW, Rule
 
 
-def _slot_covers_rate(slot, rate, tz):
-    """True iff the programme `slot` (local time-of-day) covers the
-    `rate.start` (UTC absolute datetime) in local time. HEO-7 fix:
-    pre-2026-05 ExportWindowRule built `slot_hours = set(range(start.hour,
-    end.hour))` and matched against `rate.start.hour`. That dropped
-    half-hour Agile slots crossing the hour and entirely missed slots
-    like 16:30-17:00 against a programme slot of 17:00-19:00. Working
-    in absolute time (rate.start in local tz, against slot.start_time
-    / slot.end_time) catches the overlap without rounding.
-    """
+def _slot_view_covers_rate(slot_view, rate, tz):
+    """True iff the programme `slot_view` (local time-of-day) covers
+    the `rate.start` (UTC absolute datetime) in local time."""
     if tz is not None and rate.start.tzinfo is not None:
         local_t = rate.start.astimezone(tz).time()
     else:
         local_t = rate.start.time()
-    return slot.contains_time(local_t)
+    return slot_view.contains_time(local_t)
 
 
 class ExportWindowRule(Rule):
@@ -56,6 +49,7 @@ class ExportWindowRule(Rule):
 
     name = "export_window"
     description = "Drain battery during top-ranked Agile Outgoing windows"
+    priority_class = PRIO_EXPORT_WINDOW
 
     def __init__(
         self,
@@ -76,21 +70,15 @@ class ExportWindowRule(Rule):
         self.n_med = n_med
         self.n_high = n_high
 
-    def apply(self, state: ProgrammeState, inputs: ProgrammeInputs) -> ProgrammeState:
+    def propose(self, view, inputs: ProgrammeInputs) -> None:
         if not inputs.export_rates:
-            return state
+            return
 
-        # Today only. Tomorrow's rates are out of scope for the drain
-        # decision in the current programme.
         today_rates = filter_today(inputs.export_rates, inputs.now)
         if not today_rates:
-            return state
+            return
 
         daily_load_kwh = sum(inputs.load_forecast_kwh) or 1.0
-        # Tomorrow's solar feeds the rank decision (high-SOC + high-solar
-        # -> sell aggressively; low-solar -> conservative). Falls back to
-        # today's forecast when tomorrow isn't available so the rule
-        # still produces a reasonable answer.
         tomorrow_solar_kwh = sum(inputs.solar_forecast_kwh_tomorrow) if (
             inputs.solar_forecast_kwh_tomorrow
         ) else sum(inputs.solar_forecast_kwh)
@@ -114,28 +102,20 @@ class ExportWindowRule(Rule):
         )
 
         if not worth_windows:
-            state.reason_log.append(
+            view.log(
                 f"ExportWindow: nothing worth selling in {n_reason} "
                 f"(replacement cost {self.replacement_cost_pence:.2f}p)"
             )
-            return state
+            return
 
-        # HEO-7: local-tz aware slot matching. Use inputs.local_tz
-        # (set by the coordinator post-PR2) so DST is respected;
-        # fall back to inputs.now.tzinfo for tests that don't set it.
         tz = inputs.local_tz or inputs.now.tzinfo
-        # Kept for the diagnostic log line below; the actual slot
-        # selection uses _slot_covers_rate which is sub-hour accurate.
         worth_hours = hours_covered_by(worth_windows, tz=tz)
 
         # Per SPEC §5 priority 1 (avoid peak import) DOMINATES priority 3
         # (sell during top windows). A naive drain-to-min_soc could leave
         # the battery empty going into the 18:30-23:30 evening window
-        # and force grid imports at peak rates. So the drain target is
-        # floored at min_soc + (evening_demand / capacity), matching the
-        # legacy rule's behaviour. EveningProtectRule (next in the chain)
-        # only protects pre-evening slots; this floor handles overlap
-        # cases like a 12:00-18:30 day slot that EveningProtect skips.
+        # and force grid imports at peak rates. Floor the drain target
+        # at min_soc + (evening_demand / capacity).
         evening_demand_kwh = inputs.load_kwh_between(18, 24)
         if inputs.battery_capacity_kwh > 0:
             evening_floor_soc = int(
@@ -148,18 +128,17 @@ class ExportWindowRule(Rule):
         drain_target = max(evening_floor_soc, int(inputs.min_soc))
 
         modified = False
-        for slot in state.slots:
+        for slot in view.slots:
             if slot.grid_charge:
                 continue
-            # Slot drains only if at least one worth-selling rate slot
-            # falls within its time window. Sub-hour accurate via
-            # `_slot_covers_rate`, unlike the pre-HEO-7 hour-set
-            # intersection.
             covers_any = any(
-                _slot_covers_rate(slot, r, tz) for r in worth_windows
+                _slot_view_covers_rate(slot, r, tz) for r in worth_windows
             )
             if covers_any and slot.capacity_soc > drain_target:
-                slot.capacity_soc = drain_target
+                view.claim_slot(
+                    slot.index, "capacity_soc", drain_target,
+                    reason=f"drain during worth-selling slot",
+                )
                 modified = True
 
         # NOTE: setting slot.capacity_soc=N alone authorises the
@@ -167,9 +146,6 @@ class ExportWindowRule(Rule):
         # work_mode + max_discharge_a are managed by
         # `PeakExportArbitrageRule` further down the chain, sized to
         # actual spare and only during the day's TOP-priced window(s).
-        # An earlier version flipped work_mode here for *any*
-        # worth-selling window, but that sold during second-best slots
-        # too rather than concentrating on the genuine peak.
 
         sorted_hours = sorted(worth_hours)
         rate_summary = (
@@ -180,15 +156,14 @@ class ExportWindowRule(Rule):
         )
 
         if modified:
-            state.reason_log.append(
+            view.log(
                 f"ExportWindow: drain to {drain_target}% in {n_reason}, "
                 f"{len(worth_windows)} slots @ {rate_summary} "
                 f"covering hours {sorted_hours} "
                 f"(evening floor from {evening_demand_kwh:.1f} kWh demand)"
             )
         else:
-            state.reason_log.append(
+            view.log(
                 f"ExportWindow: {n_reason}, {len(worth_windows)} worth-selling "
                 f"slots @ {rate_summary} but no slot SOC needed lowering"
             )
-        return state

--- a/custom_components/heo2/rules/igo_dispatch.py
+++ b/custom_components/heo2/rules/igo_dispatch.py
@@ -19,12 +19,14 @@ the planned-dispatch path has already pre-positioned the slot.
 
 from __future__ import annotations
 
-from ..models import PlannedDispatch, ProgrammeInputs, ProgrammeState
-from ..rule_engine import Rule
+from datetime import timedelta
+
+from ..models import PlannedDispatch, ProgrammeInputs
+from ..rule_engine import PRIO_IGO_DISPATCH, Rule
 
 
 def _slot_indices_covering_dispatch(
-    state: ProgrammeState,
+    view,
     dispatch: PlannedDispatch,
     inputs: ProgrammeInputs,
 ) -> list[int]:
@@ -50,16 +52,14 @@ def _slot_indices_covering_dispatch(
         start_local = dispatch.start
         end_local = dispatch.end
 
-    # Sample every 15 min between start and end, mark each slot that
-    # contains the sample. 15 min granularity is finer than any inverter
-    # boundary HEO II writes (5-min). Avoids hand-rolling overlap maths
-    # for the wrap-midnight case.
-    from datetime import timedelta
+    # 15-min sample sweep is finer than any inverter boundary HEO II
+    # writes (5-min). Avoids hand-rolling overlap maths for the wrap-
+    # midnight case.
     indices: set[int] = set()
     cursor = start_local
     while cursor < end_local:
         try:
-            idx = state.find_slot_at(cursor.time())
+            idx = view.find_slot_at(cursor.time())
             indices.add(idx)
         except ValueError:
             pass
@@ -72,8 +72,9 @@ class IGODispatchRule(Rule):
 
     name = "igo_dispatch"
     description = "Enable grid charge during IGO dispatch"
+    priority_class = PRIO_IGO_DISPATCH
 
-    def apply(self, state: ProgrammeState, inputs: ProgrammeInputs) -> ProgrammeState:
+    def propose(self, view, inputs: ProgrammeInputs) -> None:
         modified_log: list[str] = []
 
         # SavingSessionRule (runs earlier in the registry) drains the
@@ -86,20 +87,19 @@ class IGODispatchRule(Rule):
         if inputs.saving_session:
             try:
                 local_now = inputs.now_local()
-                saving_session_slot_idx = state.find_slot_at(local_now.time())
+                saving_session_slot_idx = view.find_slot_at(local_now.time())
             except ValueError:
                 saving_session_slot_idx = None
 
         # Path 1: planned dispatches (HEO-8). Pre-position covering slots.
         if inputs.planned_dispatches:
             now = inputs.now
-            from datetime import timedelta
             horizon_end = now + timedelta(hours=24)
             covered_slot_idxs: set[int] = set()
             for d in inputs.planned_dispatches:
                 if d.end <= now or d.start >= horizon_end:
                     continue
-                for idx in _slot_indices_covering_dispatch(state, d, inputs):
+                for idx in _slot_indices_covering_dispatch(view, d, inputs):
                     covered_slot_idxs.add(idx)
 
             for idx in sorted(covered_slot_idxs):
@@ -108,10 +108,10 @@ class IGODispatchRule(Rule):
                         f"slot {idx + 1} held by saving session, skip pre-position"
                     )
                     continue
-                slot = state.slots[idx]
+                slot = view.slots[idx]
                 if not slot.grid_charge or slot.capacity_soc < 100:
-                    slot.grid_charge = True
-                    slot.capacity_soc = 100
+                    view.claim_slot(idx, "grid_charge", True, reason="planned dispatch")
+                    view.claim_slot(idx, "capacity_soc", 100, reason="planned dispatch")
                     modified_log.append(
                         f"slot {idx + 1} pre-positioned for planned dispatch"
                     )
@@ -122,15 +122,16 @@ class IGODispatchRule(Rule):
         if inputs.igo_dispatching:
             try:
                 local_now = inputs.now_local()
-                idx = state.find_slot_at(local_now.time())
+                idx = view.find_slot_at(local_now.time())
             except ValueError:
                 idx = None
             if idx is not None and idx != saving_session_slot_idx:
-                slot = state.slots[idx]
-                slot.grid_charge = True
-                slot.capacity_soc = max(slot.capacity_soc, 100)
+                current_cap = view.get_slot(idx, "capacity_soc")
+                new_cap = max(current_cap, 100)
+                view.claim_slot(idx, "grid_charge", True, reason="active dispatch")
+                view.claim_slot(idx, "capacity_soc", new_cap, reason="active dispatch")
                 modified_log.append(
-                    f"slot {idx + 1} active dispatch (cap={slot.capacity_soc}%)"
+                    f"slot {idx + 1} active dispatch (cap={new_cap}%)"
                 )
             elif idx is not None and idx == saving_session_slot_idx:
                 modified_log.append(
@@ -138,7 +139,6 @@ class IGODispatchRule(Rule):
                 )
 
         if modified_log:
-            state.reason_log.append(
+            view.log(
                 f"IGODispatch: {'; '.join(modified_log)}"
             )
-        return state

--- a/custom_components/heo2/rules/peak_export_arbitrage.py
+++ b/custom_components/heo2/rules/peak_export_arbitrage.py
@@ -38,13 +38,12 @@ sure not to use peak rate electric").
 
 from __future__ import annotations
 
-import math
 from datetime import datetime, time, timedelta
 from zoneinfo import ZoneInfo
 
-from ..models import ProgrammeInputs, ProgrammeState, RateSlot
+from ..models import ProgrammeInputs, RateSlot
 from ..rank_pricing import next_cheap_window_start_local
-from ..rule_engine import Rule
+from ..rule_engine import PRIO_PEAK_EXPORT_ARBITRAGE, Rule
 
 
 def _local(dt: datetime, tz: ZoneInfo | None) -> datetime:
@@ -61,6 +60,7 @@ class PeakExportArbitrageRule(Rule):
         "Sell battery surplus at top-priced export slots, sized to "
         "available spare, throttled via discharge rate"
     )
+    priority_class = PRIO_PEAK_EXPORT_ARBITRAGE
 
     def __init__(
         self,
@@ -75,21 +75,12 @@ class PeakExportArbitrageRule(Rule):
         self.battery_voltage_nominal = battery_voltage_nominal
         self.max_discharge_a_default = max_discharge_a_default
 
-    # --- helpers ---------------------------------------------------
-
     def _resolve_cheap_window_start(
         self,
         now_local: datetime,
         import_rates: list[RateSlot],
         tz: ZoneInfo | None,
     ) -> datetime:
-        """Pick the start of the next cheap import window.
-
-        Prefer rate-derived (bottom-25% of upcoming import rates) so
-        Saving Sessions, non-standard IGO blocks, or any tariff change
-        flows through automatically. Fall back to the hardcoded time
-        only when no import rates are loaded.
-        """
         from_rates = next_cheap_window_start_local(
             import_rates, now_local, tz,
         )
@@ -110,13 +101,10 @@ class PeakExportArbitrageRule(Rule):
         now_local: datetime,
         until_local: datetime,
     ) -> float:
-        """Pro-rate hourly forecast values from `now_local` to
-        `until_local`. First and last hours partial-summed."""
         if not forecast_hourly or len(forecast_hourly) < 24:
             return 0.0
         total = 0.0
         cursor = now_local
-        # First partial hour from cursor to next-hour boundary
         while cursor < until_local:
             hour_idx = cursor.hour
             next_boundary = (cursor + timedelta(hours=1)).replace(
@@ -133,8 +121,6 @@ class PeakExportArbitrageRule(Rule):
         forecast_hourly: list[float],
         now_local: datetime,
     ) -> float:
-        """PV forecast from `now` until end of today's local day
-        (23:59)."""
         end_of_day = now_local.replace(
             hour=23, minute=59, second=59, microsecond=0,
         )
@@ -149,10 +135,6 @@ class PeakExportArbitrageRule(Rule):
         cheap_start: datetime,
         tz: ZoneInfo | None,
     ) -> list[RateSlot]:
-        """Filter to export slots that haven't started yet AND start
-        before the cheap window. Selling at 23:00 still counts; selling
-        post-23:30 is moot because we'd be drawing from a battery
-        we're then refilling."""
         out = []
         for r in export_rates:
             start_local = _local(r.start, tz)
@@ -161,11 +143,9 @@ class PeakExportArbitrageRule(Rule):
             out.append(r)
         return out
 
-    # --- main ------------------------------------------------------
-
-    def apply(self, state: ProgrammeState, inputs: ProgrammeInputs) -> ProgrammeState:
+    def propose(self, view, inputs: ProgrammeInputs) -> None:
         if not inputs.export_rates:
-            return state
+            return
 
         tz = inputs.local_tz
         now_local = inputs.now_local()
@@ -177,10 +157,8 @@ class PeakExportArbitrageRule(Rule):
             inputs.export_rates, now_local, cheap_start, tz,
         )
         if not future_slots:
-            return state
+            return
 
-        # Spare = (current SOC above floor) - load_to_cheap + pv_remaining.
-        # Above-floor because we never sell into the min_soc reserve.
         floor_kwh = inputs.min_soc / 100.0 * inputs.battery_capacity_kwh
         current_kwh = inputs.current_soc / 100.0 * inputs.battery_capacity_kwh
         usable_kwh = max(0.0, current_kwh - floor_kwh)
@@ -195,21 +173,19 @@ class PeakExportArbitrageRule(Rule):
         spare_kwh = usable_kwh - load_to_cheap + pv_remaining
         cheap_str = cheap_start.strftime("%H:%M")
         if spare_kwh <= 0.05:
-            state.reason_log.append(
+            view.log(
                 f"PeakArbitrage: no spare to sell "
                 f"(usable {usable_kwh:.2f} kWh - load_to_{cheap_str} "
                 f"{load_to_cheap:.2f} + pv_remaining "
                 f"{pv_remaining:.2f} = {spare_kwh:.2f} kWh)"
             )
-            return state
+            return
 
-        # Rank slots by rate desc, ties by sooner-is-better
         sorted_slots = sorted(
             future_slots,
             key=lambda r: (-r.rate_pence, _local(r.start, tz)),
         )
 
-        # Allocate spare to top slots, max 2.5 kWh per 30-min slot
         per_slot_max = self.max_discharge_kw * 0.5
         allocations: list[tuple[RateSlot, float]] = []
         remaining = spare_kwh
@@ -222,7 +198,6 @@ class PeakExportArbitrageRule(Rule):
             allocations.append((slot, kwh))
             remaining -= kwh
 
-        # Find the allocated slot covering NOW (if any)
         active_slot: RateSlot | None = None
         active_kwh: float = 0.0
         for slot, kwh in allocations:
@@ -239,32 +214,27 @@ class PeakExportArbitrageRule(Rule):
                 f"({k:.2f} kWh)"
                 for s, k in allocations[:3]
             )
-            state.reason_log.append(
+            view.log(
                 f"PeakArbitrage: spare {spare_kwh:.2f} kWh; "
                 f"sell scheduled in {future_str or 'no future slots'}"
             )
-            return state
+            return
 
-        # We are INSIDE an allocated slot - sell now.
         slot_duration_h = (
             active_slot.end - active_slot.start
         ).total_seconds() / 3600.0
-        # Throttle amp rate so we deliver exactly active_kwh over the
-        # slot's duration. Defensive minimum 1A so the inverter keeps
-        # selling at SOMETHING rather than silently halting.
         kw_for_slot = active_kwh / slot_duration_h
         amps_target = kw_for_slot * 1000.0 / self.battery_voltage_nominal
         amps = max(1.0, min(amps_target, self.max_discharge_a_default))
 
-        state.work_mode = "Selling first"
-        state.max_discharge_a = round(amps, 1)
+        view.claim_global("work_mode", "Selling first", reason="active arbitrage slot")
+        view.claim_global("max_discharge_a", round(amps, 1), reason="throttle to spare amount")
 
         slot_local_start = _local(active_slot.start, tz).strftime("%H:%M")
-        state.reason_log.append(
+        view.log(
             f"PeakArbitrage: ACTIVE - selling {active_kwh:.2f} kWh "
             f"in slot {slot_local_start} "
             f"@ {active_slot.rate_pence:.2f}p "
             f"(spare {spare_kwh:.2f} kWh, throttle {amps:.0f}A); "
             f"work_mode -> Selling first"
         )
-        return state

--- a/custom_components/heo2/rules/saving_session.py
+++ b/custom_components/heo2/rules/saving_session.py
@@ -26,8 +26,8 @@ export; the existing work mode handles the rest.
 
 from __future__ import annotations
 
-from ..models import ProgrammeInputs, ProgrammeState
-from ..rule_engine import Rule
+from ..models import ProgrammeInputs
+from ..rule_engine import PRIO_SAVING_SESSION, Rule
 
 
 class SavingSessionRule(Rule):
@@ -36,46 +36,46 @@ class SavingSessionRule(Rule):
 
     name = "saving_session"
     description = "Drain battery to floor during Octoplus saving sessions"
+    priority_class = PRIO_SAVING_SESSION
 
-    def apply(self, state: ProgrammeState, inputs: ProgrammeInputs) -> ProgrammeState:
+    def propose(self, view, inputs: ProgrammeInputs) -> None:
         if not inputs.saving_session:
-            return state
+            return
 
         local_now = inputs.now_local()
         try:
-            current_idx = state.find_slot_at(local_now.time())
+            current_idx = view.find_slot_at(local_now.time())
         except ValueError:
             # Programme isn't covering local-now; SafetyRule will fix
             # the contiguity, but this rule has nothing to do.
-            return state
+            return
 
-        slot = state.slots[current_idx]
         floor = int(inputs.min_soc)
+        slot_view = view.slots[current_idx]
+        before = (slot_view.capacity_soc, slot_view.grid_charge)
 
-        before = (slot.capacity_soc, slot.grid_charge)
-        slot.capacity_soc = floor
-        slot.grid_charge = False
-        after = (slot.capacity_soc, slot.grid_charge)
-
+        view.claim_slot(
+            current_idx, "capacity_soc", floor,
+            reason="saving session drain",
+        )
+        view.claim_slot(
+            current_idx, "grid_charge", False,
+            reason="saving session drain",
+        )
         # SPEC §9 row 3: "Selling first" lets the inverter export to
-        # grid at the published Outgoing Octopus rate. Without this the
-        # current "Zero export to CT" mode would just hold load coverage,
-        # not export, and the £3+/kWh saving-session price wouldn't be
-        # captured. Reset is handled by BaselineRule when the session
-        # ends (saving_session=False).
-        state.work_mode = "Selling first"
+        # grid at the published Outgoing Octopus rate.
+        view.claim_global("work_mode", "Selling first", reason="saving session active")
 
-        if before != after:
-            state.reason_log.append(
+        if before != (floor, False):
+            view.log(
                 f"SavingSession: drain slot {current_idx + 1} "
-                f"({slot.start_time.strftime('%H:%M')}-"
-                f"{slot.end_time.strftime('%H:%M')}) "
+                f"({slot_view.start_time.strftime('%H:%M')}-"
+                f"{slot_view.end_time.strftime('%H:%M')}) "
                 f"to {floor}% (was cap={before[0]}% gc={before[1]}); "
                 f"work_mode -> Selling first"
             )
         else:
-            state.reason_log.append(
+            view.log(
                 f"SavingSession: active but slot {current_idx + 1} "
                 f"already at floor; work_mode -> Selling first"
             )
-        return state

--- a/custom_components/heo2/rules/solar_surplus.py
+++ b/custom_components/heo2/rules/solar_surplus.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from ..models import ProgrammeState, ProgrammeInputs
-from ..rule_engine import Rule
+from ..models import ProgrammeInputs
+from ..rule_engine import PRIO_SOLAR_SURPLUS, Rule
 
 
 class SolarSurplusRule(Rule):
@@ -14,41 +14,40 @@ class SolarSurplusRule(Rule):
 
     name = "solar_surplus"
     description = "Set day-time SOC targets based on solar forecast"
+    priority_class = PRIO_SOLAR_SURPLUS
 
-    def apply(self, state: ProgrammeState, inputs: ProgrammeInputs) -> ProgrammeState:
+    def propose(self, view, inputs: ProgrammeInputs) -> None:
         total_solar = sum(inputs.solar_forecast_kwh)
         if total_solar <= 0:
-            return state  # nothing to do
+            return
 
-        # Calculate net solar surplus during day hours (06:00-18:00)
         day_solar = inputs.solar_kwh_between(6, 18)
         day_load = inputs.load_kwh_between(6, 18)
         net_surplus_kwh = day_solar - day_load
 
         if net_surplus_kwh <= 0:
-            state.reason_log.append(
+            view.log(
                 f"SolarSurplus: no surplus (solar {day_solar:.1f} kWh "
                 f"< load {day_load:.1f} kWh)"
             )
-            return state
+            return
 
-        # How much SOC would the surplus add?
         surplus_soc = net_surplus_kwh / inputs.battery_capacity_kwh * 100
 
-        # Set day slot target: current SOC + expected surplus, capped at 100
-        for slot in state.slots:
-            if not slot.grid_charge:
-                # Only modify slots that overlap with solar hours
-                start_hour = slot.start_time.hour
-                end_hour = slot.end_time.hour if slot.end_time > slot.start_time else 24
-                if start_hour < 18 and end_hour > 6:
-                    # This slot overlaps with solar production
-                    new_target = min(100, int(inputs.current_soc + surplus_soc))
-                    new_target = max(new_target, int(inputs.min_soc))
-                    slot.capacity_soc = new_target
+        for slot in view.slots:
+            if slot.grid_charge:
+                continue
+            start_hour = slot.start_time.hour
+            end_hour = slot.end_time.hour if slot.end_time > slot.start_time else 24
+            if start_hour < 18 and end_hour > 6:
+                new_target = min(100, int(inputs.current_soc + surplus_soc))
+                new_target = max(new_target, int(inputs.min_soc))
+                view.claim_slot(
+                    slot.index, "capacity_soc", new_target,
+                    reason=f"day surplus +{surplus_soc:.0f}%",
+                )
 
-        state.reason_log.append(
+        view.log(
             f"SolarSurplus: day target raised -- surplus {net_surplus_kwh:.1f} kWh "
             f"(+{surplus_soc:.0f}% SOC)"
         )
-        return state

--- a/tests/test_rule_engine_claims.py
+++ b/tests/test_rule_engine_claims.py
@@ -1,0 +1,319 @@
+"""Unit tests for the claims/arbitration machinery (HEO-31 Phase 3 PR 2).
+
+Pin the StateBuilder / Claim / arbitration semantics independent of
+any specific rule. Existing rule behaviour tests stay in
+`test_rules/`; the precedence regression net stays in
+`test_rules/test_precedence.py`. This file covers the engine itself.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, time, timezone
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from heo2.models import ProgrammeInputs, ProgrammeState
+from heo2.rule_engine import (
+    Claim,
+    PRIO_BASELINE,
+    PRIO_EPS,
+    PRIO_SAVING_SESSION,
+    Rule,
+    RuleEngine,
+    StateBuilder,
+)
+
+
+def _inputs() -> ProgrammeInputs:
+    return ProgrammeInputs(
+        now=datetime(2026, 4, 13, 12, 0, tzinfo=timezone.utc),
+        current_soc=50.0,
+        battery_capacity_kwh=20.0,
+        min_soc=20.0,
+        import_rates=[],
+        export_rates=[],
+        solar_forecast_kwh=[0.0] * 24,
+        load_forecast_kwh=[0.5] * 24,
+        igo_dispatching=False,
+        saving_session=False,
+        saving_session_start=None,
+        saving_session_end=None,
+        ev_charging=False,
+        grid_connected=True,
+        active_appliances=[],
+        appliance_expected_kwh=0.0,
+    )
+
+
+class _SocAt:
+    """Helper rule that writes capacity_soc on a fixed slot at a fixed
+    priority. Used to drive arbitration tests without dragging in real
+    rule logic."""
+
+    def __init__(self, name, slot_idx, value, prio, reason="set"):
+        self.name = name
+        self.description = ""
+        self.enabled = True
+        self.priority_class = prio
+        self._slot = slot_idx
+        self._val = value
+        self._reason = reason
+
+    def propose(self, view, inputs):
+        view.claim_slot(self._slot, "capacity_soc", self._val, reason=self._reason)
+        view.log(f"{self.name}: slot {self._slot} -> {self._val}")
+
+
+# Plumbing for the @abstractmethod check
+class _StubRule(Rule):
+    name = "stub"
+    priority_class = 50
+
+    def propose(self, view, inputs):
+        view.claim_slot(0, "capacity_soc", 80, reason="stub")
+
+
+class TestStateBuilderSeed:
+    def test_reads_return_seed_when_no_claim_made(self):
+        initial = ProgrammeState.default(min_soc=15)
+        builder = StateBuilder(initial)
+        # Seed values from the default programme
+        for i in range(6):
+            assert builder.get_slot(i, "capacity_soc") == 15
+            assert builder.get_slot(i, "grid_charge") is False
+        assert builder.get_global("work_mode") is None
+
+    def test_seed_priority_below_any_rule_priority(self):
+        """A rule's first claim must override the seed regardless of
+        its priority_class."""
+        initial = ProgrammeState.default(min_soc=15)
+        builder = StateBuilder(initial)
+        rule = _SocAt("rule_a", slot_idx=0, value=80, prio=1)
+        view = builder.view_for_rule(rule)
+        rule.propose(view, _inputs())
+        assert builder.get_slot(0, "capacity_soc") == 80
+
+
+class TestArbitration:
+    def test_higher_priority_wins(self):
+        initial = ProgrammeState.default(min_soc=15)
+        builder = StateBuilder(initial)
+        for rule in [
+            _SocAt("low", 0, 30, PRIO_BASELINE),
+            _SocAt("high", 0, 80, PRIO_SAVING_SESSION),
+        ]:
+            view = builder.view_for_rule(rule)
+            rule.propose(view, _inputs())
+        state = builder.materialise()
+        assert state.slots[0].capacity_soc == 80
+
+    def test_priority_order_independent_of_proposal_order(self):
+        """Same two claims, different proposal order, same outcome."""
+        for order in (("low_first", "high_first"), ("high_first", "low_first")):
+            initial = ProgrammeState.default(min_soc=15)
+            builder = StateBuilder(initial)
+            rules = {
+                "low_first": _SocAt("low", 0, 30, PRIO_BASELINE),
+                "high_first": _SocAt("high", 0, 80, PRIO_SAVING_SESSION),
+            }
+            for n in order:
+                rule = rules[n]
+                view = builder.view_for_rule(rule)
+                rule.propose(view, _inputs())
+            state = builder.materialise()
+            assert state.slots[0].capacity_soc == 80
+
+    def test_tie_broken_by_insertion_order(self):
+        """Same priority, later proposer wins (matches legacy
+        last-writer-wins)."""
+        initial = ProgrammeState.default(min_soc=15)
+        builder = StateBuilder(initial)
+        for rule in [
+            _SocAt("first", 0, 30, prio=50),
+            _SocAt("second", 0, 80, prio=50),
+        ]:
+            view = builder.view_for_rule(rule)
+            rule.propose(view, _inputs())
+        state = builder.materialise()
+        assert state.slots[0].capacity_soc == 80
+
+    def test_claim_on_one_slot_does_not_affect_others(self):
+        initial = ProgrammeState.default(min_soc=15)
+        builder = StateBuilder(initial)
+        rule = _SocAt("only_slot_2", 2, 70, PRIO_EPS)
+        view = builder.view_for_rule(rule)
+        rule.propose(view, _inputs())
+        state = builder.materialise()
+        assert state.slots[0].capacity_soc == 15
+        assert state.slots[1].capacity_soc == 15
+        assert state.slots[2].capacity_soc == 70
+        assert state.slots[3].capacity_soc == 15
+
+
+class TestPropoeReadsCurrentWinner:
+    """A rule reading `view.get_slot(...)` should see the highest-
+    priority claim made so far, regardless of subsequent rules."""
+
+    def test_late_rule_reads_current_winner(self):
+        initial = ProgrammeState.default(min_soc=15)
+        builder = StateBuilder(initial)
+
+        class _PostHoc:
+            name = "post"
+            description = ""
+            enabled = True
+            priority_class = 100
+
+            def __init__(self):
+                self.observed = None
+
+            def propose(self_, view, inputs):
+                self_.observed = view.get_slot(0, "capacity_soc")
+                view.claim_slot(0, "capacity_soc", 90, reason="post")
+
+        for rule in [
+            _SocAt("baseline", 0, 30, PRIO_BASELINE),
+            _SocAt("ss", 0, 70, PRIO_SAVING_SESSION),
+        ]:
+            view = builder.view_for_rule(rule)
+            rule.propose(view, _inputs())
+        post_rule = _PostHoc()
+        view = builder.view_for_rule(post_rule)
+        post_rule.propose(view, _inputs())
+        # The post-hoc rule saw 70 (SavingSession's claim, the winner
+        # at that point), not 30 (Baseline) or 15 (seed).
+        assert post_rule.observed == 70
+
+
+class TestApplyShimBackCompat:
+    """`Rule.apply(state, inputs)` is the legacy entry point. Tests
+    that call apply() directly must keep working: reads return state
+    values seeded into the builder, the rule's claims override them,
+    and the materialised state reflects the rule's writes."""
+
+    def test_apply_propose_rule_returns_modified_state(self):
+        rule = _StubRule()
+        initial = ProgrammeState.default(min_soc=15)
+        out = rule.apply(initial, _inputs())
+        assert out.slots[0].capacity_soc == 80
+
+    def test_apply_does_not_mutate_input_state(self):
+        rule = _StubRule()
+        initial = ProgrammeState.default(min_soc=15)
+        rule.apply(initial, _inputs())
+        # Initial state must be untouched (rules return new state).
+        assert initial.slots[0].capacity_soc == 15
+
+    def test_apply_seeds_reads_from_state(self):
+        """A rule reading view.get_slot should see whatever the input
+        state had; its own claim then overrides."""
+        observations = {}
+
+        class _Reader(Rule):
+            name = "reader"
+            priority_class = 50
+
+            def propose(self_, view, inputs):
+                observations["pre"] = view.get_slot(0, "capacity_soc")
+                view.claim_slot(0, "capacity_soc", 99, reason="reader")
+                observations["post"] = view.get_slot(0, "capacity_soc")
+
+        initial = ProgrammeState.default(min_soc=42)
+        rule = _Reader()
+        out = rule.apply(initial, _inputs())
+        assert observations["pre"] == 42  # seed from state
+        assert observations["post"] == 99
+        assert out.slots[0].capacity_soc == 99
+
+
+class TestClaimsLog:
+    def test_claims_log_records_all_non_seed_claims(self):
+        initial = ProgrammeState.default(min_soc=15)
+        builder = StateBuilder(initial)
+        for rule in [
+            _SocAt("a", 0, 30, prio=10),
+            _SocAt("b", 0, 80, prio=70),
+            _SocAt("c", 1, 40, prio=20),
+        ]:
+            view = builder.view_for_rule(rule)
+            rule.propose(view, _inputs())
+        state = builder.materialise()
+        assert len(state.claims_log) == 3
+        rule_names = sorted(c.rule_name for c in state.claims_log)
+        assert rule_names == ["a", "b", "c"]
+        # Seeds excluded
+        assert all(c.priority != StateBuilder.SEED_PRIORITY for c in state.claims_log)
+
+    def test_claims_log_preserves_losing_claims(self):
+        """Losing claims are kept so the dashboard can render the full
+        chain ('Baseline 100% -> CheapRateCharge 80% -> EPS 0%'
+        winner: EPS)."""
+        initial = ProgrammeState.default(min_soc=15)
+        builder = StateBuilder(initial)
+        for rule in [
+            _SocAt("baseline", 0, 100, PRIO_BASELINE),
+            _SocAt("eps", 0, 0, PRIO_EPS),
+        ]:
+            view = builder.view_for_rule(rule)
+            rule.propose(view, _inputs())
+        state = builder.materialise()
+        soc_claims = [
+            c for c in state.claims_log
+            if c.field == "capacity_soc" and c.slot_index == 0
+        ]
+        assert len(soc_claims) == 2
+        assert state.slots[0].capacity_soc == 0  # EPS won
+
+
+class TestSafetyRuleStaysOutsideArbitration:
+    def test_safety_runs_post_arbitration_via_legacy_apply(self):
+        """Any rule named 'safety' is collected and run after
+        materialisation, mutating the state directly. This preserves
+        the invariant-pass shape (clamping/snapping/contiguity)."""
+        applied = []
+
+        class _FakeSafety(Rule):
+            name = "safety"
+            priority_class = 999
+
+            def apply(self, state, inputs):
+                applied.append(True)
+                # Mutate to prove we ran post-arbitration.
+                state.slots[0].capacity_soc = 0
+                return state
+
+            def propose(self, view, inputs):
+                # Should NEVER be called
+                view.log("propose called incorrectly")
+                view.claim_slot(0, "capacity_soc", 999, reason="propose")
+
+        # A regular rule that would otherwise have set slot 0 to 80.
+        class _Setter(Rule):
+            name = "setter"
+            priority_class = 50
+
+            def propose(self, view, inputs):
+                view.claim_slot(0, "capacity_soc", 80, reason="setter")
+
+        engine = RuleEngine(rules=[_Setter(), _FakeSafety()])
+        out = engine.calculate(_inputs())
+        assert applied == [True]
+        # Safety's apply mutation wins; propose was bypassed
+        assert out.slots[0].capacity_soc == 0
+        assert "propose called incorrectly" not in out.reason_log
+
+
+class TestEngineRunsRules:
+    def test_engine_skips_disabled(self):
+        rule = _SocAt("a", 0, 80, PRIO_BASELINE)
+        rule.enabled = False
+        engine = RuleEngine(rules=[rule])
+        out = engine.calculate(_inputs())
+        assert out.slots[0].capacity_soc == 20  # seed (min_soc)
+
+    def test_engine_applies_min_soc_seed(self):
+        engine = RuleEngine(rules=[])
+        out = engine.calculate(_inputs())
+        for s in out.slots:
+            assert s.capacity_soc == 20


### PR DESCRIPTION
## Summary

PR 2 of the HEO-31 Phase 3 stack. Replaces the implicit "execution-order defines precedence" sequential pipeline with an explicit claims-and-arbitration model. Behaviour-preserving port — every test green at every commit.

## What changed

**New engine** (`custom_components/heo2/rule_engine.py`):

- `Claim` dataclass: `field`, `value`, `priority`, `reason`, `rule_name`, `slot_index`, `insertion_order`.
- `StateBuilder`: accumulates claims; reads return the highest-priority claim so far (or seed from initial state).
- `Rule.propose(view, inputs)`: rules add claims via a pre-bound view, no hidden state.
- `Rule.apply(state, inputs)`: kept as a back-compat shim that runs propose against a single-rule builder seeded from `state`. Existing tests calling `rule.apply(...)` keep working.
- Standard priority bands `PRIO_BASELINE=10` … `PRIO_EPS=110` in steps of 10. Mapped to `default_rules()` index × 10 so the literal port preserves current precedence with room to fine-tune later.
- `ProgrammeState.claims_log` (new field): structured per-claim trace, parallel to `reason_log` which keeps its flat-string list shape unchanged.

**Rules ported** (11 of 12):

- BaselineRule → `PRIO_BASELINE`
- CheapRateChargeRule → `PRIO_CHEAP_RATE_CHARGE`
- SolarSurplusRule → `PRIO_SOLAR_SURPLUS`
- ExportWindowRule → `PRIO_EXPORT_WINDOW`
- EveningProtectRule → `PRIO_EVENING_PROTECT`
- PeakExportArbitrageRule → `PRIO_PEAK_EXPORT_ARBITRAGE`
- SavingSessionRule → `PRIO_SAVING_SESSION`
- IGODispatchRule → `PRIO_IGO_DISPATCH` (F2 guard preserved as-is)
- EVDeferralRule → `PRIO_EV_DEFERRAL`
- EVChargingRule → `PRIO_EV_CHARGING`
- EPSModeRule → `PRIO_EPS`

**SafetyRule** stays on `apply()` — runs as a final post-arbitration invariant pass (clamping / 5-min snapping / contiguity). The engine routes around it during the propose phase.

## What this PR does NOT close

Be honest about scope:

- **F1 (work_mode coalescence)** — three rules still write `work_mode = "Selling first"` at different priorities; highest wins, same final value. The reason chain is now structurally explicit (claims_log), but the rules aren't merged. Future work.
- **F4 (slot-3 consolidation)** — pulled out as PR 3 of this stack.
- **F5 (silent SOC overrides)** — implicit overrides are now explicit priority claims, but no rule has been re-tuned to express different intent. Future fine-tuning.

## Test plan

- [x] 15 new engine-level unit tests (`tests/test_rule_engine_claims.py`) covering seed, arbitration, read-current-winner, apply-shim back-compat, claims_log shape, and Safety bypass.
- [x] All 9 precedence regression tests from PR 1 still green — F2 fix preserved through the port.
- [x] Full suite green at every commit (per-rule commits to give bisect signal): 507/507.

## Commit structure

7 commits, each independently verified by `pytest tests/`:

1. Engine machinery + shim + 15 engine tests
2. BaselineRule port
3. CheapRateCharge port
4. SolarSurplus + ExportWindow port
5. EveningProtect + PeakExportArbitrage port
6. SavingSession + IGODispatch port (F2 guard preserved)
7. EVDeferral + EVCharging + EPSMode port

🤖 Generated with [Claude Code](https://claude.com/claude-code)