### PR TITLE
feat(heo3): P1.0 — package skeleton + Operator + mock transport

### DIFF
--- a/custom_components/heo3/__init__.py
+++ b/custom_components/heo3/__init__.py
@@ -1,0 +1,35 @@
+"""HEO III — Energy Optimiser (operator module).
+
+Tracking issue: https://github.com/a1acrity/heo2/issues/75
+Design doc: docs/HEO_III_DESIGN.md
+
+P1.0: package skeleton + Operator class with stub methods + mock
+transport + config_flow shell. The integration loads cleanly in HA
+but does no inverter I/O until P1.1+ fills in the adapters.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from .const import DOMAIN
+
+logger = logging.getLogger(__name__)
+
+PLATFORMS: list[str] = []  # Sensors/switches added in later phases.
+
+
+async def async_setup_entry(hass, entry) -> bool:  # type: ignore[no-untyped-def]
+    """Set up HEO III from a config entry. P1.0: no-op + log."""
+    logger.info(
+        "HEO III setup_entry — skeleton only, no I/O until P1.1+. entry_id=%s",
+        entry.entry_id,
+    )
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {"phase": "P1.0"}
+    return True
+
+
+async def async_unload_entry(hass, entry) -> bool:  # type: ignore[no-untyped-def]
+    """Tear down."""
+    hass.data.get(DOMAIN, {}).pop(entry.entry_id, None)
+    return True

--- a/custom_components/heo3/adapters/__init__.py
+++ b/custom_components/heo3/adapters/__init__.py
@@ -1,0 +1,10 @@
+"""Adapters: mechanical I/O between the Operator and the world.
+
+Three adapters compose the State layer (§3):
+- InverterAdapter — MQTT W/R against SA broker.
+- PeripheralAdapter — HA service calls + reads for zappi, Tesla, appliances.
+- WorldGatherer — read-only collation of HA entities (rates, forecasts, flags).
+
+Each adapter produces a slice of the Snapshot. The Operator composes
+them in one snapshot() call.
+"""

--- a/custom_components/heo3/adapters/inverter.py
+++ b/custom_components/heo3/adapters/inverter.py
@@ -1,0 +1,44 @@
+"""Inverter Adapter — MQTT writes + reads against Solar Assistant.
+
+P1.0 stub: methods raise NotImplementedError. Full implementation in
+P1.1 (writes) and P1.2 (reads).
+"""
+
+from __future__ import annotations
+
+from ..transport import Transport
+from ..types import InverterSettings, InverterState, PlannedAction, Write
+
+
+class InverterAdapter:
+    """Writes to and reads from the Sunsynk inverter via SA's MQTT broker.
+
+    All writes target inverter_1 per SPEC §2 (inverter_2 is RS485-mirrored).
+    Writes are diff-only, sequenced, and verified against SA's
+    `set/response_message/state` channel.
+    """
+
+    def __init__(self, transport: Transport, inverter_name: str) -> None:
+        self._transport = transport
+        self._inverter_name = inverter_name
+
+    async def read_state(self) -> InverterState:
+        """P1.2."""
+        raise NotImplementedError("P1.2 — Inverter Adapter reads")
+
+    async def read_settings(self) -> InverterSettings:
+        """P1.2."""
+        raise NotImplementedError("P1.2 — Inverter Adapter reads")
+
+    def writes_for(self, action: PlannedAction) -> tuple[Write, ...]:
+        """Translate a PlannedAction into a sequenced list of MQTT
+        writes, snapping values, validating safety invariants (§17),
+        and ordering globals before slots before current limits. P1.1.
+        """
+        raise NotImplementedError("P1.1 — Inverter Adapter writes")
+
+    async def publish_and_verify(self, write: Write) -> str:
+        """Publish one write, await SA response, return verification
+        state (OK / SET_BUT_UNVERIFIED / FAILED / PENDING). P1.1.
+        """
+        raise NotImplementedError("P1.1 — verification cycle")

--- a/custom_components/heo3/adapters/peripheral.py
+++ b/custom_components/heo3/adapters/peripheral.py
@@ -1,0 +1,54 @@
+"""Peripheral Adapter — zappi, Tesla (Teslemetry), appliances.
+
+P1.0 stub. Full implementation in P1.3.
+"""
+
+from __future__ import annotations
+
+from ..types import (
+    ApplianceState,
+    EVAction,
+    EVState,
+    PlannedAction,
+    TeslaAction,
+    TeslaState,
+)
+
+
+class PeripheralAdapter:
+    """HA service calls + reads for non-inverter equipment.
+
+    Tesla writes are gated on `binary_sensor.<vehicle>_located_at_home`
+    being `on` — the operator suppresses commands when the car is away
+    rather than letting them queue or error.
+    """
+
+    def __init__(
+        self,
+        zappi_charge_mode_entity: str,
+        tesla_entity_prefix: str | None,
+        appliance_switches: dict[str, str],
+    ) -> None:
+        self._zappi_charge_mode_entity = zappi_charge_mode_entity
+        self._tesla_entity_prefix = tesla_entity_prefix
+        self._appliance_switches = appliance_switches
+
+    async def read_ev(self) -> EVState:
+        raise NotImplementedError("P1.3 — Peripheral Adapter reads")
+
+    async def read_tesla(self) -> TeslaState | None:
+        """Returns None if Tesla is not configured."""
+        raise NotImplementedError("P1.3 — Peripheral Adapter reads")
+
+    async def read_appliances(self) -> ApplianceState:
+        raise NotImplementedError("P1.3 — Peripheral Adapter reads")
+
+    async def apply_ev(self, action: EVAction) -> None:
+        raise NotImplementedError("P1.3 — Peripheral Adapter writes")
+
+    async def apply_tesla(self, action: TeslaAction) -> None:
+        """No-op if car is not at home (gating per design §6/§7)."""
+        raise NotImplementedError("P1.3 — Peripheral Adapter writes")
+
+    async def apply_appliances(self, action: PlannedAction) -> None:
+        raise NotImplementedError("P1.3 — Peripheral Adapter writes")

--- a/custom_components/heo3/adapters/world.py
+++ b/custom_components/heo3/adapters/world.py
@@ -1,0 +1,50 @@
+"""World Gatherer — read-only collation of HA entities.
+
+Rates (BD + IGO + AgilePredict), forecasts (Solcast + HEO-5),
+flags (IGO dispatch, saving session, EPS, temperature alarms).
+
+P1.0 stub. Full implementation across P1.4 / P1.5 / P1.6.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from ..types import (
+    LiveRates,
+    LoadForecast,
+    PredictedRates,
+    SolarForecast,
+    SystemFlags,
+)
+
+
+class WorldGatherer:
+    """One pass over external HA state per snapshot tick.
+
+    All values are read from HA entities — never from the network
+    directly. The integrations (BottlecapDave, Solcast, octopus_energy,
+    teslemetry, etc.) handle the upstream calls; this layer just
+    collates their state into the operator's typed view.
+    """
+
+    def __init__(self, hass) -> None:  # type: ignore[no-untyped-def]
+        self._hass = hass
+
+    async def read_rates_live(self) -> LiveRates:
+        raise NotImplementedError("P1.4 — World Gatherer rates")
+
+    async def read_rates_predicted(self) -> PredictedRates:
+        raise NotImplementedError("P1.4 — World Gatherer rates")
+
+    async def read_rates_freshness(self) -> dict[str, datetime]:
+        raise NotImplementedError("P1.4 — World Gatherer rates")
+
+    async def read_solar_forecast(self) -> SolarForecast:
+        raise NotImplementedError("P1.5 — World Gatherer forecasts")
+
+    async def read_load_forecast(self) -> LoadForecast:
+        raise NotImplementedError("P1.5 — World Gatherer forecasts")
+
+    async def read_flags(self) -> SystemFlags:
+        raise NotImplementedError("P1.6 — World Gatherer flags")

--- a/custom_components/heo3/build.py
+++ b/custom_components/heo3/build.py
@@ -1,0 +1,95 @@
+"""ActionBuilder — intent → PlannedAction constructors.
+
+The planner expresses WHAT it wants ("sell 8 kWh in these top slots",
+"charge to 80% by 05:30"); the constructors figure out WHICH inverter
+writes achieve it. See §13 of the design.
+
+P1.0 stub: methods raise NotImplementedError. Full implementation in P1.9.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from .compute import RateWindow, TimeRange
+from .types import PlannedAction, Snapshot
+
+
+class ActionBuilder:
+    """High-level action constructors. P1.9."""
+
+    # ── 13a. Energy actions ───────────────────────────────────────
+
+    def sell_kwh(
+        self,
+        *,
+        total_kwh: float,
+        across_slots: list[RateWindow],
+        snap: Snapshot,
+    ) -> PlannedAction:
+        raise NotImplementedError("P1.9 — ActionBuilder.sell_kwh")
+
+    def charge_to(
+        self,
+        *,
+        target_soc_pct: float,
+        by: datetime,
+        snap: Snapshot,
+        rate_limit_a: float | None = None,
+    ) -> PlannedAction:
+        raise NotImplementedError("P1.9 — ActionBuilder.charge_to")
+
+    def hold_at(
+        self,
+        *,
+        soc_pct: float,
+        window: TimeRange,
+        snap: Snapshot,
+    ) -> PlannedAction:
+        raise NotImplementedError("P1.9 — ActionBuilder.hold_at")
+
+    def drain_to(
+        self,
+        *,
+        target_soc_pct: float,
+        by: datetime,
+        snap: Snapshot,
+    ) -> PlannedAction:
+        raise NotImplementedError("P1.9 — ActionBuilder.drain_to")
+
+    # ── 13b. Mode actions ─────────────────────────────────────────
+
+    def lockdown_eps(self, snap: Snapshot) -> PlannedAction:
+        """SPEC H3: grid down. All slots cap=0%, gc=False. EV stop.
+        Appliance switches off. Coordinator triggers this on
+        eps_active transition.
+        """
+        raise NotImplementedError("P1.9 — ActionBuilder.lockdown_eps")
+
+    def baseline_static(self, snap: Snapshot) -> PlannedAction:
+        """The known-good static plan: 80% overnight charge, day hold
+        at 100%, evening drain to 25%, no arbitrage. Used by the
+        cutover script (P1.11) and as the planner's fallback.
+        """
+        raise NotImplementedError("P1.9 — ActionBuilder.baseline_static")
+
+    def restore_default(self, snap: Snapshot) -> PlannedAction:
+        raise NotImplementedError("P1.9 — ActionBuilder.restore_default")
+
+    # ── 13c. Peripheral actions ───────────────────────────────────
+
+    def defer_ev(self, snap: Snapshot) -> PlannedAction:
+        raise NotImplementedError("P1.9 — ActionBuilder.defer_ev")
+
+    def restore_ev(self, snap: Snapshot) -> PlannedAction:
+        raise NotImplementedError("P1.9 — ActionBuilder.restore_ev")
+
+    # ── 13d. Composition ──────────────────────────────────────────
+
+    def merge(self, *actions: PlannedAction) -> PlannedAction:
+        """Field-by-field reconciliation:
+        - Slot fields: union, last-write-wins on conflicts (with warning).
+        - Globals: same.
+        - Peripheral actions: must agree or merge raises.
+        """
+        raise NotImplementedError("P1.9 — ActionBuilder.merge")

--- a/custom_components/heo3/compute.py
+++ b/custom_components/heo3/compute.py
@@ -1,0 +1,203 @@
+"""Compute — pure-function library over a Snapshot.
+
+Five families per §12 of the design:
+- Energy / SOC / kWh conversions
+- Time / rate windows
+- Forecast aggregation
+- Counterfactual analysis (visibility / dashboard)
+- Physics predictions
+
+Stateless. Every method takes a Snapshot (or relevant subset) plus
+parameters; returns a value. No I/O. Safe to call from anywhere.
+
+P1.0 stub: methods raise NotImplementedError. Full implementation
+in P1.8.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+
+from .types import PlannedAction, Snapshot
+
+
+@dataclass(frozen=True)
+class TimeRange:
+    start: datetime
+    end: datetime
+
+
+@dataclass(frozen=True)
+class RateWindow:
+    start: datetime
+    end: datetime
+    rate_pence: float
+    avg_rate_pence: float
+
+
+class RateBand:
+    PEAK = "peak"
+    OFF_PEAK = "off_peak"
+    CHEAP_WINDOW = "cheap_window"
+
+
+class Compute:
+    """Stateless library of derived calculations. P1.8."""
+
+    # ── 12a. Energy / SOC / kWh conversions ───────────────────────
+
+    def kwh_for_soc(self, soc_pct: float, snap: Snapshot) -> float:
+        raise NotImplementedError("P1.8 — Compute.kwh_for_soc")
+
+    def soc_for_kwh(self, kwh: float, snap: Snapshot) -> float:
+        raise NotImplementedError("P1.8 — Compute.soc_for_kwh")
+
+    def usable_kwh(self, snap: Snapshot) -> float:
+        raise NotImplementedError("P1.8 — Compute.usable_kwh")
+
+    def headroom_kwh(self, snap: Snapshot) -> float:
+        """Energy capacity remaining for charging: from current SOC to
+        100%. The hardware has no global SOC ceiling — if the planner
+        wants one, it tracks it in policy and throttles charge current
+        when SOC reaches its chosen cap (write max_charge_a=1 for
+        trickle, =0 for hard freeze).
+        """
+        raise NotImplementedError("P1.8 — Compute.headroom_kwh")
+
+    def round_trip_efficiency(self) -> float:
+        raise NotImplementedError("P1.8 — Compute.round_trip_efficiency")
+
+    # ── 12b. Time / rate windows ──────────────────────────────────
+
+    def next_cheap_window(
+        self, snap: Snapshot, *, after: datetime | None = None
+    ) -> RateWindow | None:
+        raise NotImplementedError("P1.8 — Compute.next_cheap_window")
+
+    def next_peak_window(
+        self, snap: Snapshot, *, after: datetime | None = None
+    ) -> RateWindow | None:
+        raise NotImplementedError("P1.8 — Compute.next_peak_window")
+
+    def time_until(self, target: datetime, snap: Snapshot) -> timedelta:
+        raise NotImplementedError("P1.8 — Compute.time_until")
+
+    def top_export_windows(
+        self,
+        snap: Snapshot,
+        *,
+        n: int = 3,
+        until: datetime | None = None,
+    ) -> list[RateWindow]:
+        raise NotImplementedError("P1.8 — Compute.top_export_windows")
+
+    def cheap_window_duration(self, window: RateWindow) -> timedelta:
+        raise NotImplementedError("P1.8 — Compute.cheap_window_duration")
+
+    # ── 12c. Forecast aggregation ─────────────────────────────────
+
+    def total_load(self, snap: Snapshot, window: TimeRange) -> float:
+        raise NotImplementedError("P1.8 — Compute.total_load")
+
+    def total_solar(self, snap: Snapshot, window: TimeRange) -> float:
+        raise NotImplementedError("P1.8 — Compute.total_solar")
+
+    def net_load(self, snap: Snapshot, window: TimeRange) -> float:
+        raise NotImplementedError("P1.8 — Compute.net_load")
+
+    def cumulative_load_to(self, snap: Snapshot, target: datetime) -> float:
+        raise NotImplementedError("P1.8 — Compute.cumulative_load_to")
+
+    def cumulative_solar_to(self, snap: Snapshot, target: datetime) -> float:
+        raise NotImplementedError("P1.8 — Compute.cumulative_solar_to")
+
+    def bridge_kwh(
+        self, snap: Snapshot, *, until: datetime | None = None
+    ) -> float:
+        """Net energy the battery must supply to bridge from now to
+        `until` (default: next cheap window). Floor at zero.
+        THE 2026-05-08 KEY METRIC.
+        """
+        raise NotImplementedError("P1.8 — Compute.bridge_kwh")
+
+    def pv_takeover_hour(self, snap: Snapshot) -> int | None:
+        raise NotImplementedError("P1.8 — Compute.pv_takeover_hour")
+
+    # ── 12d. Counterfactual analysis ──────────────────────────────
+
+    def usage_at_rate_band(
+        self, snap: Snapshot, window: TimeRange
+    ) -> dict[str, float]:
+        raise NotImplementedError("P1.8 — Compute.usage_at_rate_band")
+
+    def cost_breakdown(
+        self, snap: Snapshot, window: TimeRange
+    ) -> dict[str, float]:
+        raise NotImplementedError("P1.8 — Compute.cost_breakdown")
+
+    def import_volume_under_plan(
+        self, plan: PlannedAction, snap: Snapshot
+    ) -> float:
+        """Counterfactual: if THIS plan ran from now to end of horizon
+        given current forecasts, how much grid import would the plan
+        need? Lets the planner compare candidate plans without writing
+        them. THE OBJECTIVE-FUNCTION BUILDING BLOCK.
+        """
+        raise NotImplementedError("P1.8 — Compute.import_volume_under_plan")
+
+    def export_revenue_under_plan(
+        self, plan: PlannedAction, snap: Snapshot
+    ) -> float:
+        raise NotImplementedError("P1.8 — Compute.export_revenue_under_plan")
+
+    # ── 12e. Physics predictions ──────────────────────────────────
+
+    def time_to_charge(
+        self,
+        *,
+        target_soc_pct: float,
+        charge_rate_kw: float,
+        snap: Snapshot,
+    ) -> timedelta:
+        raise NotImplementedError("P1.8 — Compute.time_to_charge")
+
+    def time_to_discharge(
+        self,
+        *,
+        target_soc_pct: float,
+        discharge_rate_kw: float,
+        snap: Snapshot,
+    ) -> timedelta:
+        raise NotImplementedError("P1.8 — Compute.time_to_discharge")
+
+    def kwh_deliverable_in(
+        self,
+        *,
+        duration: timedelta,
+        throttle_a: float,
+        snap: Snapshot,
+    ) -> float:
+        raise NotImplementedError("P1.8 — Compute.kwh_deliverable_in")
+
+    def discharge_throttle_for(
+        self,
+        *,
+        kwh: float,
+        duration: timedelta,
+        snap: Snapshot,
+    ) -> float:
+        """Inverse of kwh_deliverable_in. Replaces the ad-hoc
+        `kw_for_slot / battery_voltage * 1000` formula scattered across
+        HEO II's PeakArbitrageRule.
+        """
+        raise NotImplementedError("P1.8 — Compute.discharge_throttle_for")
+
+    def charge_throttle_for(
+        self,
+        *,
+        kwh: float,
+        duration: timedelta,
+        snap: Snapshot,
+    ) -> float:
+        raise NotImplementedError("P1.8 — Compute.charge_throttle_for")

--- a/custom_components/heo3/config_flow.py
+++ b/custom_components/heo3/config_flow.py
@@ -1,0 +1,34 @@
+"""Config flow for HEO III — single-step shell for P1.0.
+
+Real wizard (MQTT broker, inverter name, peripheral entity IDs,
+storage path) lands incrementally as the adapter phases need them.
+"""
+
+from __future__ import annotations
+
+import voluptuous as vol
+
+from homeassistant import config_entries
+from homeassistant.const import CONF_HOST, CONF_PORT
+
+from .const import DEFAULT_MQTT_HOST, DEFAULT_MQTT_PORT, DOMAIN
+
+
+class HEO3ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    VERSION = 1
+
+    async def async_step_user(self, user_input: dict | None = None):
+        """Single-step setup: just the SA broker host/port."""
+        if user_input is not None:
+            return self.async_create_entry(
+                title="HEO III",
+                data=user_input,
+            )
+
+        schema = vol.Schema(
+            {
+                vol.Required(CONF_HOST, default=DEFAULT_MQTT_HOST): str,
+                vol.Required(CONF_PORT, default=DEFAULT_MQTT_PORT): int,
+            }
+        )
+        return self.async_show_form(step_id="user", data_schema=schema)

--- a/custom_components/heo3/const.py
+++ b/custom_components/heo3/const.py
@@ -1,0 +1,18 @@
+"""Constants for HEO III integration."""
+
+DOMAIN = "heo3"
+
+# SA MQTT broker defaults (override in config_flow).
+DEFAULT_MQTT_HOST = "192.168.4.7"
+DEFAULT_MQTT_PORT = 1883
+
+# Inverter identity. Per SPEC §2: writes only ever go to inverter 1.
+DEFAULT_INVERTER_NAME = "inverter_1"
+
+# Tick latency budget (§21 resolution).
+TICK_HARD_BUDGET_S = 60.0
+TICK_WARNING_S = 30.0
+
+# Verification cycle (§16).
+WRITE_RETRY_LIMIT = 3
+WRITE_RETRY_BACKOFF_S = 5.0

--- a/custom_components/heo3/manifest.json
+++ b/custom_components/heo3/manifest.json
@@ -1,0 +1,11 @@
+{
+    "domain": "heo3",
+    "name": "HEO III — Energy Optimiser",
+    "codeowners": ["@a1acrity"],
+    "config_flow": true,
+    "dependencies": ["mqtt"],
+    "documentation": "https://github.com/a1acrity/heo2/blob/master/docs/HEO_III_DESIGN.md",
+    "iot_class": "local_push",
+    "requirements": ["paho-mqtt>=2.0", "httpx>=0.27"],
+    "version": "0.0.1"
+}

--- a/custom_components/heo3/operator.py
+++ b/custom_components/heo3/operator.py
@@ -1,0 +1,86 @@
+"""The Operator — single point of contact for the planner.
+
+Composes State (Inverter/Peripheral/World adapters → Snapshot),
+Compute (pure derived calculations), Build (intent constructors),
+and Execute (apply). The planner (deferred) talks only to this surface.
+
+P1.0 stub: snapshot() and apply() raise NotImplementedError until the
+adapters are filled in. The compute/build properties return live
+instances (also stubs).
+"""
+
+from __future__ import annotations
+
+from .adapters.inverter import InverterAdapter
+from .adapters.peripheral import PeripheralAdapter
+from .adapters.world import WorldGatherer
+from .build import ActionBuilder
+from .compute import Compute
+from .const import DEFAULT_INVERTER_NAME
+from .transport import Transport
+from .types import ApplyResult, PlannedAction, Snapshot
+
+
+class Operator:
+    """The mechanical layer. Zero economic opinions. §3."""
+
+    def __init__(
+        self,
+        *,
+        transport: Transport,
+        hass=None,  # type: ignore[no-untyped-def]
+        inverter_name: str = DEFAULT_INVERTER_NAME,
+        zappi_charge_mode_entity: str = "select.zappi_charge_mode",
+        tesla_entity_prefix: str | None = None,
+        appliance_switches: dict[str, str] | None = None,
+    ) -> None:
+        self._transport = transport
+        self._hass = hass
+
+        self._inverter = InverterAdapter(
+            transport=transport, inverter_name=inverter_name
+        )
+        self._peripheral = PeripheralAdapter(
+            zappi_charge_mode_entity=zappi_charge_mode_entity,
+            tesla_entity_prefix=tesla_entity_prefix,
+            appliance_switches=appliance_switches or {},
+        )
+        self._world = WorldGatherer(hass=hass)
+
+        self._compute = Compute()
+        self._build = ActionBuilder()
+
+    # ── State ─────────────────────────────────────────────────────
+
+    async def snapshot(self) -> Snapshot:
+        """Gather complete frozen state: inverter + peripherals +
+        world. Single call returns everything for one planner tick.
+        Adapters are awaited concurrently in P1.7.
+        """
+        raise NotImplementedError("P1.7 — Snapshot integration")
+
+    # ── Derived facts ─────────────────────────────────────────────
+
+    @property
+    def compute(self) -> Compute:
+        return self._compute
+
+    # ── Action construction ───────────────────────────────────────
+
+    @property
+    def build(self) -> ActionBuilder:
+        return self._build
+
+    # ── Execution ─────────────────────────────────────────────────
+
+    async def apply(self, action: PlannedAction) -> ApplyResult:
+        """Mechanically execute a planned action: inverter writes,
+        peripheral changes. Verifies and reports per-write outcome.
+        Refuses if SPEC H4 / H3 / dry_run / disconnected (§16).
+        Hard cap: 60s per call (§21 resolution).
+        """
+        raise NotImplementedError("P1.1 — apply() execution loop")
+
+    async def shutdown(self) -> None:
+        """Graceful close: MQTT disconnect, pending verifications cancelled."""
+        await self._transport.disconnect()

--- a/custom_components/heo3/strings.json
+++ b/custom_components/heo3/strings.json
@@ -1,0 +1,14 @@
+{
+    "config": {
+        "step": {
+            "user": {
+                "title": "HEO III — SA broker",
+                "description": "Solar Assistant MQTT broker host and port.",
+                "data": {
+                    "host": "MQTT host",
+                    "port": "MQTT port"
+                }
+            }
+        }
+    }
+}

--- a/custom_components/heo3/transport.py
+++ b/custom_components/heo3/transport.py
@@ -1,0 +1,107 @@
+"""MQTT transport abstraction.
+
+Defines the Transport Protocol the InverterAdapter writes against,
+plus a MockTransport for tests. The real paho-based implementation
+lands in P1.1; only the protocol shape and mock are needed for P1.0.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from typing import Awaitable, Callable, Protocol
+
+
+@dataclass(frozen=True)
+class PublishedMessage:
+    topic: str
+    payload: str
+
+
+class Transport(Protocol):
+    """What the InverterAdapter expects from any transport."""
+
+    async def connect(self) -> None: ...
+
+    async def disconnect(self) -> None: ...
+
+    async def publish(self, topic: str, payload: str) -> None: ...
+
+    async def subscribe(
+        self,
+        topic: str,
+        handler: Callable[[str, str], Awaitable[None]],
+    ) -> None: ...
+
+    @property
+    def is_connected(self) -> bool: ...
+
+
+class MockTransport:
+    """Records publishes; lets tests inject inbound messages.
+
+    Use in unit tests to assert the adapter sends the right topic +
+    payload sequence and to simulate SA's `set/response_message/state`
+    replies. Per `feedback_dry_run.md`, do NOT test the writer via
+    dry_run — use this mock instead.
+    """
+
+    def __init__(self) -> None:
+        self.published: list[PublishedMessage] = []
+        self._subscriptions: dict[str, list[Callable[[str, str], Awaitable[None]]]] = (
+            {}
+        )
+        self._connected = False
+
+    async def connect(self) -> None:
+        self._connected = True
+
+    async def disconnect(self) -> None:
+        self._connected = False
+
+    async def publish(self, topic: str, payload: str) -> None:
+        if not self._connected:
+            raise RuntimeError("MockTransport.publish before connect()")
+        self.published.append(PublishedMessage(topic=topic, payload=payload))
+
+    async def subscribe(
+        self,
+        topic: str,
+        handler: Callable[[str, str], Awaitable[None]],
+    ) -> None:
+        self._subscriptions.setdefault(topic, []).append(handler)
+
+    @property
+    def is_connected(self) -> bool:
+        return self._connected
+
+    # ── test injection ────────────────────────────────────────────
+
+    async def inject(self, topic: str, payload: str) -> None:
+        """Simulate an inbound MQTT message. Awaits all handlers."""
+        for sub_topic, handlers in self._subscriptions.items():
+            if _topic_matches(sub_topic, topic):
+                for h in handlers:
+                    await h(topic, payload)
+
+    def clear(self) -> None:
+        self.published.clear()
+
+
+def _topic_matches(subscription: str, topic: str) -> bool:
+    """MQTT wildcard matcher: + (single level) and # (multi-level).
+
+    Minimal implementation — enough for the SA topics we subscribe to.
+    """
+    sub_parts = subscription.split("/")
+    top_parts = topic.split("/")
+    for i, sp in enumerate(sub_parts):
+        if sp == "#":
+            return True
+        if i >= len(top_parts):
+            return False
+        if sp == "+":
+            continue
+        if sp != top_parts[i]:
+            return False
+    return len(sub_parts) == len(top_parts)

--- a/custom_components/heo3/types.py
+++ b/custom_components/heo3/types.py
@@ -1,0 +1,214 @@
+"""HEO III type definitions.
+
+Snapshot, PlannedAction, ApplyResult and the nested dataclasses they
+compose. Top-level shapes are defined here per §11/§14 of the design;
+nested types are placeholders until the adapter phases (P1.1-P1.6)
+fill them in. Frozen so the planner cannot accidentally mutate state.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+
+# ── Inverter ────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class InverterState:
+    """Live telemetry snapshot. Filled in P1.2."""
+
+
+@dataclass(frozen=True)
+class InverterSettings:
+    """Current values of writable inverter settings. Filled in P1.2."""
+
+
+# ── Peripherals ─────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class EVState:
+    """Zappi state. Filled in P1.3."""
+
+
+@dataclass(frozen=True)
+class TeslaState:
+    """Tesla state via Teslemetry. Filled in P1.3.
+
+    Gated by `located_at_home` — operator suppresses commands when off.
+    """
+
+
+@dataclass(frozen=True)
+class ApplianceState:
+    """Washer / dryer / dishwasher running flags. Filled in P1.3."""
+
+
+# ── World ───────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class LiveRates:
+    """BD import/export rates today + tomorrow. Filled in P1.4."""
+
+
+@dataclass(frozen=True)
+class PredictedRates:
+    """AgilePredict 7-day forward (visualisation only). Filled in P1.4."""
+
+
+@dataclass(frozen=True)
+class SolarForecast:
+    """Solcast P10/P50/P90 today + tomorrow. Filled in P1.5."""
+
+
+@dataclass(frozen=True)
+class LoadForecast:
+    """HEO-5 model output today + tomorrow. Filled in P1.5."""
+
+
+@dataclass(frozen=True)
+class SystemFlags:
+    """eps_active, igo_dispatching, saving_session, etc. Filled in P1.6."""
+
+
+@dataclass(frozen=True)
+class SystemConfig:
+    """Runtime tunables: min_soc, cycle_budget, target_end_soc."""
+
+    min_soc: int = 10
+    cycle_budget: float = 1.0
+    target_end_soc: int = 25
+
+
+# ── Snapshot ────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class Snapshot:
+    """Frozen state — what the world IS right now. §11."""
+
+    captured_at: datetime
+    local_tz: ZoneInfo
+
+    inverter: InverterState
+    inverter_settings: InverterSettings
+
+    ev: EVState
+    tesla: TeslaState | None
+    appliances: ApplianceState
+
+    rates_live: LiveRates
+    rates_predicted: PredictedRates
+    rates_freshness: dict[str, datetime]
+
+    solar_forecast: SolarForecast
+    load_forecast: LoadForecast
+
+    flags: SystemFlags
+
+    config: SystemConfig
+
+
+# ── PlannedAction ───────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class SlotPlan:
+    """One inverter timer slot (1..6). Filled in P1.1."""
+
+    slot_n: int
+    start_hhmm: str | None = None
+    grid_charge: bool | None = None
+    capacity_pct: int | None = None
+
+
+@dataclass(frozen=True)
+class EVAction:
+    """Zappi-side intent. Filled in P1.3."""
+
+
+@dataclass(frozen=True)
+class TeslaAction:
+    """Tesla-side intent: stop/start, charge_limit, charge_current. P1.3."""
+
+
+@dataclass(frozen=True)
+class ApplianceAction:
+    """Which appliances to turn off/on. Filled in P1.3."""
+
+
+@dataclass(frozen=True)
+class PlannedAction:
+    """The planner's output. §14.
+
+    `Optional` fields = "don't touch this dimension". The operator
+    diffs; absent fields produce no writes.
+    """
+
+    slots: tuple[SlotPlan, ...] = ()
+    work_mode: str | None = None
+    energy_pattern: str | None = None
+    max_charge_a: float | None = None
+    max_discharge_a: float | None = None
+
+    ev_action: EVAction | None = None
+    tesla_action: TeslaAction | None = None
+    appliances_action: ApplianceAction | None = None
+
+    plan_id: str = ""
+    rationale: str = ""
+    source_planner_version: str = ""
+
+    spec_h4_live_rates: bool = False
+    spec_h5_validated: bool = False
+
+
+# ── ApplyResult ─────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class Write:
+    """One MQTT publish (or HA service call). Filled in P1.1."""
+
+    topic: str
+    payload: str
+
+
+@dataclass(frozen=True)
+class FailedWrite:
+    """A write that did not land. Filled in P1.1."""
+
+    write: Write
+    reason: str
+
+
+@dataclass(frozen=True)
+class SkippedWrite:
+    """Diff said the write was a no-op. Filled in P1.1."""
+
+    write: Write
+
+
+@dataclass(frozen=True)
+class VerificationResult:
+    """Per-write verification outcome. Filled in P1.1."""
+
+    states: dict[str, str] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class ApplyResult:
+    """What happened during apply(). §15."""
+
+    plan_id: str
+    requested: tuple[Write, ...]
+    succeeded: tuple[Write, ...]
+    failed: tuple[FailedWrite, ...]
+    skipped: tuple[SkippedWrite, ...]
+    verification: VerificationResult
+    duration_ms: float
+    captured_at: datetime

--- a/tests/test_heo3_mock_transport.py
+++ b/tests/test_heo3_mock_transport.py
@@ -1,0 +1,120 @@
+"""Tests for the MockTransport.
+
+Per `feedback_dry_run.md`: do NOT test the writer via dry_run — use
+this mock instead. These tests pin the mock's contract so future
+adapter tests can rely on it.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from heo3.transport import MockTransport, _topic_matches
+
+
+class TestPublish:
+    @pytest.mark.asyncio
+    async def test_records_publishes(self):
+        t = MockTransport()
+        await t.connect()
+        await t.publish("foo/bar", "value1")
+        await t.publish("foo/baz", "value2")
+        assert len(t.published) == 2
+        assert t.published[0].topic == "foo/bar"
+        assert t.published[0].payload == "value1"
+        assert t.published[1].payload == "value2"
+
+    @pytest.mark.asyncio
+    async def test_publish_before_connect_raises(self):
+        t = MockTransport()
+        with pytest.raises(RuntimeError, match="before connect"):
+            await t.publish("foo", "bar")
+
+    @pytest.mark.asyncio
+    async def test_clear(self):
+        t = MockTransport()
+        await t.connect()
+        await t.publish("a", "b")
+        t.clear()
+        assert t.published == []
+
+
+class TestSubscribeAndInject:
+    @pytest.mark.asyncio
+    async def test_inject_calls_handler(self):
+        t = MockTransport()
+        received: list[tuple[str, str]] = []
+
+        async def handler(topic: str, payload: str) -> None:
+            received.append((topic, payload))
+
+        await t.subscribe("response/+", handler)
+        await t.inject("response/state", "Saved")
+        assert received == [("response/state", "Saved")]
+
+    @pytest.mark.asyncio
+    async def test_inject_to_unsubscribed_topic_is_silent(self):
+        t = MockTransport()
+        received: list[tuple[str, str]] = []
+
+        async def handler(topic: str, payload: str) -> None:
+            received.append((topic, payload))
+
+        await t.subscribe("foo/+", handler)
+        await t.inject("bar/state", "ignored")
+        assert received == []
+
+    @pytest.mark.asyncio
+    async def test_multiple_handlers_per_topic(self):
+        t = MockTransport()
+        calls: list[str] = []
+
+        async def h1(topic: str, payload: str) -> None:
+            calls.append(f"h1:{payload}")
+
+        async def h2(topic: str, payload: str) -> None:
+            calls.append(f"h2:{payload}")
+
+        await t.subscribe("x/y", h1)
+        await t.subscribe("x/y", h2)
+        await t.inject("x/y", "v")
+        assert calls == ["h1:v", "h2:v"]
+
+
+class TestConnectionState:
+    @pytest.mark.asyncio
+    async def test_default_disconnected(self):
+        assert MockTransport().is_connected is False
+
+    @pytest.mark.asyncio
+    async def test_connect_disconnect_cycle(self):
+        t = MockTransport()
+        await t.connect()
+        assert t.is_connected is True
+        await t.disconnect()
+        assert t.is_connected is False
+
+
+class TestTopicMatcher:
+    """Pin the wildcard semantics — tests for SA-style topics."""
+
+    def test_exact_match(self):
+        assert _topic_matches("solar_assistant/inverter_1/x", "solar_assistant/inverter_1/x")
+
+    def test_no_match_different_levels(self):
+        assert not _topic_matches("solar_assistant/inverter_1/x", "solar_assistant/inverter_1/y")
+
+    def test_plus_wildcard_single_level(self):
+        assert _topic_matches("solar_assistant/+/state", "solar_assistant/inverter_1/state")
+        assert not _topic_matches("solar_assistant/+/state", "solar_assistant/inverter_1/sub/state")
+
+    def test_hash_wildcard_multi_level(self):
+        assert _topic_matches("solar_assistant/#", "solar_assistant/inverter_1/state")
+        assert _topic_matches("solar_assistant/#", "solar_assistant/x/y/z")
+
+    def test_response_topic_pattern(self):
+        # The exact pattern HEO III subscribes to per §16.
+        assert _topic_matches(
+            "solar_assistant/set/response_message/state",
+            "solar_assistant/set/response_message/state",
+        )

--- a/tests/test_heo3_skeleton.py
+++ b/tests/test_heo3_skeleton.py
@@ -1,0 +1,159 @@
+"""P1.0 skeleton smoke tests.
+
+Confirm the package imports cleanly, the Operator class wires its
+sub-components, and the type surface from §11/§14 is reachable.
+The stubs themselves raise NotImplementedError — that's expected.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from heo3 import const
+from heo3.adapters.inverter import InverterAdapter
+from heo3.adapters.peripheral import PeripheralAdapter
+from heo3.adapters.world import WorldGatherer
+from heo3.build import ActionBuilder
+from heo3.compute import Compute
+from heo3.operator import Operator
+from heo3.transport import MockTransport
+from heo3.types import (
+    ApplianceState,
+    ApplyResult,
+    EVState,
+    InverterSettings,
+    InverterState,
+    LiveRates,
+    LoadForecast,
+    PlannedAction,
+    PredictedRates,
+    SlotPlan,
+    Snapshot,
+    SolarForecast,
+    SystemConfig,
+    SystemFlags,
+    TeslaState,
+)
+
+
+class TestPackageImports:
+    def test_domain_constant(self):
+        assert const.DOMAIN == "heo3"
+
+    def test_tick_budget_constants_present(self):
+        assert const.TICK_HARD_BUDGET_S == 60.0
+        assert const.TICK_WARNING_S == 30.0
+
+
+class TestOperatorWiring:
+    def test_operator_constructs_with_mock_transport(self):
+        op = Operator(transport=MockTransport())
+        assert isinstance(op.compute, Compute)
+        assert isinstance(op.build, ActionBuilder)
+
+    def test_operator_holds_three_adapters(self):
+        op = Operator(transport=MockTransport())
+        assert isinstance(op._inverter, InverterAdapter)
+        assert isinstance(op._peripheral, PeripheralAdapter)
+        assert isinstance(op._world, WorldGatherer)
+
+    @pytest.mark.asyncio
+    async def test_shutdown_disconnects_transport(self):
+        transport = MockTransport()
+        await transport.connect()
+        op = Operator(transport=transport)
+        assert transport.is_connected is True
+        await op.shutdown()
+        assert transport.is_connected is False
+
+    @pytest.mark.asyncio
+    async def test_snapshot_stub_raises(self):
+        op = Operator(transport=MockTransport())
+        with pytest.raises(NotImplementedError, match="P1.7"):
+            await op.snapshot()
+
+    @pytest.mark.asyncio
+    async def test_apply_stub_raises(self):
+        op = Operator(transport=MockTransport())
+        with pytest.raises(NotImplementedError, match="P1.1"):
+            await op.apply(PlannedAction())
+
+
+class TestTypeSurface:
+    """The dataclasses are reachable and constructible. Phase
+    placeholders (InverterState etc.) take no args yet — they get
+    fields filled in during the adapter phases."""
+
+    def test_planned_action_default_is_no_op(self):
+        action = PlannedAction()
+        assert action.slots == ()
+        assert action.work_mode is None
+        assert action.max_charge_a is None
+        assert action.tesla_action is None
+
+    def test_planned_action_is_frozen(self):
+        action = PlannedAction()
+        with pytest.raises(Exception):  # FrozenInstanceError
+            action.work_mode = "Selling first"  # type: ignore[misc]
+
+    def test_slot_plan_optional_fields(self):
+        slot = SlotPlan(slot_n=1)
+        assert slot.start_hhmm is None
+        assert slot.grid_charge is None
+
+    def test_snapshot_construct(self):
+        snap = Snapshot(
+            captured_at=datetime(2026, 5, 10, 18, 0, tzinfo=timezone.utc),
+            local_tz=ZoneInfo("Europe/London"),
+            inverter=InverterState(),
+            inverter_settings=InverterSettings(),
+            ev=EVState(),
+            tesla=TeslaState(),
+            appliances=ApplianceState(),
+            rates_live=LiveRates(),
+            rates_predicted=PredictedRates(),
+            rates_freshness={},
+            solar_forecast=SolarForecast(),
+            load_forecast=LoadForecast(),
+            flags=SystemFlags(),
+            config=SystemConfig(),
+        )
+        assert snap.config.min_soc == 10
+        assert snap.tesla is not None
+
+    def test_snapshot_tesla_is_optional(self):
+        snap = Snapshot(
+            captured_at=datetime(2026, 5, 10, 18, 0, tzinfo=timezone.utc),
+            local_tz=ZoneInfo("Europe/London"),
+            inverter=InverterState(),
+            inverter_settings=InverterSettings(),
+            ev=EVState(),
+            tesla=None,
+            appliances=ApplianceState(),
+            rates_live=LiveRates(),
+            rates_predicted=PredictedRates(),
+            rates_freshness={},
+            solar_forecast=SolarForecast(),
+            load_forecast=LoadForecast(),
+            flags=SystemFlags(),
+            config=SystemConfig(),
+        )
+        assert snap.tesla is None
+
+    def test_apply_result_construct(self):
+        from heo3.types import VerificationResult
+
+        result = ApplyResult(
+            plan_id="test",
+            requested=(),
+            succeeded=(),
+            failed=(),
+            skipped=(),
+            verification=VerificationResult(),
+            duration_ms=0.0,
+            captured_at=datetime(2026, 5, 10, tzinfo=timezone.utc),
+        )
+        assert result.duration_ms == 0.0


### PR DESCRIPTION
## Summary

First build phase of HEO III, against the design landing in #76. Tracking issue #75.

This PR is **scoped to P1.0 only**: package layout + Operator class with stub methods + MockTransport + config_flow shell. Adapter / Compute / Build implementations come in later phases. The integration loads cleanly in HA but does **no inverter I/O** until P1.1+ fills in the adapters.

Note: this PR targets \`docs/heo3-design\` so its diff shows just the code. Once #76 merges to master, this PR's base will retarget automatically (or can be rebased onto master).

## What's in here

**Package** (\`custom_components/heo3/\`, 14 files):
- \`manifest.json\`, \`const.py\`, \`strings.json\`
- \`types.py\`: \`Snapshot\`, \`PlannedAction\`, \`ApplyResult\` and nested dataclasses per §11/§14 (frozen, modern \`X | None\` syntax). Nested types are placeholders — fields filled in adapter phases.
- \`transport.py\`: \`Transport\` Protocol + \`MockTransport\` (records publishes, lets tests inject inbound messages, MQTT topic-matcher with \`+\`/\`#\` wildcards).
- \`adapters/{inverter,peripheral,world}.py\`: stubs raising \`NotImplementedError(\"P1.X — ...\")\` — anyone calling them gets a pointer to the phase that fills them in.
- \`compute.py\`: \`Compute\` class with five families per §12 (all stubs).
- \`build.py\`: \`ActionBuilder\` per §13 (all stubs).
- \`operator.py\`: wires three adapters + Compute + ActionBuilder. \`snapshot()\`/\`apply()\` raise pointing at their phases. \`shutdown()\` disconnects transport.
- \`__init__.py\`: \`async_setup_entry\` / \`async_unload_entry\` no-ops.
- \`config_flow.py\`: single-step shell asking for SA broker host/port.

**Tests** (26 new, all passing):
- \`test_heo3_skeleton.py\`: package imports, Operator wiring, type-surface contracts (frozen, optional fields, Tesla nullable in Snapshot), stub-raises-with-phase pointer.
- \`test_heo3_mock_transport.py\`: pins MockTransport contract for the adapter tests landing in P1.1+; topic-matcher tests cover SA wildcard patterns.

Per \`feedback_dry_run.md\`: tests use MockTransport, **not** dry_run.

## Verification

- \`pytest tests/test_heo3_skeleton.py tests/test_heo3_mock_transport.py -v\` — 26/26 pass
- Full suite: 552/552 pass (no regression)

## Test plan

- [ ] Read the package layout and challenge anything that doesn't match the design
- [ ] Run the full test suite locally
- [ ] If the integration is loaded in HA, confirm config flow shows the SA broker step (no error) and entry creates cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)