### PR TITLE
fix(peak_export_arbitrage): include in-progress slots in allocations

### DIFF
--- a/custom_components/heo2/rules/peak_export_arbitrage.py
+++ b/custom_components/heo2/rules/peak_export_arbitrage.py
@@ -135,10 +135,23 @@ class PeakExportArbitrageRule(Rule):
         cheap_start: datetime,
         tz: ZoneInfo | None,
     ) -> list[RateSlot]:
+        """Slots that are still allocatable: end time in the future
+        (so we have at least some of the slot left to sell into) AND
+        starting before the cheap window.
+
+        Pre-2026-05-08 this filtered on `start_local < now_local` -
+        which excluded any slot whose start had passed, even if the
+        slot was still in progress. Active-slot detection downstream
+        then never matched because the in-progress slot wasn't in the
+        allocation list. Tick at 19:12 inside a 19:00-19:30 slot ->
+        rule logs 'scheduled' and never flips work_mode. Real
+        production miss documented in PR #74.
+        """
         out = []
         for r in export_rates:
             start_local = _local(r.start, tz)
-            if start_local < now_local or start_local >= cheap_start:
+            end_local = _local(r.end, tz)
+            if end_local <= now_local or start_local >= cheap_start:
                 continue
             out.append(r)
         return out

--- a/tests/test_rules/test_peak_export_arbitrage.py
+++ b/tests/test_rules/test_peak_export_arbitrage.py
@@ -121,6 +121,70 @@ class TestPeakExportArbitrageRule:
         assert result.max_discharge_a > 0
         assert any("ACTIVE" in r for r in result.reason_log)
 
+    def test_active_mid_slot_when_tick_fires_after_slot_start(self):
+        """Real production miss 2026-05-08: tick fires at 19:12 BST,
+        inside an in-progress 19:00-19:30 export slot. Pre-fix the
+        `_today_remaining_export_slots` filter excluded any slot whose
+        start was already past, so 19:00 wasn't even in allocations
+        and the active-slot detection failed. Rule must fire ACTIVE
+        for in-progress slots, not just slots whose start instant
+        coincides with `now_local`.
+        """
+        today = datetime(2026, 5, 8, 19, 12, tzinfo=_LON)  # 12 min into the slot
+        rates = [
+            _half_hour_rate(today, 19, 0, 13.10),   # active mid-slot
+            _half_hour_rate(today, 19, 30, 13.28),  # next, slightly higher
+            _half_hour_rate(today, 20, 0, 13.06),
+            _half_hour_rate(today, 18, 30, 12.50),  # in past - should be ignored
+        ]
+        # IGO off-peak start at 23:30 - 6:30 forward = end of cheap window day
+        # before. Set import rates with a clear cheap-window boundary so
+        # `_resolve_cheap_window_start` lands at 23:30 BST tonight.
+        cheap_start_local = today.replace(hour=23, minute=30)
+        import_rates = [
+            RateSlot(
+                start=cheap_start_local.astimezone(timezone.utc),
+                end=(cheap_start_local + timedelta(hours=6)).astimezone(timezone.utc),
+                rate_pence=7.0,
+            ),
+            RateSlot(
+                start=(cheap_start_local - timedelta(hours=18)).astimezone(timezone.utc),
+                end=cheap_start_local.astimezone(timezone.utc),
+                rate_pence=27.88,
+            ),
+        ]
+        inputs = _inputs(
+            now_local=today, current_soc=80.0, capacity=20.0, min_soc=10.0,
+            export_rates=rates, import_rates=import_rates,
+            load_24=[0.3] * 24,
+        )
+        result = PeakExportArbitrageRule().apply(_empty_programme(), inputs)
+        assert result.work_mode == "Selling first", \
+            f"Mid-slot activation failed: reason_log={result.reason_log}"
+        assert result.max_discharge_a is not None
+        assert any("ACTIVE" in r for r in result.reason_log), \
+            f"Expected ACTIVE log, got: {result.reason_log}"
+
+    def test_past_slots_excluded_from_allocation(self):
+        """Slots whose end is in the past should not appear in
+        allocations - we can't sell into yesterday."""
+        today = datetime(2026, 5, 8, 20, 0, tzinfo=_LON)
+        rates = [
+            _half_hour_rate(today, 18, 0, 25.0),   # ended at 18:30, in past
+            _half_hour_rate(today, 20, 0, 13.0),   # active now
+        ]
+        inputs = _inputs(
+            now_local=today, current_soc=100.0, capacity=20.0, min_soc=10.0,
+            export_rates=rates, load_24=[0.3] * 24,
+        )
+        result = PeakExportArbitrageRule().apply(_empty_programme(), inputs)
+        # Active should be the 20:00 slot; the past 18:00 slot should
+        # not be in allocations or accidentally chosen as active.
+        if result.work_mode == "Selling first":
+            assert any("20:00" in r for r in result.reason_log)
+            assert not any("ACTIVE - selling" in r and "18:00" in r
+                           for r in result.reason_log)
+
     def test_inactive_outside_allocated_slot(self):
         """Battery full, top-priced slot is 18:00-18:30, but we're at
         17:00 (between rates with no allocation) -> work_mode left


### PR DESCRIPTION
## Sister bug to #73

PR #73 fixed the trigger; this PR fixes the rule so the trigger has something meaningful to act on.

## Root cause

\`_today_remaining_export_slots\` filtered on \`start_local < now_local\` — excluding any slot whose start had passed, even if the slot was still in progress. The active-slot detection downstream expects an allocation to cover NOW, which requires the slot to be in the list. So the rule could only fire if the tick landed at the slot's start instant.

Coordinator ticks fire ~12-14s after the quarter-hour (drift seeded by HA restart time). A tick at 19:12:14 inside a 19:00–19:30 slot saw \`19:00 < 19:12:14 == True\` and dropped the slot. Result: work_mode never flipped, no export at any of today's top-priced windows.

## Fix

Filter on \`end_local <= now_local\` instead. A slot stays in the candidate list as long as some of it is still in the future.

The throttle calc still uses full slot duration. Sub-optimal mid-slot (we joined late, deliver less actual kWh than allocated), but correct: the inverter exports for the rest of the slot at the throttled amp rate. Fine-tuning the throttle to remaining duration is a future optimisation.

## Test plan

- [x] \`test_active_mid_slot_when_tick_fires_after_slot_start\` — reproduces the bug at 19:12 inside 19:00–19:30. Fails before fix.
- [x] \`test_past_slots_excluded_from_allocation\` — pins the existing behaviour for fully-past slots so the filter loosening doesn't go too far the other way.
- [x] All 9 peak-arbitrage tests + 526 total green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)