### PR TITLE
fix(replan_triggers): commit on globals change so PeakArbitrage actually exports

### DIFF
--- a/custom_components/heo2/replan_triggers.py
+++ b/custom_components/heo2/replan_triggers.py
@@ -188,6 +188,22 @@ def should_commit_replan(
             f"({baseline.soc_at_capture:.0f} -> {inputs.current_soc:.0f}%)"
         )
 
+    # SPEC §2 globals (work_mode / energy_pattern / max_*_a): a runtime
+    # rule activation - PeakArbitrageRule entering an allocated top-
+    # priced export slot, EVDeferralRule crossing its threshold, or
+    # SavingSession ending and reverting work_mode to the Baseline
+    # default - changes the new programme's globals without firing any
+    # of the input-deviation triggers above. Without this check the
+    # new globals never land on the inverter and the rule's intent is
+    # silently dropped (real production miss 2026-05-08: peak-export
+    # window passed with work_mode stuck at Zero export to CT).
+    globals_diff = _globals_diff(new_programme, baseline.programme)
+    if globals_diff:
+        return ReplanDecision(
+            True,
+            f"trigger: programme globals changed ({globals_diff})",
+        )
+
     return ReplanDecision(
         False,
         f"hold baseline ({baseline.captured_at.strftime('%H:%M')}; "
@@ -195,6 +211,44 @@ def should_commit_replan(
         f"load dev {load_dev:.0f}% < {replan_load_pct:.0f}%, "
         f"SOC dev {soc_dev:.1f}% < {replan_soc_pct:.0f}%)"
     )
+
+
+def _globals_diff(new: ProgrammeState, baseline: ProgrammeState) -> str | None:
+    """Return a short diff description if any SPEC §2 global differs
+    between `new` and `baseline`, else None. Comparison rules match
+    `MqttWriter.diff_globals` so this trigger and the writer agree on
+    what counts as a meaningful delta:
+
+      * strings: case-insensitive, whitespace-trimmed equality
+      * floats: tol=0.5 to suppress noisy round-trip flicker
+      * None on either side is a "don't touch" signal -> ignored
+    """
+    def _str_equal(a, b) -> bool:
+        if a is None or b is None:
+            return True  # don't fire on "don't touch" sentinel
+        return str(a).strip().casefold() == str(b).strip().casefold()
+
+    def _float_equal(a, b, tol: float = 0.5) -> bool:
+        if a is None or b is None:
+            return True
+        return abs(float(a) - float(b)) <= tol
+
+    diffs: list[str] = []
+    if not _str_equal(new.work_mode, baseline.work_mode):
+        diffs.append(f"work_mode {baseline.work_mode!r}->{new.work_mode!r}")
+    if not _str_equal(new.energy_pattern, baseline.energy_pattern):
+        diffs.append(
+            f"energy_pattern {baseline.energy_pattern!r}->{new.energy_pattern!r}"
+        )
+    if not _float_equal(new.max_charge_a, baseline.max_charge_a):
+        diffs.append(
+            f"max_charge_a {baseline.max_charge_a}->{new.max_charge_a}"
+        )
+    if not _float_equal(new.max_discharge_a, baseline.max_discharge_a):
+        diffs.append(
+            f"max_discharge_a {baseline.max_discharge_a}->{new.max_discharge_a}"
+        )
+    return "; ".join(diffs) if diffs else None
 
 
 def capture_baseline(

--- a/tests/test_replan_triggers.py
+++ b/tests/test_replan_triggers.py
@@ -261,3 +261,144 @@ class TestEventTriggers:
             replan_solar_pct=25, replan_load_pct=25, replan_soc_pct=10,
         )
         assert not decision.commit
+
+
+class TestGlobalsChangedCommits:
+    """Real production bug 2026-05-08: PeakArbitrageRule flips
+    `state.work_mode` from "Zero export to CT" to "Selling first" when
+    a tick lands inside an allocated top-priced export slot.
+    EVDeferralRule does the same when its triggers cross threshold.
+    SavingSession on session-end resets work_mode back to baseline
+    (transition False->False is silent).
+
+    None of these transitions are caught by the input-deviation
+    triggers above (forecast / SOC / IGO / saving session / grid).
+    Without a globals-changed trigger, the new programme is computed
+    every tick but never committed - the inverter holds the stale
+    baseline `Zero export to CT` and never exports during the day's
+    top-priced window. Direct revenue loss.
+
+    Each test below: baseline programme has globals A, new programme
+    has globals B, NO input-deviation trigger fires. The trigger MUST
+    fire purely on the globals delta.
+    """
+
+    def _baseline_with_globals(
+        self,
+        *,
+        work_mode="Zero export to CT",
+        energy_pattern="Load first",
+        max_charge_a=100.0,
+        max_discharge_a=100.0,
+    ) -> BaselineSnapshot:
+        prog = _default_programme()
+        prog.work_mode = work_mode
+        prog.energy_pattern = energy_pattern
+        prog.max_charge_a = max_charge_a
+        prog.max_discharge_a = max_discharge_a
+        inputs = _inputs()
+        return capture_baseline(prog, inputs, tz=_LON, is_daily_plan=True)
+
+    def _new_programme(
+        self,
+        *,
+        work_mode="Zero export to CT",
+        energy_pattern="Load first",
+        max_charge_a=100.0,
+        max_discharge_a=100.0,
+    ) -> ProgrammeState:
+        prog = _default_programme()
+        prog.work_mode = work_mode
+        prog.energy_pattern = energy_pattern
+        prog.max_charge_a = max_charge_a
+        prog.max_discharge_a = max_discharge_a
+        return prog
+
+    def _decide(
+        self, *, baseline: BaselineSnapshot, new: ProgrammeState,
+    ):
+        return should_commit_replan(
+            new_programme=new,
+            inputs=_inputs(),
+            baseline=baseline,
+            tz=_LON,
+            daily_plan_time=time(18, 0),
+            replan_solar_pct=25, replan_load_pct=25, replan_soc_pct=10,
+        )
+
+    def test_work_mode_flip_to_selling_first_commits(self):
+        """The PeakArbitrage / SavingSession / EVDeferral case: rule
+        activated, new programme has work_mode=Selling first, baseline
+        had Zero export to CT, no input deviation."""
+        baseline = self._baseline_with_globals(work_mode="Zero export to CT")
+        new = self._new_programme(work_mode="Selling first")
+        decision = self._decide(baseline=baseline, new=new)
+        assert decision.commit, decision.reason
+        assert "global" in decision.reason.lower() or "work_mode" in decision.reason.lower()
+
+    def test_work_mode_flip_back_to_zero_export_commits(self):
+        """Rule deactivated (e.g. saving session ended, peak window
+        passed). New programme reverts to Baseline's `Zero export to
+        CT`; baseline still carried `Selling first`. Without commit
+        the inverter stays in Selling first forever."""
+        baseline = self._baseline_with_globals(work_mode="Selling first")
+        new = self._new_programme(work_mode="Zero export to CT")
+        decision = self._decide(baseline=baseline, new=new)
+        assert decision.commit, decision.reason
+
+    def test_energy_pattern_change_commits(self):
+        baseline = self._baseline_with_globals(energy_pattern="Load first")
+        new = self._new_programme(energy_pattern="Battery first")
+        decision = self._decide(baseline=baseline, new=new)
+        assert decision.commit, decision.reason
+
+    def test_max_discharge_a_change_commits(self):
+        """PeakArbitrage throttles `max_discharge_a` by spare amount
+        when active. Different from Baseline's 100A default."""
+        baseline = self._baseline_with_globals(max_discharge_a=100.0)
+        new = self._new_programme(max_discharge_a=49.0)
+        decision = self._decide(baseline=baseline, new=new)
+        assert decision.commit, decision.reason
+
+    def test_max_charge_a_change_commits(self):
+        baseline = self._baseline_with_globals(max_charge_a=100.0)
+        new = self._new_programme(max_charge_a=50.0)
+        decision = self._decide(baseline=baseline, new=new)
+        assert decision.commit, decision.reason
+
+    def test_globals_unchanged_no_commit(self):
+        """Same globals between baseline and new: no globals trigger,
+        no other trigger fired - hold the baseline. Existing 15-min
+        no-op behaviour preserved."""
+        baseline = self._baseline_with_globals(
+            work_mode="Zero export to CT",
+            energy_pattern="Load first",
+            max_charge_a=100.0,
+            max_discharge_a=100.0,
+        )
+        new = self._new_programme(
+            work_mode="Zero export to CT",
+            energy_pattern="Load first",
+            max_charge_a=100.0,
+            max_discharge_a=100.0,
+        )
+        decision = self._decide(baseline=baseline, new=new)
+        assert not decision.commit
+
+    def test_max_discharge_a_within_tolerance_no_commit(self):
+        """Float compare uses tol=0.5 to match MqttWriter.diff_globals
+        - 99.7 vs 100.0 is below the write threshold, so no spurious
+        commit on noisy float arithmetic."""
+        baseline = self._baseline_with_globals(max_discharge_a=100.0)
+        new = self._new_programme(max_discharge_a=99.8)
+        decision = self._decide(baseline=baseline, new=new)
+        assert not decision.commit
+
+    def test_work_mode_case_insensitive(self):
+        """SA round-trips work_mode strings with occasional case
+        flicker. Equality check should casefold like
+        MqttWriter.diff_globals does."""
+        baseline = self._baseline_with_globals(work_mode="Zero export to CT")
+        new = self._new_programme(work_mode="zero export to ct")
+        decision = self._decide(baseline=baseline, new=new)
+        assert not decision.commit


### PR DESCRIPTION
## Real production miss 2026-05-08

PeakArbitrage allocated 7.5 kWh to today's top-priced 17:30-19:00 windows at 17-18p. The rule fired correctly each tick but the inverter held \`work_mode = Zero export to CT\` through the entire window. Zero kWh sold. ~£1.30 of revenue missed.

## Root cause

\`should_commit_replan\` in PR #38 only commits a fresh plan on input-deviation triggers (forecast, SOC, IGO transition, saving session announce, grid restore). PeakArbitrage's runtime flip of \`state.work_mode\` from \"Zero export to CT\" → \"Selling first\" when entering an allocated slot is **not** an input deviation — it's a derived programme change. The new globals never land on the inverter.

EVDeferralRule and SavingSession on session-end suffer the same drop.

## Fix

Add a final trigger after the existing checks: compare the new programme's SPEC §2 globals against the baseline programme. Any meaningful diff fires the trigger. Comparison rules mirror \`MqttWriter.diff_globals\` so the trigger and writer agree on what counts as a write-worthy delta (strings case-insensitive + trimmed, floats tol=0.5, None = don't touch).

## Test plan

- [x] 8 new tests in \`TestGlobalsChangedCommits\` — bug reproduces (5 fail before fix), all pass after.
- [x] No-op cases (identical globals / within-tol / case flicker) still hold the baseline so the writer doesn't churn.
- [x] Full suite green: 524/524.

🤖 Generated with [Claude Code](https://claude.com/claude-code)