### PR TITLE
feat(heo3): P1.3 — peripheral adapter (zappi + Tesla + appliances)

### DIFF
--- a/custom_components/heo3/adapters/peripheral.py
+++ b/custom_components/heo3/adapters/peripheral.py
@@ -1,54 +1,334 @@
 """Peripheral Adapter — zappi, Tesla (Teslemetry), appliances.
 
-P1.0 stub. Full implementation in P1.3.
+Implements §6 (controls) and §7 (reads) of the design.
+
+Tesla writes are gated on `binary_sensor.<vehicle>_located_at_home`
+being on — the operator silently no-ops commands when the car is
+away rather than queuing them or erroring.
+
+Zappi mode capture: when the planner sets mode=Stopped, the adapter
+captures the previously-read mode so a later restore action can
+write it back. Capture lives in-memory; survives across apply() calls
+within the same Operator instance but not across HA restarts (P1.7
+can promote to persistent storage if needed).
 """
 
 from __future__ import annotations
 
+import logging
+from dataclasses import dataclass
+
+from ..service_caller import ServiceCaller
+from ..state_reader import (
+    StateReader,
+    parse_bool,
+    parse_float,
+    parse_int,
+    parse_str,
+)
 from ..types import (
+    ApplianceAction,
     ApplianceState,
     EVAction,
     EVState,
-    PlannedAction,
     TeslaAction,
     TeslaState,
+    ZAPPI_VALID_MODES,
 )
+
+logger = logging.getLogger(__name__)
+
+
+# Outcome codes the apply_* methods return — the operator records
+# these in ApplyResult so the planner can see what actually happened.
+APPLIED = "APPLIED"
+NO_OP = "NO_OP"  # action had no fields set
+SKIPPED_NOT_AT_HOME = "SKIPPED_NOT_AT_HOME"
+SKIPPED_NO_CONFIG = "SKIPPED_NO_CONFIG"
+SKIPPED_NO_CAPTURED_MODE = "SKIPPED_NO_CAPTURED_MODE"
+FAILED = "FAILED"
+
+
+# ── Config dataclasses ────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class ZappiConfig:
+    charge_mode: str = "select.zappi_charge_mode"
+    charging_state: str = "sensor.zappi_charging_state"
+    charge_power: str = "sensor.zappi_charge_power"
+
+
+@dataclass(frozen=True)
+class TeslaConfig:
+    """Entity IDs for one Tesla via Teslemetry.
+
+    Teslemetry's naming is `<domain>.<vehicle>_<leaf>` — derive the
+    full set from a vehicle short-name with `from_vehicle()`.
+    """
+
+    charge_switch: str
+    battery_level: str
+    charging: str
+    charger_power: str
+    charge_limit: str
+    charge_current: str
+    charge_cable: str
+    located_at_home: str
+
+    @classmethod
+    def from_vehicle(cls, vehicle: str) -> "TeslaConfig":
+        return cls(
+            charge_switch=f"switch.{vehicle}_charge",
+            battery_level=f"sensor.{vehicle}_battery_level",
+            charging=f"sensor.{vehicle}_charging",
+            charger_power=f"sensor.{vehicle}_charger_power",
+            charge_limit=f"number.{vehicle}_charge_limit",
+            charge_current=f"number.{vehicle}_charge_current",
+            charge_cable=f"binary_sensor.{vehicle}_charge_cable",
+            located_at_home=f"binary_sensor.{vehicle}_located_at_home",
+        )
+
+
+# ── Adapter ───────────────────────────────────────────────────────
 
 
 class PeripheralAdapter:
-    """HA service calls + reads for non-inverter equipment.
-
-    Tesla writes are gated on `binary_sensor.<vehicle>_located_at_home`
-    being `on` — the operator suppresses commands when the car is away
-    rather than letting them queue or error.
-    """
+    """HA service calls + reads for non-inverter equipment."""
 
     def __init__(
         self,
-        zappi_charge_mode_entity: str,
-        tesla_entity_prefix: str | None,
-        appliance_switches: dict[str, str],
+        *,
+        state_reader: StateReader | None = None,
+        service_caller: ServiceCaller | None = None,
+        # zappi
+        zappi_charge_mode_entity: str = "select.zappi_charge_mode",
+        zappi_config: ZappiConfig | None = None,
+        # tesla
+        tesla_entity_prefix: str | None = None,
+        tesla_config: TeslaConfig | None = None,
+        # appliances: name → entity_id (e.g. "washer" → "switch.washer")
+        # Reads use the same map; running flags assumed to live on
+        # binary_sensor.<name>_running by default.
+        appliance_switches: dict[str, str] | None = None,
+        appliance_running_sensors: dict[str, str] | None = None,
     ) -> None:
-        self._zappi_charge_mode_entity = zappi_charge_mode_entity
-        self._tesla_entity_prefix = tesla_entity_prefix
-        self._appliance_switches = appliance_switches
+        self._state_reader = state_reader
+        self._service_caller = service_caller
+
+        # Zappi: prefer explicit config; fall back to charge_mode entity
+        # arg (legacy P1.0 shape) plus defaults.
+        if zappi_config is not None:
+            self._zappi = zappi_config
+        else:
+            self._zappi = ZappiConfig(charge_mode=zappi_charge_mode_entity)
+
+        # Tesla: prefer explicit config; else derive from vehicle prefix;
+        # else None means Tesla is not configured.
+        if tesla_config is not None:
+            self._tesla: TeslaConfig | None = tesla_config
+        elif tesla_entity_prefix is not None:
+            self._tesla = TeslaConfig.from_vehicle(tesla_entity_prefix)
+        else:
+            self._tesla = None
+
+        self._appliance_switches = dict(appliance_switches or {})
+        if appliance_running_sensors is not None:
+            self._appliance_running = dict(appliance_running_sensors)
+        else:
+            # Default convention: switch.washer → binary_sensor.washer_running
+            self._appliance_running = {
+                name: f"binary_sensor.{name}_running"
+                for name in self._appliance_switches
+            }
+
+        # In-memory captured pre-stop EV mode for restore_previous.
+        self._captured_ev_mode: str | None = None
+
+    # ── Reads ─────────────────────────────────────────────────────
 
     async def read_ev(self) -> EVState:
-        raise NotImplementedError("P1.3 — Peripheral Adapter reads")
+        if self._state_reader is None:
+            return EVState()
+        r = self._state_reader
+        charging_raw = parse_str(r.get_state(self._zappi.charging_state))
+        return EVState(
+            charging=(
+                charging_raw is not None
+                and charging_raw.strip().lower() == "charging"
+            ),
+            mode=parse_str(r.get_state(self._zappi.charge_mode)),
+            charge_power_w=parse_float(r.get_state(self._zappi.charge_power)),
+        )
 
     async def read_tesla(self) -> TeslaState | None:
-        """Returns None if Tesla is not configured."""
-        raise NotImplementedError("P1.3 — Peripheral Adapter reads")
+        """None if Tesla is not configured; otherwise a TeslaState
+        (fields may be None individually if Teslemetry returned
+        unknown — common when the car is asleep)."""
+        if self._tesla is None or self._state_reader is None:
+            return None
+        r = self._state_reader
+        cfg = self._tesla
+        charging_raw = parse_str(r.get_state(cfg.charging))
+        return TeslaState(
+            soc_pct=parse_float(r.get_state(cfg.battery_level)),
+            is_charging=(
+                None
+                if charging_raw is None
+                else charging_raw.strip().lower() == "charging"
+            ),
+            charge_power_w=parse_float(r.get_state(cfg.charger_power)),
+            charge_limit_pct=parse_int(r.get_state(cfg.charge_limit)),
+            charge_current_a=parse_int(r.get_state(cfg.charge_current)),
+            cable_plugged=parse_bool(r.get_state(cfg.charge_cable)),
+            located_at_home=parse_bool(r.get_state(cfg.located_at_home)),
+        )
 
     async def read_appliances(self) -> ApplianceState:
-        raise NotImplementedError("P1.3 — Peripheral Adapter reads")
+        if self._state_reader is None:
+            return ApplianceState()
+        r = self._state_reader
+        return ApplianceState(
+            washer_running=parse_bool(
+                r.get_state(self._appliance_running.get("washer", ""))
+            ),
+            dryer_running=parse_bool(
+                r.get_state(self._appliance_running.get("dryer", ""))
+            ),
+            dishwasher_running=parse_bool(
+                r.get_state(self._appliance_running.get("dishwasher", ""))
+            ),
+        )
 
-    async def apply_ev(self, action: EVAction) -> None:
-        raise NotImplementedError("P1.3 — Peripheral Adapter writes")
+    # ── Writes ────────────────────────────────────────────────────
 
-    async def apply_tesla(self, action: TeslaAction) -> None:
-        """No-op if car is not at home (gating per design §6/§7)."""
-        raise NotImplementedError("P1.3 — Peripheral Adapter writes")
+    async def apply_ev(self, action: EVAction) -> str:
+        """Set zappi mode (or restore previous). Returns outcome code."""
+        if self._service_caller is None:
+            return SKIPPED_NO_CONFIG
 
-    async def apply_appliances(self, action: PlannedAction) -> None:
-        raise NotImplementedError("P1.3 — Peripheral Adapter writes")
+        if action.restore_previous:
+            if self._captured_ev_mode is None:
+                logger.warning("restore_ev requested but no captured mode")
+                return SKIPPED_NO_CAPTURED_MODE
+            target_mode = self._captured_ev_mode
+        elif action.set_mode is not None:
+            if action.set_mode not in ZAPPI_VALID_MODES:
+                logger.error("invalid zappi mode: %r", action.set_mode)
+                return FAILED
+            target_mode = action.set_mode
+            # Capture pre-stop state for later restore.
+            if action.set_mode == "Stopped":
+                current = await self._read_current_ev_mode()
+                if current is not None and current != "Stopped":
+                    self._captured_ev_mode = current
+        else:
+            return NO_OP
+
+        try:
+            await self._service_caller.call(
+                "select",
+                "select_option",
+                self._zappi.charge_mode,
+                option=target_mode,
+            )
+        except Exception as exc:
+            logger.error("apply_ev service call failed: %s", exc)
+            return FAILED
+
+        # If we just restored, clear the capture.
+        if action.restore_previous:
+            self._captured_ev_mode = None
+        return APPLIED
+
+    async def _read_current_ev_mode(self) -> str | None:
+        if self._state_reader is None:
+            return None
+        return parse_str(self._state_reader.get_state(self._zappi.charge_mode))
+
+    async def apply_tesla(self, action: TeslaAction) -> str:
+        """Apply Tesla intent — gated on located_at_home. Returns outcome."""
+        if self._tesla is None or self._service_caller is None:
+            return SKIPPED_NO_CONFIG
+        if (
+            action.set_charging is None
+            and action.set_charge_limit_pct is None
+            and action.set_charge_current_a is None
+        ):
+            return NO_OP
+
+        # Gate: located_at_home must be True. Missing/unknown counts as
+        # "not at home" — we'd rather skip than send commands to a car
+        # that might not receive them.
+        if self._state_reader is None:
+            return SKIPPED_NO_CONFIG
+        at_home = parse_bool(
+            self._state_reader.get_state(self._tesla.located_at_home)
+        )
+        if at_home is not True:
+            logger.info(
+                "Tesla command skipped: located_at_home=%s",
+                at_home,
+            )
+            return SKIPPED_NOT_AT_HOME
+
+        try:
+            if action.set_charging is True:
+                await self._service_caller.call(
+                    "switch", "turn_on", self._tesla.charge_switch
+                )
+            elif action.set_charging is False:
+                await self._service_caller.call(
+                    "switch", "turn_off", self._tesla.charge_switch
+                )
+
+            if action.set_charge_limit_pct is not None:
+                await self._service_caller.call(
+                    "number",
+                    "set_value",
+                    self._tesla.charge_limit,
+                    value=float(action.set_charge_limit_pct),
+                )
+
+            if action.set_charge_current_a is not None:
+                await self._service_caller.call(
+                    "number",
+                    "set_value",
+                    self._tesla.charge_current,
+                    value=float(action.set_charge_current_a),
+                )
+        except Exception as exc:
+            logger.error("apply_tesla service call failed: %s", exc)
+            return FAILED
+
+        return APPLIED
+
+    async def apply_appliances(self, action: ApplianceAction) -> str:
+        """Turn appliances on/off via the configured switches."""
+        if self._service_caller is None:
+            return SKIPPED_NO_CONFIG
+        if not action.turn_off and not action.turn_on:
+            return NO_OP
+
+        try:
+            for name in action.turn_off:
+                entity = self._appliance_switches.get(name)
+                if entity is None:
+                    logger.warning("appliance %r not configured; skip", name)
+                    continue
+                await self._service_caller.call(
+                    "switch", "turn_off", entity
+                )
+            for name in action.turn_on:
+                entity = self._appliance_switches.get(name)
+                if entity is None:
+                    logger.warning("appliance %r not configured; skip", name)
+                    continue
+                await self._service_caller.call(
+                    "switch", "turn_on", entity
+                )
+        except Exception as exc:
+            logger.error("apply_appliances service call failed: %s", exc)
+            return FAILED
+
+        return APPLIED

--- a/custom_components/heo3/operator.py
+++ b/custom_components/heo3/operator.py
@@ -22,7 +22,12 @@ from .adapters.inverter import (
     VERIFY_TIMEOUT,
 )
 from .adapters.inverter_validate import SafetyError
-from .adapters.peripheral import PeripheralAdapter
+from .adapters.peripheral import (
+    NO_OP as PERIPHERAL_NO_OP,
+    PeripheralAdapter,
+    TeslaConfig,
+    ZappiConfig,
+)
 from .adapters.world import WorldGatherer
 from .build import ActionBuilder
 from .compute import Compute
@@ -31,6 +36,7 @@ from .const import (
     TICK_HARD_BUDGET_S,
     TICK_WARNING_S,
 )
+from .service_caller import ServiceCaller
 from .state_reader import StateReader
 from .transport import Transport
 from .types import (
@@ -55,15 +61,20 @@ class Operator:
         transport: Transport,
         hass=None,  # type: ignore[no-untyped-def]
         state_reader: StateReader | None = None,
+        service_caller: ServiceCaller | None = None,
         inverter_name: str = DEFAULT_INVERTER_NAME,
         inverter_sensor_prefix: str | None = None,
+        zappi_config: ZappiConfig | None = None,
         zappi_charge_mode_entity: str = "select.zappi_charge_mode",
+        tesla_config: TeslaConfig | None = None,
         tesla_entity_prefix: str | None = None,
         appliance_switches: dict[str, str] | None = None,
+        appliance_running_sensors: dict[str, str] | None = None,
     ) -> None:
         self._transport = transport
         self._hass = hass
         self._state_reader = state_reader
+        self._service_caller = service_caller
 
         self._inverter = InverterAdapter(
             transport=transport,
@@ -72,9 +83,14 @@ class Operator:
             sensor_prefix=inverter_sensor_prefix,
         )
         self._peripheral = PeripheralAdapter(
+            state_reader=state_reader,
+            service_caller=service_caller,
             zappi_charge_mode_entity=zappi_charge_mode_entity,
+            zappi_config=zappi_config,
+            tesla_config=tesla_config,
             tesla_entity_prefix=tesla_entity_prefix,
-            appliance_switches=appliance_switches or {},
+            appliance_switches=appliance_switches,
+            appliance_running_sensors=appliance_running_sensors,
         )
         self._world = WorldGatherer(hass=hass)
 
@@ -155,10 +171,18 @@ class Operator:
         succeeded: list[Write] = []
         failed: list[FailedWrite] = []
         verify_states: dict[str, str] = {}
+        peripheral_outcomes: dict[str, str] = {}
 
         try:
             await asyncio.wait_for(
-                self._execute_writes(writes, succeeded, failed, verify_states),
+                self._execute_all(
+                    writes,
+                    action,
+                    succeeded,
+                    failed,
+                    verify_states,
+                    peripheral_outcomes,
+                ),
                 timeout=TICK_HARD_BUDGET_S,
             )
         except asyncio.TimeoutError:
@@ -166,7 +190,6 @@ class Operator:
                 "apply() exceeded hard budget %ds — aborting tick",
                 TICK_HARD_BUDGET_S,
             )
-            # Record the writes that hadn't been attempted yet as failed.
             attempted_topics = {w.topic for w in succeeded} | {
                 fw.write.topic for fw in failed
             }
@@ -193,9 +216,24 @@ class Operator:
             verification=VerificationResult(states=verify_states),
             duration_ms=duration_ms,
             captured_at=captured_at,
+            peripheral_outcomes=peripheral_outcomes,
         )
 
-    async def _execute_writes(
+    async def _execute_all(
+        self,
+        writes: tuple[Write, ...],
+        action: PlannedAction,
+        succeeded: list[Write],
+        failed: list[FailedWrite],
+        verify_states: dict[str, str],
+        peripheral_outcomes: dict[str, str],
+    ) -> None:
+        await self._execute_inverter_writes(
+            writes, succeeded, failed, verify_states
+        )
+        await self._execute_peripheral_writes(action, peripheral_outcomes)
+
+    async def _execute_inverter_writes(
         self,
         writes: tuple[Write, ...],
         succeeded: list[Write],
@@ -215,6 +253,26 @@ class Operator:
                 )
             else:  # pragma: no cover — defensive
                 failed.append(FailedWrite(write=write, reason=f"unknown: {state}"))
+
+    async def _execute_peripheral_writes(
+        self,
+        action: PlannedAction,
+        peripheral_outcomes: dict[str, str],
+    ) -> None:
+        if action.ev_action is not None:
+            outcome = await self._peripheral.apply_ev(action.ev_action)
+            if outcome != PERIPHERAL_NO_OP:
+                peripheral_outcomes["ev"] = outcome
+        if action.tesla_action is not None:
+            outcome = await self._peripheral.apply_tesla(action.tesla_action)
+            if outcome != PERIPHERAL_NO_OP:
+                peripheral_outcomes["tesla"] = outcome
+        if action.appliances_action is not None:
+            outcome = await self._peripheral.apply_appliances(
+                action.appliances_action
+            )
+            if outcome != PERIPHERAL_NO_OP:
+                peripheral_outcomes["appliances"] = outcome
 
     async def shutdown(self) -> None:
         """Graceful close: MQTT disconnect, pending verifications cancelled."""

--- a/custom_components/heo3/service_caller.py
+++ b/custom_components/heo3/service_caller.py
@@ -1,0 +1,69 @@
+"""Abstraction over Home Assistant service calls.
+
+The peripheral adapter writes via HA services (select.set_option,
+switch.turn_on/off, number.set_value), not MQTT. Tests need to
+inject a recording double; the real implementation in P1.7 wraps
+hass.services.async_call.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Protocol
+
+
+@dataclass(frozen=True)
+class ServiceCall:
+    """One recorded service invocation."""
+
+    domain: str
+    service: str
+    entity_id: str
+    data: dict[str, Any] = field(default_factory=dict)
+
+
+class ServiceCaller(Protocol):
+    """What the peripheral adapter needs from HA."""
+
+    async def call(
+        self,
+        domain: str,
+        service: str,
+        entity_id: str,
+        **data: Any,
+    ) -> None: ...
+
+
+class MockServiceCaller:
+    """Records every call. Use in tests to assert correct service +
+    target + payload. Optionally fails specific calls for error-path
+    tests via `fail_on(predicate)`.
+    """
+
+    def __init__(self) -> None:
+        self.calls: list[ServiceCall] = []
+        self._fail_predicates: list = []
+
+    async def call(
+        self,
+        domain: str,
+        service: str,
+        entity_id: str,
+        **data: Any,
+    ) -> None:
+        sc = ServiceCall(
+            domain=domain, service=service, entity_id=entity_id, data=dict(data)
+        )
+        for pred in self._fail_predicates:
+            if pred(sc):
+                self.calls.append(sc)
+                raise RuntimeError(f"injected failure on {domain}.{service}({entity_id})")
+        self.calls.append(sc)
+
+    def fail_on(self, predicate) -> None:
+        """Schedule that any subsequent call matching `predicate(sc)` raises."""
+        self._fail_predicates.append(predicate)
+
+    def clear(self) -> None:
+        self.calls.clear()
+        self._fail_predicates.clear()

--- a/custom_components/heo3/types.py
+++ b/custom_components/heo3/types.py
@@ -79,22 +79,43 @@ class InverterSettings:
 # ── Peripherals ─────────────────────────────────────────────────────
 
 
+ZAPPI_VALID_MODES = ("Stopped", "Eco", "Eco+", "Fast")
+
+
 @dataclass(frozen=True)
 class EVState:
-    """Zappi state. Filled in P1.3."""
+    """Zappi snapshot. All fields nullable — entities may be unavailable."""
+
+    charging: bool | None = None  # True if currently delivering power
+    mode: str | None = None  # one of ZAPPI_VALID_MODES
+    charge_power_w: float | None = None
 
 
 @dataclass(frozen=True)
 class TeslaState:
-    """Tesla state via Teslemetry. Filled in P1.3.
+    """Tesla state via Teslemetry.
 
     Gated by `located_at_home` — operator suppresses commands when off.
+    All fields nullable — Teslemetry returns 'unknown' when the car
+    is asleep (which is most of the time).
     """
+
+    soc_pct: float | None = None
+    is_charging: bool | None = None  # derived from sensor.<vehicle>_charging
+    charge_power_w: float | None = None
+    charge_limit_pct: int | None = None  # car-side SOC ceiling
+    charge_current_a: int | None = None  # car-side AC draw
+    cable_plugged: bool | None = None
+    located_at_home: bool | None = None
 
 
 @dataclass(frozen=True)
 class ApplianceState:
-    """Washer / dryer / dishwasher running flags. Filled in P1.3."""
+    """Running flags for the SPEC H3 EPS load-shedding set."""
+
+    washer_running: bool | None = None
+    dryer_running: bool | None = None
+    dishwasher_running: bool | None = None
 
 
 # ── World ───────────────────────────────────────────────────────────
@@ -178,17 +199,47 @@ class SlotPlan:
 
 @dataclass(frozen=True)
 class EVAction:
-    """Zappi-side intent. Filled in P1.3."""
+    """Zappi-side intent.
+
+    `set_mode`: write a specific mode (one of ZAPPI_VALID_MODES) to
+    `select.zappi_charge_mode`.
+    `restore_previous`: use the previously-captured mode (operator
+    captures whenever the planner sets mode=Stopped).
+    """
+
+    set_mode: str | None = None
+    restore_previous: bool = False
 
 
 @dataclass(frozen=True)
 class TeslaAction:
-    """Tesla-side intent: stop/start, charge_limit, charge_current. P1.3."""
+    """Tesla-side intent.
+
+    All fields optional. `None` = don't touch this dimension.
+    `set_charging`: True flips charge switch on, False flips off.
+    `set_charge_limit_pct`: write the car's SOC ceiling (50-100).
+    `set_charge_current_a`: write AC draw amps.
+
+    All writes are silently no-op'd if `located_at_home` is False at
+    apply time — the operator surfaces this in the outcome.
+    """
+
+    set_charging: bool | None = None
+    set_charge_limit_pct: int | None = None
+    set_charge_current_a: int | None = None
 
 
 @dataclass(frozen=True)
 class ApplianceAction:
-    """Which appliances to turn off/on. Filled in P1.3."""
+    """Per-appliance turn off/on.
+
+    Identifiers in `turn_off` and `turn_on` correspond to keys in
+    PeripheralAdapter's `appliance_switches` config — they're not
+    HA entity IDs themselves.
+    """
+
+    turn_off: tuple[str, ...] = ()
+    turn_on: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -252,7 +303,13 @@ class VerificationResult:
 
 @dataclass(frozen=True)
 class ApplyResult:
-    """What happened during apply(). §15."""
+    """What happened during apply(). §15.
+
+    `peripheral_outcomes` carries the result of peripheral writes
+    (zappi, Tesla, appliances) by adapter name → outcome code. Codes
+    come from `adapters.peripheral`: APPLIED / NO_OP / SKIPPED_NOT_
+    AT_HOME / SKIPPED_NO_CONFIG / SKIPPED_NO_CAPTURED_MODE / FAILED.
+    """
 
     plan_id: str
     requested: tuple[Write, ...]
@@ -262,3 +319,4 @@ class ApplyResult:
     verification: VerificationResult
     duration_ms: float
     captured_at: datetime
+    peripheral_outcomes: dict[str, str] = field(default_factory=dict)

--- a/tests/test_heo3_apply_peripheral.py
+++ b/tests/test_heo3_apply_peripheral.py
@@ -1,0 +1,123 @@
+"""operator.apply() peripheral dispatch — integration tests."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from heo3.adapters import inverter as inverter_module
+from heo3.operator import Operator
+from heo3.service_caller import MockServiceCaller
+from heo3.state_reader import MockStateReader
+from heo3.transport import MockTransport
+from heo3.types import (
+    ApplianceAction,
+    EVAction,
+    PlannedAction,
+    TeslaAction,
+)
+
+
+@pytest.fixture
+def fast_retry(monkeypatch):
+    monkeypatch.setattr(inverter_module, "RESPONSE_TIMEOUT_S", 0.05)
+    monkeypatch.setattr(inverter_module, "WRITE_RETRY_BACKOFF_S", 0.0)
+
+
+async def _op(states=None, *, tesla=True):
+    transport = MockTransport()
+    await transport.connect()
+    return Operator(
+        transport=transport,
+        state_reader=MockStateReader(states or {}),
+        service_caller=MockServiceCaller(),
+        tesla_entity_prefix="natalia" if tesla else None,
+        appliance_switches={"washer": "switch.washer"},
+    )
+
+
+class TestEVDispatch:
+    @pytest.mark.asyncio
+    async def test_ev_action_dispatched(self, fast_retry):
+        op = await _op({"select.zappi_charge_mode": "Eco"})
+        result = await op.apply(
+            PlannedAction(ev_action=EVAction(set_mode="Stopped"))
+        )
+        assert result.peripheral_outcomes.get("ev") == "APPLIED"
+        # No inverter writes were requested.
+        assert result.requested == ()
+
+
+class TestTeslaDispatch:
+    @pytest.mark.asyncio
+    async def test_tesla_action_at_home(self, fast_retry):
+        op = await _op({"binary_sensor.natalia_located_at_home": "on"})
+        result = await op.apply(
+            PlannedAction(
+                tesla_action=TeslaAction(set_charge_limit_pct=80)
+            )
+        )
+        assert result.peripheral_outcomes.get("tesla") == "APPLIED"
+
+    @pytest.mark.asyncio
+    async def test_tesla_action_not_at_home(self, fast_retry):
+        op = await _op({"binary_sensor.natalia_located_at_home": "off"})
+        result = await op.apply(
+            PlannedAction(
+                tesla_action=TeslaAction(set_charging=False)
+            )
+        )
+        assert result.peripheral_outcomes.get("tesla") == "SKIPPED_NOT_AT_HOME"
+
+
+class TestApplianceDispatch:
+    @pytest.mark.asyncio
+    async def test_appliance_action_dispatched(self, fast_retry):
+        op = await _op()
+        result = await op.apply(
+            PlannedAction(
+                appliances_action=ApplianceAction(turn_off=("washer",))
+            )
+        )
+        assert result.peripheral_outcomes.get("appliances") == "APPLIED"
+
+
+class TestCombinedDispatch:
+    @pytest.mark.asyncio
+    async def test_inverter_plus_peripherals(self, fast_retry):
+        op = await _op({"binary_sensor.natalia_located_at_home": "on"})
+        # Auto-respond to the one inverter publish.
+        transport = op._transport
+
+        async def hook(topic, payload):
+            await transport.inject(
+                "solar_assistant/set/response_message/state", "Saved"
+            )
+
+        original_publish = transport.publish
+
+        async def hooked_publish(topic, payload):
+            await original_publish(topic, payload)
+            asyncio.create_task(hook(topic, payload))
+
+        transport.publish = hooked_publish  # type: ignore[method-assign]
+
+        result = await op.apply(
+            PlannedAction(
+                work_mode="Selling first",
+                tesla_action=TeslaAction(set_charge_limit_pct=80),
+                appliances_action=ApplianceAction(turn_off=("washer",)),
+            )
+        )
+        assert len(result.succeeded) == 1
+        assert result.peripheral_outcomes.get("tesla") == "APPLIED"
+        assert result.peripheral_outcomes.get("appliances") == "APPLIED"
+
+
+class TestNoPeripheralAction:
+    @pytest.mark.asyncio
+    async def test_no_peripheral_actions_no_outcomes(self, fast_retry):
+        op = await _op()
+        result = await op.apply(PlannedAction())
+        assert result.peripheral_outcomes == {}

--- a/tests/test_heo3_peripheral.py
+++ b/tests/test_heo3_peripheral.py
@@ -1,0 +1,363 @@
+"""PeripheralAdapter tests — reads + writes for zappi, Tesla, appliances."""
+
+from __future__ import annotations
+
+import pytest
+
+from heo3.adapters.peripheral import (
+    APPLIED,
+    FAILED,
+    NO_OP,
+    PeripheralAdapter,
+    SKIPPED_NOT_AT_HOME,
+    SKIPPED_NO_CAPTURED_MODE,
+    SKIPPED_NO_CONFIG,
+    TeslaConfig,
+    ZappiConfig,
+)
+from heo3.service_caller import MockServiceCaller
+from heo3.state_reader import MockStateReader
+from heo3.types import (
+    ApplianceAction,
+    EVAction,
+    TeslaAction,
+)
+
+
+def _adapter(*, states=None, attributes=None, tesla=True, appliances=True):
+    return PeripheralAdapter(
+        state_reader=MockStateReader(states or {}, attributes or {}),
+        service_caller=MockServiceCaller(),
+        tesla_entity_prefix="natalia" if tesla else None,
+        appliance_switches=(
+            {"washer": "switch.washer", "dryer": "switch.dryer"}
+            if appliances
+            else None
+        ),
+    )
+
+
+# ── TeslaConfig.from_vehicle ───────────────────────────────────────
+
+
+class TestTeslaConfigFromVehicle:
+    def test_natalia_naming(self):
+        cfg = TeslaConfig.from_vehicle("natalia")
+        assert cfg.charge_switch == "switch.natalia_charge"
+        assert cfg.battery_level == "sensor.natalia_battery_level"
+        assert cfg.charge_limit == "number.natalia_charge_limit"
+        assert cfg.charge_current == "number.natalia_charge_current"
+        assert cfg.located_at_home == "binary_sensor.natalia_located_at_home"
+
+
+# ── EV reads ───────────────────────────────────────────────────────
+
+
+class TestReadEV:
+    @pytest.mark.asyncio
+    async def test_full_state(self):
+        adapter = _adapter(
+            states={
+                "select.zappi_charge_mode": "Eco+",
+                "sensor.zappi_charging_state": "Charging",
+                "sensor.zappi_charge_power": "3500.5",
+            }
+        )
+        state = await adapter.read_ev()
+        assert state.charging is True
+        assert state.mode == "Eco+"
+        assert state.charge_power_w == 3500.5
+
+    @pytest.mark.asyncio
+    async def test_not_charging(self):
+        adapter = _adapter(
+            states={
+                "select.zappi_charge_mode": "Stopped",
+                "sensor.zappi_charging_state": "Connected",
+            }
+        )
+        state = await adapter.read_ev()
+        assert state.charging is False
+        assert state.mode == "Stopped"
+
+    @pytest.mark.asyncio
+    async def test_missing_state_reader_returns_empty(self):
+        adapter = PeripheralAdapter()
+        state = await adapter.read_ev()
+        assert state.mode is None
+        assert state.charge_power_w is None
+
+
+# ── Tesla reads ────────────────────────────────────────────────────
+
+
+class TestReadTesla:
+    @pytest.mark.asyncio
+    async def test_full_state(self):
+        adapter = _adapter(
+            states={
+                "sensor.natalia_battery_level": "82.253",
+                "sensor.natalia_charging": "Stopped",
+                "sensor.natalia_charger_power": "0",
+                "number.natalia_charge_limit": "80",
+                "number.natalia_charge_current": "24",
+                "binary_sensor.natalia_charge_cable": "off",
+                "binary_sensor.natalia_located_at_home": "on",
+            }
+        )
+        state = await adapter.read_tesla()
+        assert state is not None
+        assert state.soc_pct == 82.253
+        assert state.is_charging is False
+        assert state.charge_limit_pct == 80
+        assert state.charge_current_a == 24
+        assert state.cable_plugged is False
+        assert state.located_at_home is True
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_not_configured(self):
+        adapter = _adapter(tesla=False)
+        assert await adapter.read_tesla() is None
+
+    @pytest.mark.asyncio
+    async def test_unknown_fields_become_none(self):
+        # Car asleep — Teslemetry returns 'unknown' for live fields.
+        adapter = _adapter(
+            states={
+                "sensor.natalia_battery_level": "82",
+                "sensor.natalia_charging": "unknown",
+                "sensor.natalia_charger_power": "unknown",
+                "binary_sensor.natalia_located_at_home": "on",
+            }
+        )
+        state = await adapter.read_tesla()
+        assert state is not None
+        assert state.soc_pct == 82.0
+        assert state.is_charging is None
+        assert state.charge_power_w is None
+        assert state.located_at_home is True
+
+
+# ── Appliance reads ────────────────────────────────────────────────
+
+
+class TestReadAppliances:
+    @pytest.mark.asyncio
+    async def test_full_state(self):
+        adapter = _adapter(
+            states={
+                "binary_sensor.washer_running": "on",
+                "binary_sensor.dryer_running": "off",
+            }
+        )
+        state = await adapter.read_appliances()
+        assert state.washer_running is True
+        assert state.dryer_running is False
+        assert state.dishwasher_running is None  # not configured
+
+
+# ── EV writes ──────────────────────────────────────────────────────
+
+
+class TestApplyEV:
+    @pytest.mark.asyncio
+    async def test_set_mode_calls_select_service(self):
+        adapter = _adapter(
+            states={"select.zappi_charge_mode": "Eco"}
+        )
+        outcome = await adapter.apply_ev(EVAction(set_mode="Stopped"))
+        assert outcome == APPLIED
+        sc = adapter._service_caller
+        assert sc.calls[0].domain == "select"
+        assert sc.calls[0].service == "select_option"
+        assert sc.calls[0].entity_id == "select.zappi_charge_mode"
+        assert sc.calls[0].data == {"option": "Stopped"}
+
+    @pytest.mark.asyncio
+    async def test_invalid_mode_returns_failed(self):
+        adapter = _adapter()
+        outcome = await adapter.apply_ev(EVAction(set_mode="Bogus"))
+        assert outcome == FAILED
+
+    @pytest.mark.asyncio
+    async def test_no_op_when_no_intent(self):
+        adapter = _adapter()
+        outcome = await adapter.apply_ev(EVAction())
+        assert outcome == NO_OP
+
+    @pytest.mark.asyncio
+    async def test_capture_then_restore(self):
+        # Currently Eco; planner sets Stopped (captures); then restores.
+        adapter = _adapter(
+            states={"select.zappi_charge_mode": "Eco"}
+        )
+        await adapter.apply_ev(EVAction(set_mode="Stopped"))
+        # Now state is "Stopped" in HA (we'd update via inject normally,
+        # but the captured value is what matters for restore).
+        outcome = await adapter.apply_ev(EVAction(restore_previous=True))
+        assert outcome == APPLIED
+        sc = adapter._service_caller
+        # Two calls: stop, then restore-to-Eco.
+        assert sc.calls[1].data == {"option": "Eco"}
+
+    @pytest.mark.asyncio
+    async def test_restore_with_no_capture_returns_skipped(self):
+        adapter = _adapter()
+        outcome = await adapter.apply_ev(EVAction(restore_previous=True))
+        assert outcome == SKIPPED_NO_CAPTURED_MODE
+
+    @pytest.mark.asyncio
+    async def test_no_capture_when_already_stopped(self):
+        # If mode is already Stopped when we set Stopped, don't capture.
+        adapter = _adapter(
+            states={"select.zappi_charge_mode": "Stopped"}
+        )
+        await adapter.apply_ev(EVAction(set_mode="Stopped"))
+        # Restore should now have nothing to restore to.
+        outcome = await adapter.apply_ev(EVAction(restore_previous=True))
+        assert outcome == SKIPPED_NO_CAPTURED_MODE
+
+
+# ── Tesla writes ───────────────────────────────────────────────────
+
+
+class TestApplyTesla:
+    @pytest.mark.asyncio
+    async def test_stop_charging_at_home(self):
+        adapter = _adapter(
+            states={"binary_sensor.natalia_located_at_home": "on"}
+        )
+        outcome = await adapter.apply_tesla(TeslaAction(set_charging=False))
+        assert outcome == APPLIED
+        sc = adapter._service_caller
+        assert sc.calls[0].domain == "switch"
+        assert sc.calls[0].service == "turn_off"
+        assert sc.calls[0].entity_id == "switch.natalia_charge"
+
+    @pytest.mark.asyncio
+    async def test_start_charging_at_home(self):
+        adapter = _adapter(
+            states={"binary_sensor.natalia_located_at_home": "on"}
+        )
+        outcome = await adapter.apply_tesla(TeslaAction(set_charging=True))
+        assert outcome == APPLIED
+        sc = adapter._service_caller
+        assert sc.calls[0].service == "turn_on"
+
+    @pytest.mark.asyncio
+    async def test_set_charge_limit(self):
+        adapter = _adapter(
+            states={"binary_sensor.natalia_located_at_home": "on"}
+        )
+        outcome = await adapter.apply_tesla(
+            TeslaAction(set_charge_limit_pct=85)
+        )
+        assert outcome == APPLIED
+        sc = adapter._service_caller
+        assert sc.calls[0].domain == "number"
+        assert sc.calls[0].service == "set_value"
+        assert sc.calls[0].entity_id == "number.natalia_charge_limit"
+        assert sc.calls[0].data == {"value": 85.0}
+
+    @pytest.mark.asyncio
+    async def test_set_charge_current(self):
+        adapter = _adapter(
+            states={"binary_sensor.natalia_located_at_home": "on"}
+        )
+        outcome = await adapter.apply_tesla(
+            TeslaAction(set_charge_current_a=16)
+        )
+        assert outcome == APPLIED
+        sc = adapter._service_caller
+        assert sc.calls[0].entity_id == "number.natalia_charge_current"
+        assert sc.calls[0].data == {"value": 16.0}
+
+    @pytest.mark.asyncio
+    async def test_combined_action_applies_all(self):
+        adapter = _adapter(
+            states={"binary_sensor.natalia_located_at_home": "on"}
+        )
+        outcome = await adapter.apply_tesla(
+            TeslaAction(
+                set_charging=True,
+                set_charge_limit_pct=75,
+                set_charge_current_a=20,
+            )
+        )
+        assert outcome == APPLIED
+        sc = adapter._service_caller
+        assert len(sc.calls) == 3
+
+    @pytest.mark.asyncio
+    async def test_skipped_when_not_at_home(self):
+        adapter = _adapter(
+            states={"binary_sensor.natalia_located_at_home": "off"}
+        )
+        outcome = await adapter.apply_tesla(TeslaAction(set_charging=False))
+        assert outcome == SKIPPED_NOT_AT_HOME
+        assert adapter._service_caller.calls == []
+
+    @pytest.mark.asyncio
+    async def test_skipped_when_at_home_unknown(self):
+        # Missing/unknown counts as not-at-home.
+        adapter = _adapter(
+            states={"binary_sensor.natalia_located_at_home": "unknown"}
+        )
+        outcome = await adapter.apply_tesla(TeslaAction(set_charging=False))
+        assert outcome == SKIPPED_NOT_AT_HOME
+
+    @pytest.mark.asyncio
+    async def test_no_op_when_no_intent(self):
+        adapter = _adapter(
+            states={"binary_sensor.natalia_located_at_home": "on"}
+        )
+        outcome = await adapter.apply_tesla(TeslaAction())
+        assert outcome == NO_OP
+
+    @pytest.mark.asyncio
+    async def test_skipped_when_tesla_not_configured(self):
+        adapter = _adapter(tesla=False)
+        outcome = await adapter.apply_tesla(TeslaAction(set_charging=False))
+        assert outcome == SKIPPED_NO_CONFIG
+
+
+# ── Appliance writes ───────────────────────────────────────────────
+
+
+class TestApplyAppliances:
+    @pytest.mark.asyncio
+    async def test_turn_off(self):
+        adapter = _adapter()
+        outcome = await adapter.apply_appliances(
+            ApplianceAction(turn_off=("washer",))
+        )
+        assert outcome == APPLIED
+        sc = adapter._service_caller
+        assert sc.calls[0].service == "turn_off"
+        assert sc.calls[0].entity_id == "switch.washer"
+
+    @pytest.mark.asyncio
+    async def test_turn_on(self):
+        adapter = _adapter()
+        outcome = await adapter.apply_appliances(
+            ApplianceAction(turn_on=("dryer",))
+        )
+        assert outcome == APPLIED
+        sc = adapter._service_caller
+        assert sc.calls[0].service == "turn_on"
+        assert sc.calls[0].entity_id == "switch.dryer"
+
+    @pytest.mark.asyncio
+    async def test_unknown_appliance_skipped_silently(self):
+        adapter = _adapter()
+        outcome = await adapter.apply_appliances(
+            ApplianceAction(turn_off=("nonexistent",))
+        )
+        assert outcome == APPLIED  # adapter completes; just logs the skip
+        assert adapter._service_caller.calls == []
+
+    @pytest.mark.asyncio
+    async def test_no_op_when_empty(self):
+        adapter = _adapter()
+        outcome = await adapter.apply_appliances(ApplianceAction())
+        assert outcome == NO_OP

--- a/tests/test_heo3_service_caller.py
+++ b/tests/test_heo3_service_caller.py
@@ -1,0 +1,52 @@
+"""MockServiceCaller contract tests."""
+
+from __future__ import annotations
+
+import pytest
+
+from heo3.service_caller import MockServiceCaller, ServiceCall
+
+
+class TestRecording:
+    @pytest.mark.asyncio
+    async def test_records_call(self):
+        c = MockServiceCaller()
+        await c.call("switch", "turn_on", "switch.x")
+        assert len(c.calls) == 1
+        assert c.calls[0] == ServiceCall(
+            domain="switch",
+            service="turn_on",
+            entity_id="switch.x",
+            data={},
+        )
+
+    @pytest.mark.asyncio
+    async def test_records_data(self):
+        c = MockServiceCaller()
+        await c.call("number", "set_value", "number.x", value=80.0)
+        assert c.calls[0].data == {"value": 80.0}
+
+    @pytest.mark.asyncio
+    async def test_clear(self):
+        c = MockServiceCaller()
+        await c.call("a", "b", "c")
+        c.clear()
+        assert c.calls == []
+
+
+class TestFailureInjection:
+    @pytest.mark.asyncio
+    async def test_fail_on_match_raises(self):
+        c = MockServiceCaller()
+        c.fail_on(lambda sc: sc.entity_id == "switch.fragile")
+        with pytest.raises(RuntimeError, match="injected failure"):
+            await c.call("switch", "turn_on", "switch.fragile")
+        # Call still recorded.
+        assert c.calls[0].entity_id == "switch.fragile"
+
+    @pytest.mark.asyncio
+    async def test_fail_on_no_match_passes(self):
+        c = MockServiceCaller()
+        c.fail_on(lambda sc: sc.entity_id == "switch.fragile")
+        await c.call("switch", "turn_on", "switch.fine")  # no exception
+        assert len(c.calls) == 1


### PR DESCRIPTION
## Summary

Stacks on #79. Implements §6 (controls) + §7 (reads) of the design. Tracking issue #75.

## Lands

- **\`service_caller.py\`** (new) — \`ServiceCaller\` Protocol + \`MockServiceCaller\` (records every call; supports failure injection).
- **Real state types**: \`EVState\`, \`TeslaState\` (8 fields including \`located_at_home\`), \`ApplianceState\`.
- **Real action types**: \`EVAction\` (set_mode + restore_previous), \`TeslaAction\` (set_charging + set_charge_limit_pct + set_charge_current_a), \`ApplianceAction\` (turn_off + turn_on tuples).
- **\`ApplyResult.peripheral_outcomes\`** — per-adapter outcome codes.
- **\`ZappiConfig\` / \`TeslaConfig\`** — TeslaConfig.from_vehicle('natalia') derives all 8 entity IDs.
- **\`PeripheralAdapter\`** — full reads + writes:
  - **EV**: capture-pre-stop mode in-memory; restore_previous uses captured value
  - **Tesla**: gated on \`located_at_home\` (missing/unknown counts as off — safer than queuing commands); writes via switch.turn_on/off and number.set_value
  - **Appliances**: per-name → entity_id resolution; unknown names logged + skipped
- **\`operator.apply()\`** dispatches peripheral writes after inverter writes; outcomes recorded in \`ApplyResult.peripheral_outcomes\`.

Outcome codes: \`APPLIED\` / \`NO_OP\` / \`SKIPPED_NOT_AT_HOME\` / \`SKIPPED_NO_CONFIG\` / \`SKIPPED_NO_CAPTURED_MODE\` / \`FAILED\`.

## Tests
- 38 new across 3 files
- Full suite: 696/696 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)