### PR TITLE
refactor: extract shared evening-floor calc into load_budget helper

### DIFF
--- a/custom_components/heo2/load_budget.py
+++ b/custom_components/heo2/load_budget.py
@@ -1,0 +1,67 @@
+"""Shared load-budget calculations for the rules engine.
+
+ExportWindowRule (drain target floor) and EveningProtectRule (required
+SOC) both ask the same question: "what SOC does the battery need to
+hold to ride out the evening peak window from battery alone, without
+importing at peak rates?"
+
+Pre-Phase 3 PR 3 the formula was duplicated in both rules with subtle
+differences (one had a divide-by-zero guard, the other didn't; one
+applied an extra `max(..., min_soc)` clamp). This module is the
+single source of truth.
+
+Usage:
+
+    from .load_budget import evening_floor_soc
+
+    floor = evening_floor_soc(inputs)              # defaults 18..24
+    floor = evening_floor_soc(inputs, start_hour=17, end_hour=23)
+"""
+
+from __future__ import annotations
+
+from .models import ProgrammeInputs
+
+
+def evening_demand_kwh(
+    inputs: ProgrammeInputs,
+    *,
+    start_hour: int = 18,
+    end_hour: int = 24,
+) -> float:
+    """Sum the load forecast across the evening peak window.
+
+    `start_hour` and `end_hour` are 24h clock indices into
+    `inputs.load_forecast_kwh` (which is 24-hour, index 0 = 00:00).
+    Default 18..24 covers the 18:00-00:00 evening peak that drives
+    HEO II's drain-then-refill cycle.
+    """
+    return inputs.load_kwh_between(start_hour, end_hour)
+
+
+def evening_floor_soc(
+    inputs: ProgrammeInputs,
+    *,
+    start_hour: int = 18,
+    end_hour: int = 24,
+) -> int:
+    """Minimum slot SOC required to cover the evening peak window
+    from battery alone.
+
+    Returns `min_soc + (evening_demand_kwh / battery_capacity_kwh * 100)`,
+    clamped to `[min_soc, 100]`. Battery capacity of 0 (degenerate
+    test setup) returns `min_soc` rather than dividing.
+
+    Used by:
+      * ExportWindowRule - sets the floor on the drain target so
+        a worth-selling export window doesn't leave the battery
+        empty entering the evening peak.
+      * EveningProtectRule - raises a non-GC slot covering the
+        evening boundary if its current target is below this floor.
+    """
+    if inputs.battery_capacity_kwh <= 0:
+        return int(inputs.min_soc)
+    demand = evening_demand_kwh(inputs, start_hour=start_hour, end_hour=end_hour)
+    pct = demand / inputs.battery_capacity_kwh * 100
+    target = int(inputs.min_soc + pct)
+    return min(100, max(int(inputs.min_soc), target))

--- a/custom_components/heo2/rules/evening_protect.py
+++ b/custom_components/heo2/rules/evening_protect.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 from datetime import time
 
+from ..load_budget import evening_demand_kwh, evening_floor_soc
 from ..models import ProgrammeInputs
 from ..rule_engine import PRIO_EVENING_PROTECT, Rule
 
@@ -25,17 +26,20 @@ class EveningProtectRule(Rule):
         self.evening_end_hour = evening_end_hour
 
     def propose(self, view, inputs: ProgrammeInputs) -> None:
-        evening_demand_kwh = inputs.load_kwh_between(
-            self.evening_start_hour, self.evening_end_hour
+        evening_kwh = evening_demand_kwh(
+            inputs,
+            start_hour=self.evening_start_hour,
+            end_hour=self.evening_end_hour,
         )
 
-        if evening_demand_kwh <= 0:
+        if evening_kwh <= 0:
             return
 
-        required_soc = int(
-            inputs.min_soc + (evening_demand_kwh / inputs.battery_capacity_kwh * 100)
+        required_soc = evening_floor_soc(
+            inputs,
+            start_hour=self.evening_start_hour,
+            end_hour=self.evening_end_hour,
         )
-        required_soc = min(required_soc, 100)
 
         evening_t = time(self.evening_start_hour, 0)
 
@@ -52,7 +56,7 @@ class EveningProtectRule(Rule):
                 if slot.capacity_soc < required_soc:
                     view.claim_slot(
                         slot.index, "capacity_soc", required_soc,
-                        reason=f"evening demand {evening_demand_kwh:.1f} kWh",
+                        reason=f"evening demand {evening_kwh:.1f} kWh",
                     )
                     modified = True
 
@@ -60,11 +64,11 @@ class EveningProtectRule(Rule):
             view.log(
                 f"EveningProtect: raised SOC to {required_soc}% in slot "
                 f"covering {evening_t.strftime('%H:%M')} "
-                f"({evening_demand_kwh:.1f} kWh evening demand)"
+                f"({evening_kwh:.1f} kWh evening demand)"
             )
         else:
             view.log(
                 f"EveningProtect: no change needed "
-                f"({evening_demand_kwh:.1f} kWh evening demand, "
+                f"({evening_kwh:.1f} kWh evening demand, "
                 f"required {required_soc}%)"
             )

--- a/custom_components/heo2/rules/export_window.py
+++ b/custom_components/heo2/rules/export_window.py
@@ -11,6 +11,7 @@ from ..const import (
     DEFAULT_SELL_TOP_PCT_LOW_SOC,
     ROUND_TRIP_EFFICIENCY,
 )
+from ..load_budget import evening_demand_kwh, evening_floor_soc
 from ..models import ProgrammeInputs
 from ..rank_pricing import (
     filter_today,
@@ -115,17 +116,9 @@ class ExportWindowRule(Rule):
         # (sell during top windows). A naive drain-to-min_soc could leave
         # the battery empty going into the 18:30-23:30 evening window
         # and force grid imports at peak rates. Floor the drain target
-        # at min_soc + (evening_demand / capacity).
-        evening_demand_kwh = inputs.load_kwh_between(18, 24)
-        if inputs.battery_capacity_kwh > 0:
-            evening_floor_soc = int(
-                inputs.min_soc
-                + (evening_demand_kwh / inputs.battery_capacity_kwh * 100)
-            )
-        else:
-            evening_floor_soc = int(inputs.min_soc)
-        evening_floor_soc = min(evening_floor_soc, 100)
-        drain_target = max(evening_floor_soc, int(inputs.min_soc))
+        # at the shared evening-floor calc (also used by EveningProtect).
+        evening_kwh = evening_demand_kwh(inputs)
+        drain_target = evening_floor_soc(inputs)
 
         modified = False
         for slot in view.slots:
@@ -160,7 +153,7 @@ class ExportWindowRule(Rule):
                 f"ExportWindow: drain to {drain_target}% in {n_reason}, "
                 f"{len(worth_windows)} slots @ {rate_summary} "
                 f"covering hours {sorted_hours} "
-                f"(evening floor from {evening_demand_kwh:.1f} kWh demand)"
+                f"(evening floor from {evening_kwh:.1f} kWh demand)"
             )
         else:
             view.log(

--- a/tests/test_load_budget.py
+++ b/tests/test_load_budget.py
@@ -1,0 +1,78 @@
+"""Unit tests for the shared load-budget calculations (HEO-31 Phase 3 PR 3)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from heo2.load_budget import evening_demand_kwh, evening_floor_soc
+from heo2.models import ProgrammeInputs
+
+
+def _inputs(*, load_per_hour=1.0, capacity=20.0, min_soc=10.0) -> ProgrammeInputs:
+    return ProgrammeInputs(
+        now=datetime(2026, 4, 13, 12, 0, tzinfo=timezone.utc),
+        current_soc=50.0,
+        battery_capacity_kwh=capacity,
+        min_soc=min_soc,
+        import_rates=[],
+        export_rates=[],
+        solar_forecast_kwh=[0.0] * 24,
+        load_forecast_kwh=[load_per_hour] * 24,
+        igo_dispatching=False,
+        saving_session=False,
+        saving_session_start=None,
+        saving_session_end=None,
+        ev_charging=False,
+        grid_connected=True,
+        active_appliances=[],
+        appliance_expected_kwh=0.0,
+    )
+
+
+class TestEveningDemand:
+    def test_default_window_is_18_to_24(self):
+        # 6h * 1.0 kWh/h = 6.0 kWh
+        assert evening_demand_kwh(_inputs(load_per_hour=1.0)) == 6.0
+
+    def test_custom_window(self):
+        # 5h * 2.0 kWh/h = 10.0 kWh
+        assert evening_demand_kwh(_inputs(load_per_hour=2.0), start_hour=17, end_hour=22) == 10.0
+
+    def test_zero_load(self):
+        assert evening_demand_kwh(_inputs(load_per_hour=0.0)) == 0.0
+
+
+class TestEveningFloorSoc:
+    def test_min_soc_plus_demand_percentage(self):
+        # 6.0 kWh / 20.0 kWh = 30% + min_soc 10 = 40%
+        assert evening_floor_soc(_inputs(load_per_hour=1.0, capacity=20.0, min_soc=10.0)) == 40
+
+    def test_clamped_to_100(self):
+        # 24h * 5.0 kWh = 120 kWh demand, way over capacity. With
+        # default 18..24 window (6h), 30 kWh / 20 kWh = 150% + min_soc.
+        # Clamped to 100.
+        assert evening_floor_soc(_inputs(load_per_hour=5.0, capacity=20.0, min_soc=10.0)) == 100
+
+    def test_clamped_to_min_soc_when_demand_zero(self):
+        # No demand -> floor is just min_soc.
+        assert evening_floor_soc(_inputs(load_per_hour=0.0, min_soc=15.0)) == 15
+
+    def test_zero_capacity_returns_min_soc(self):
+        # Degenerate: battery has no capacity. Don't divide.
+        assert evening_floor_soc(_inputs(load_per_hour=2.0, capacity=0.0, min_soc=20.0)) == 20
+
+    def test_int_truncation_matches_legacy(self):
+        """Legacy code did `int(min_soc + pct)` (truncation toward
+        zero). We preserve that so floor values match historical
+        behaviour exactly."""
+        # 0.5 kWh/h * 6h = 3.0 kWh; 3.0/20.0 = 15.0%; min_soc=10 -> 25.
+        assert evening_floor_soc(_inputs(load_per_hour=0.5, capacity=20.0, min_soc=10.0)) == 25
+
+        # 0.55 * 6 = 3.3; 3.3/20 = 16.5%; min_soc 10 + 16.5 = 26.5 -> int -> 26
+        assert evening_floor_soc(_inputs(load_per_hour=0.55, capacity=20.0, min_soc=10.0)) == 26
+
+    def test_custom_window_passes_through(self):
+        # 17..22 = 5h * 1.0 = 5 kWh / 20 kWh = 25% + 10 = 35
+        assert evening_floor_soc(_inputs(load_per_hour=1.0), start_hour=17, end_hour=22) == 35


### PR DESCRIPTION
## Summary

PR 3 of the HEO-31 Phase 3 stack. Closes the matrix's slot-3 consolidation finding (F4) by extracting the shared `min_soc + evening_demand%` formula that ExportWindow and EveningProtect were each computing in slightly different ways.

## What changed

New module `custom_components/heo2/load_budget.py`:

- `evening_demand_kwh(inputs, start_hour=18, end_hour=24)` — sum the load forecast across a configurable window.
- `evening_floor_soc(inputs, start_hour=18, end_hour=24)` — minimum slot SOC to ride out the window from battery alone, clamped to `[min_soc, 100]`.

Both ExportWindowRule.propose and EveningProtectRule.propose now use the helper:

- ExportWindow uses the defaults (18..24).
- EveningProtect passes its configurable `evening_start_hour` / `evening_end_hour` through.

Subtle pre-existing differences eliminated:

- ExportWindow had a `battery_capacity_kwh > 0` divide-by-zero guard; EveningProtect didn't. Helper has the guard.
- ExportWindow had an extra `max(..., min_soc)` clamp on top of the formula. Helper has it.
- Both implementations agreed on the int-truncation behaviour; helper keeps it (test pinned).

## Out of scope

The matrix flagged three rules under F4 (SolarSurplus, ExportWindow, EveningProtect). Only two share this formula — SolarSurplus computes `current_soc + day_surplus_soc`, which is a different quantity. Not consolidating that. The matrix's framing was slightly imprecise; the actual dedup target was two rules, not three.

## Test plan

- [x] 9 new unit tests in `tests/test_load_budget.py` covering defaults, custom windows, clamping, zero-capacity guard, int-truncation parity with legacy.
- [x] All existing rule + precedence tests still green.
- [x] Full suite green: 516/516.

🤖 Generated with [Claude Code](https://claude.com/claude-code)