### PR TITLE
feat(heo3): P1.4 — world gatherer rates (BD + IGO + AgilePredict)

### DIFF
--- a/custom_components/heo3/adapters/world.py
+++ b/custom_components/heo3/adapters/world.py
@@ -1,44 +1,204 @@
-"""World Gatherer — read-only collation of HA entities.
+"""World Gatherer — read-only collation of HA entities + external sources.
 
-Rates (BD + IGO + AgilePredict), forecasts (Solcast + HEO-5),
-flags (IGO dispatch, saving session, EPS, temperature alarms).
+Rates (BD + IGO + AgilePredict): P1.4
+Forecasts (Solcast + HEO-5):     P1.5
+Flags (IGO/saving/EPS/temp):      P1.6
 
-P1.0 stub. Full implementation across P1.4 / P1.5 / P1.6.
+All values are read from HA entities or external HTTP — never from
+the SA broker directly. The integrations (BottlecapDave, Solcast,
+octopus_energy, teslemetry) handle the upstream calls; this layer
+collates their state into the operator's typed view.
 """
 
 from __future__ import annotations
 
-from datetime import datetime
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime, time, timezone
+from typing import Any
 
+from ..agilepredict_client import AgilePredictClient
+from ..state_reader import StateReader, parse_float, parse_str
 from ..types import (
     LiveRates,
     LoadForecast,
     PredictedRates,
+    RatePeriod,
     SolarForecast,
     SystemFlags,
 )
 
+logger = logging.getLogger(__name__)
 
-class WorldGatherer:
-    """One pass over external HA state per snapshot tick.
 
-    All values are read from HA entities — never from the network
-    directly. The integrations (BottlecapDave, Solcast, octopus_energy,
-    teslemetry, etc.) handle the upstream calls; this layer just
-    collates their state into the operator's typed view.
+# Conversion: BottlecapDave publishes rates in GBP/kWh; HEO III uses pence.
+GBP_TO_PENCE = 100.0
+
+
+# ── Config dataclasses ────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class BDConfig:
+    """BottlecapDave entity IDs for one electricity meter.
+
+    Use `from_meter_key()` to derive from the {mpan}_{serial} key.
     """
 
-    def __init__(self, hass) -> None:  # type: ignore[no-untyped-def]
+    import_current_rate: str
+    export_current_rate: str
+    import_day_rates: str
+    import_next_day_rates: str
+    export_day_rates: str
+    export_next_day_rates: str
+
+    @classmethod
+    def from_meter_key(cls, key: str) -> "BDConfig":
+        """Derive entity IDs from the BD `{mpan}_{serial}` key.
+
+        Example: from_meter_key('18p5009498_2372761090617') gives
+        sensor.octopus_energy_electricity_18p5009498_2372761090617_current_rate, etc.
+        Export entity IDs use the same key — BD pairs import + export
+        on a single meter pair.
+        """
+        return cls(
+            import_current_rate=(
+                f"sensor.octopus_energy_electricity_{key}_current_rate"
+            ),
+            export_current_rate=(
+                f"sensor.octopus_energy_electricity_{key}_export_current_rate"
+            ),
+            import_day_rates=(
+                f"event.octopus_energy_electricity_{key}_current_day_rates"
+            ),
+            import_next_day_rates=(
+                f"event.octopus_energy_electricity_{key}_next_day_rates"
+            ),
+            export_day_rates=(
+                f"event.octopus_energy_electricity_{key}_export_current_day_rates"
+            ),
+            export_next_day_rates=(
+                f"event.octopus_energy_electricity_{key}_export_next_day_rates"
+            ),
+        )
+
+
+@dataclass(frozen=True)
+class IGOConfig:
+    """IGO fixed-rate fallback constants. Per docs/SPEC.md §1, §10."""
+
+    peak_pence: float = 24.8423
+    off_peak_pence: float = 4.9524
+    off_peak_start: time = time(23, 30)
+    off_peak_end: time = time(5, 30)
+
+
+# ── WorldGatherer ─────────────────────────────────────────────────
+
+
+class WorldGatherer:
+    """One pass over external HA state + external HTTP per snapshot tick."""
+
+    def __init__(
+        self,
+        *,
+        state_reader: StateReader | None = None,
+        bd_config: BDConfig | None = None,
+        igo_config: IGOConfig | None = None,
+        agilepredict_client: AgilePredictClient | None = None,
+        hass=None,  # type: ignore[no-untyped-def]
+    ) -> None:
+        self._state_reader = state_reader
+        self._bd = bd_config
+        self._igo = igo_config or IGOConfig()
+        self._agilepredict = agilepredict_client
         self._hass = hass
 
+    # ── Rates (P1.4) ──────────────────────────────────────────────
+
     async def read_rates_live(self) -> LiveRates:
-        raise NotImplementedError("P1.4 — World Gatherer rates")
+        """Read BD's current rates + today/tomorrow rate slot lists.
+
+        Returns an empty LiveRates if BD isn't configured / entities
+        are missing — the operator surfaces this via SPEC H4 freshness
+        checks, not by faking values.
+        """
+        if self._bd is None or self._state_reader is None:
+            return LiveRates()
+        r = self._state_reader
+
+        import_today = _parse_rates_attr(
+            r.get_attributes(self._bd.import_day_rates).get("rates", [])
+        )
+        import_tomorrow = _parse_rates_attr(
+            r.get_attributes(self._bd.import_next_day_rates).get("rates", [])
+        )
+        export_today = _parse_rates_attr(
+            r.get_attributes(self._bd.export_day_rates).get("rates", [])
+        )
+        export_tomorrow = _parse_rates_attr(
+            r.get_attributes(self._bd.export_next_day_rates).get("rates", [])
+        )
+
+        # Current rate sensors publish GBP/kWh; convert to pence.
+        ic = parse_float(r.get_state(self._bd.import_current_rate))
+        ec = parse_float(r.get_state(self._bd.export_current_rate))
+
+        tariff_code = parse_str(
+            r.get_attributes(self._bd.import_current_rate).get("tariff_code")
+        )
+
+        return LiveRates(
+            import_current_pence=ic * GBP_TO_PENCE if ic is not None else None,
+            export_current_pence=ec * GBP_TO_PENCE if ec is not None else None,
+            import_today=import_today,
+            import_tomorrow=import_tomorrow,
+            export_today=export_today,
+            export_tomorrow=export_tomorrow,
+            tariff_code=tariff_code,
+        )
 
     async def read_rates_predicted(self) -> PredictedRates:
-        raise NotImplementedError("P1.4 — World Gatherer rates")
+        """AgilePredict 7-day forward export rates (visualisation only).
+
+        Returns empty PredictedRates if AgilePredict isn't configured
+        or the network call failed (the client returns [] on errors).
+        """
+        if self._agilepredict is None:
+            return PredictedRates()
+        export = await self._agilepredict.fetch_export_rates()
+        # Import predictions aren't currently sourced; reserved for
+        # a future improvement that gets Agile Import predictions too.
+        return PredictedRates(
+            import_pence=(),
+            export_pence=tuple(export),
+        )
 
     async def read_rates_freshness(self) -> dict[str, datetime]:
-        raise NotImplementedError("P1.4 — World Gatherer rates")
+        """Per-source last-updated timestamp for SPEC H4 enforcement.
+
+        Read from each BD entity's `last_updated` if exposed; otherwise
+        fall back to the entity state datetime if it parses. Missing
+        sources are simply absent from the returned dict.
+        """
+        if self._bd is None or self._state_reader is None:
+            return {}
+        out: dict[str, datetime] = {}
+        for label, eid in (
+            ("import_today", self._bd.import_day_rates),
+            ("import_tomorrow", self._bd.import_next_day_rates),
+            ("export_today", self._bd.export_day_rates),
+            ("export_tomorrow", self._bd.export_next_day_rates),
+        ):
+            # BD event entities publish their state as the ISO timestamp
+            # of the last refresh — convenient for freshness tracking.
+            raw_state = self._state_reader.get_state(eid)
+            ts = _try_parse_iso(raw_state)
+            if ts is not None:
+                out[label] = ts
+        return out
+
+    # ── Forecasts (P1.5) ──────────────────────────────────────────
 
     async def read_solar_forecast(self) -> SolarForecast:
         raise NotImplementedError("P1.5 — World Gatherer forecasts")
@@ -46,5 +206,63 @@ class WorldGatherer:
     async def read_load_forecast(self) -> LoadForecast:
         raise NotImplementedError("P1.5 — World Gatherer forecasts")
 
+    # ── Flags (P1.6) ──────────────────────────────────────────────
+
     async def read_flags(self) -> SystemFlags:
         raise NotImplementedError("P1.6 — World Gatherer flags")
+
+    # ── Convenience accessors for IGO config ──────────────────────
+
+    @property
+    def igo(self) -> IGOConfig:
+        """Public access to IGO constants for the planner / Compute layer."""
+        return self._igo
+
+
+# ── Helpers ───────────────────────────────────────────────────────
+
+
+def _parse_rates_attr(raw: Any) -> tuple[RatePeriod, ...]:
+    """Convert BD's `attributes.rates` list into RatePeriod tuple.
+
+    BD's rate dict shape:
+      {
+        "start": "2026-04-30T23:30:00+01:00",
+        "end":   "2026-05-01T00:00:00+01:00",
+        "value_inc_vat": 0.04952,        # GBP/kWh
+        "is_capped": False,
+        "is_intelligent_adjusted": False,
+      }
+    """
+    if not isinstance(raw, list):
+        return ()
+    out: list[RatePeriod] = []
+    for entry in raw:
+        if not isinstance(entry, dict):
+            continue
+        start = _try_parse_iso(entry.get("start"))
+        end = _try_parse_iso(entry.get("end"))
+        gbp = entry.get("value_inc_vat")
+        if start is None or end is None or gbp is None:
+            continue
+        try:
+            pence = float(gbp) * GBP_TO_PENCE
+        except (TypeError, ValueError):
+            continue
+        out.append(RatePeriod(start=start, end=end, rate_pence=pence))
+    out.sort(key=lambda p: p.start)
+    return tuple(out)
+
+
+def _try_parse_iso(raw: Any) -> datetime | None:
+    if raw is None:
+        return None
+    try:
+        dt = datetime.fromisoformat(str(raw))
+    except (ValueError, TypeError):
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    else:
+        dt = dt.astimezone(timezone.utc)
+    return dt

--- a/custom_components/heo3/agilepredict_client.py
+++ b/custom_components/heo3/agilepredict_client.py
@@ -1,0 +1,122 @@
+"""AgilePredict export rate forecast client.
+
+AgilePredict (http://agilepredict.com) publishes half-hourly Agile-
+Outgoing-like rate forecasts for every GB DNO region. This client
+fetches the response, filters to one region, and returns a list of
+30-minute RatePeriod objects with UTC-aware boundaries.
+
+Per SPEC H4: AgilePredict output NEVER reaches the inverter — it's
+visualisation-only fodder for daily-plan rendering.
+
+Ported from heo2/agilepredict_client.py — same external API, uses
+HEO III's RatePeriod type. Pure HTTP client; no HA imports.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta, timezone
+
+import httpx
+
+from .types import RatePeriod
+
+logger = logging.getLogger(__name__)
+
+# Default DNO region. M = NGED Yorkshire (Hull).
+# A Eastern, B East Midlands, C London, D Merseyside & N Wales,
+# E West Midlands, F North Eastern, G North Western, H Southern,
+# J South Eastern, K Southern Western, L South Western, M Yorkshire,
+# N Southern Scotland, P Northern Scotland, X national average.
+DEFAULT_REGION = "M"
+
+
+class AgilePredictClient:
+    """Fetches Agile Outgoing export rate forecasts from AgilePredict.
+
+    Construct once, call `fetch_export_rates()` repeatedly. Results
+    are cached in memory for `cache_hours` to avoid hammering the
+    service. Returns an empty list on any error so the WorldGatherer
+    can always tick.
+    """
+
+    def __init__(
+        self,
+        base_url: str = "https://agilepredict.com",
+        region: str = DEFAULT_REGION,
+        cache_hours: int = 6,
+    ) -> None:
+        self._base_url = base_url.rstrip("/")
+        self._region = region
+        self._cache_hours = cache_hours
+        self._cache: list[RatePeriod] | None = None
+        self._cache_time: datetime | None = None
+
+    async def fetch_export_rates(self) -> list[RatePeriod]:
+        if self._cache is not None and self._cache_time is not None:
+            age = datetime.now(timezone.utc) - self._cache_time
+            if age < timedelta(hours=self._cache_hours):
+                return list(self._cache)
+
+        try:
+            async with httpx.AsyncClient() as client:
+                resp = await client.get(
+                    f"{self._base_url}/api/",
+                    timeout=30.0,
+                )
+                resp.raise_for_status()
+                data = resp.json()
+        except (httpx.HTTPError, ValueError) as exc:
+            logger.warning("AgilePredict fetch failed: %s", exc)
+            return []
+        except Exception as exc:  # pragma: no cover
+            logger.warning("AgilePredict unexpected error: %s", exc)
+            return []
+
+        rates = self._parse_rates(data)
+        self._cache = rates
+        self._cache_time = datetime.now(timezone.utc)
+        return list(rates)
+
+    def _parse_rates(self, data: list) -> list[RatePeriod]:
+        """Region-filter and parse the AgilePredict response."""
+        if not isinstance(data, list) or not data:
+            return []
+        first = data[0]
+        if not isinstance(first, dict):
+            return []
+        prices = first.get("prices", [])
+        if not isinstance(prices, list):
+            return []
+
+        rates: list[RatePeriod] = []
+        for entry in prices:
+            if not isinstance(entry, dict):
+                continue
+            if entry.get("region") != self._region:
+                continue
+            ts = entry.get("date_time")
+            pence = entry.get("agile_pred")
+            if ts is None or pence is None:
+                continue
+            try:
+                start_local = datetime.fromisoformat(str(ts))
+                start_utc = start_local.astimezone(timezone.utc)
+                end_utc = start_utc + timedelta(minutes=30)
+                rate_pence = float(pence)
+            except (ValueError, TypeError) as exc:
+                logger.debug(
+                    "Skipping malformed AgilePredict entry %r: %s", entry, exc
+                )
+                continue
+            rates.append(
+                RatePeriod(start=start_utc, end=end_utc, rate_pence=rate_pence)
+            )
+
+        rates.sort(key=lambda r: r.start)
+        return rates
+
+    def invalidate_cache(self) -> None:
+        """Force the next fetch to hit the network. For tests + manual ops."""
+        self._cache = None
+        self._cache_time = None

--- a/custom_components/heo3/operator.py
+++ b/custom_components/heo3/operator.py
@@ -28,7 +28,8 @@ from .adapters.peripheral import (
     TeslaConfig,
     ZappiConfig,
 )
-from .adapters.world import WorldGatherer
+from .adapters.world import BDConfig, IGOConfig, WorldGatherer
+from .agilepredict_client import AgilePredictClient
 from .build import ActionBuilder
 from .compute import Compute
 from .const import (
@@ -70,6 +71,9 @@ class Operator:
         tesla_entity_prefix: str | None = None,
         appliance_switches: dict[str, str] | None = None,
         appliance_running_sensors: dict[str, str] | None = None,
+        bd_config: BDConfig | None = None,
+        igo_config: IGOConfig | None = None,
+        agilepredict_client: AgilePredictClient | None = None,
     ) -> None:
         self._transport = transport
         self._hass = hass
@@ -92,7 +96,13 @@ class Operator:
             appliance_switches=appliance_switches,
             appliance_running_sensors=appliance_running_sensors,
         )
-        self._world = WorldGatherer(hass=hass)
+        self._world = WorldGatherer(
+            state_reader=state_reader,
+            bd_config=bd_config,
+            igo_config=igo_config,
+            agilepredict_client=agilepredict_client,
+            hass=hass,
+        )
 
         self._compute = Compute()
         self._build = ActionBuilder()

--- a/custom_components/heo3/types.py
+++ b/custom_components/heo3/types.py
@@ -122,13 +122,50 @@ class ApplianceState:
 
 
 @dataclass(frozen=True)
+class RatePeriod:
+    """One half-hour rate period.
+
+    `start` and `end` are timezone-aware datetimes (typically UTC after
+    parsing); `rate_pence` is in pence/kWh (BD publishes GBP/kWh —
+    we convert at the boundary).
+    """
+
+    start: datetime
+    end: datetime
+    rate_pence: float
+
+
+@dataclass(frozen=True)
 class LiveRates:
-    """BD import/export rates today + tomorrow. Filled in P1.4."""
+    """Octopus rates from BottlecapDave, plus IGO fixed-rate fallback.
+
+    Per SPEC H4: live rates only ever feed inverter writes. AgilePredict
+    forecasts (`PredictedRates`) NEVER reach the inverter — they're for
+    daily-plan visualisation only.
+
+    Fields are nullable / empty when the BD entity hasn't been
+    discovered or HA is still warming up.
+    """
+
+    import_current_pence: float | None = None
+    export_current_pence: float | None = None
+    import_today: tuple["RatePeriod", ...] = ()
+    import_tomorrow: tuple["RatePeriod", ...] = ()
+    export_today: tuple["RatePeriod", ...] = ()
+    export_tomorrow: tuple["RatePeriod", ...] = ()
+    tariff_code: str | None = None  # for audit log / tariff change detection
 
 
 @dataclass(frozen=True)
 class PredictedRates:
-    """AgilePredict 7-day forward (visualisation only). Filled in P1.4."""
+    """AgilePredict 7-day forward (visualisation only).
+
+    NEVER reaches the inverter (SPEC H4). Used by Compute for daily-
+    plan rendering.
+    """
+
+    import_pence: tuple["RatePeriod", ...] = ()
+    export_pence: tuple["RatePeriod", ...] = ()
 
 
 @dataclass(frozen=True)

--- a/tests/test_heo3_agilepredict_client.py
+++ b/tests/test_heo3_agilepredict_client.py
@@ -1,0 +1,104 @@
+"""AgilePredict HTTP client tests using pytest-httpx mock."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import httpx
+import pytest
+
+from heo3.agilepredict_client import AgilePredictClient
+
+
+def _sample_response(region="M"):
+    """Realistic AgilePredict API response shape."""
+    return [
+        {
+            "name": "2026-05-10 16:17",
+            "created_at": "2026-05-10T16:17:10.292633+01:00",
+            "prices": [
+                {
+                    "date_time": "2026-05-10T17:00:00+01:00",
+                    "agile_pred": 30.78,
+                    "agile_low": 30.57,
+                    "agile_high": 31.0,
+                    "region": region,
+                },
+                {
+                    "date_time": "2026-05-10T17:30:00+01:00",
+                    "agile_pred": 28.45,
+                    "agile_low": 28.0,
+                    "agile_high": 29.0,
+                    "region": region,
+                },
+                {
+                    # Other region — should be filtered out.
+                    "date_time": "2026-05-10T17:00:00+01:00",
+                    "agile_pred": 99.0,
+                    "region": "X",
+                },
+            ],
+        }
+    ]
+
+
+class TestFetch:
+    @pytest.mark.asyncio
+    async def test_parses_region_filtered(self, httpx_mock):
+        httpx_mock.add_response(json=_sample_response("M"))
+        client = AgilePredictClient(region="M", cache_hours=0)
+        rates = await client.fetch_export_rates()
+        assert len(rates) == 2
+        assert rates[0].rate_pence == 30.78
+        assert rates[0].start == datetime(2026, 5, 10, 16, 0, tzinfo=timezone.utc)
+        assert rates[1].rate_pence == 28.45
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_on_404(self, httpx_mock):
+        httpx_mock.add_response(status_code=404)
+        client = AgilePredictClient(cache_hours=0)
+        assert await client.fetch_export_rates() == []
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_on_malformed_json(self, httpx_mock):
+        httpx_mock.add_response(content=b"not json")
+        client = AgilePredictClient(cache_hours=0)
+        assert await client.fetch_export_rates() == []
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_on_unexpected_shape(self, httpx_mock):
+        httpx_mock.add_response(json={"unexpected": "shape"})
+        client = AgilePredictClient(cache_hours=0)
+        assert await client.fetch_export_rates() == []
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_for_unknown_region(self, httpx_mock):
+        httpx_mock.add_response(json=_sample_response("M"))
+        client = AgilePredictClient(region="X", cache_hours=0)
+        # X exists in the sample but only one record; but then the loop
+        # below runs once and returns the X record.
+        rates = await client.fetch_export_rates()
+        assert len(rates) == 1
+        assert rates[0].rate_pence == 99.0
+
+
+class TestCache:
+    @pytest.mark.asyncio
+    async def test_second_call_uses_cache(self, httpx_mock):
+        httpx_mock.add_response(json=_sample_response("M"))
+        client = AgilePredictClient(region="M", cache_hours=6)
+        first = await client.fetch_export_rates()
+        # No further httpx_mock add — second call must hit cache.
+        second = await client.fetch_export_rates()
+        assert second == first
+
+    @pytest.mark.asyncio
+    async def test_invalidate_forces_refetch(self, httpx_mock):
+        httpx_mock.add_response(json=_sample_response("M"))
+        httpx_mock.add_response(json=_sample_response("M"))
+        client = AgilePredictClient(region="M", cache_hours=6)
+        await client.fetch_export_rates()
+        client.invalidate_cache()
+        await client.fetch_export_rates()  # second network call expected
+        # If cache wasn't invalidated, pytest-httpx would complain
+        # about the unused mock.

--- a/tests/test_heo3_world_rates.py
+++ b/tests/test_heo3_world_rates.py
@@ -1,0 +1,209 @@
+"""WorldGatherer rate-reading tests + BDConfig + IGOConfig."""
+
+from __future__ import annotations
+
+from datetime import datetime, time, timezone
+
+import pytest
+
+from heo3.adapters.world import BDConfig, IGOConfig, WorldGatherer
+from heo3.state_reader import MockStateReader
+
+
+METER_KEY = "18p5009498_2372761090617"
+EXPORT_METER_KEY = "18p5009498_2394300396097"
+
+
+# ── BDConfig ───────────────────────────────────────────────────────
+
+
+class TestBDConfigFromMeterKey:
+    def test_entity_ids_derived(self):
+        cfg = BDConfig.from_meter_key(METER_KEY)
+        assert cfg.import_current_rate == (
+            f"sensor.octopus_energy_electricity_{METER_KEY}_current_rate"
+        )
+        assert cfg.import_day_rates == (
+            f"event.octopus_energy_electricity_{METER_KEY}_current_day_rates"
+        )
+        assert cfg.export_day_rates == (
+            f"event.octopus_energy_electricity_{METER_KEY}_export_current_day_rates"
+        )
+
+
+# ── IGOConfig ──────────────────────────────────────────────────────
+
+
+class TestIGOConfigDefaults:
+    def test_spec_aligned_constants(self):
+        c = IGOConfig()
+        # Pinned by docs/SPEC.md §1, §10 (HEO II reference values).
+        assert c.peak_pence == pytest.approx(24.8423)
+        assert c.off_peak_pence == pytest.approx(4.9524)
+        assert c.off_peak_start == time(23, 30)
+        assert c.off_peak_end == time(5, 30)
+
+
+# ── Rate parsing ───────────────────────────────────────────────────
+
+
+def _bd_rates_attr() -> list[dict]:
+    """Realistic BD attribute shape for event.*_current_day_rates."""
+    return [
+        {
+            "start": "2026-05-10T00:00:00+01:00",
+            "end": "2026-05-10T00:30:00+01:00",
+            "value_inc_vat": 0.04952,
+            "is_capped": False,
+            "is_intelligent_adjusted": False,
+        },
+        {
+            "start": "2026-05-10T00:30:00+01:00",
+            "end": "2026-05-10T01:00:00+01:00",
+            "value_inc_vat": 0.04952,
+        },
+    ]
+
+
+def _gatherer(states=None, attributes=None, *, bd=True):
+    return WorldGatherer(
+        state_reader=MockStateReader(states or {}, attributes or {}),
+        bd_config=BDConfig.from_meter_key(METER_KEY) if bd else None,
+    )
+
+
+class TestReadRatesLive:
+    @pytest.mark.asyncio
+    async def test_full_rates_parsed(self):
+        cfg = BDConfig.from_meter_key(METER_KEY)
+        states = {
+            cfg.import_current_rate: "0.285844",  # GBP/kWh
+            cfg.export_current_rate: "0.1134",
+        }
+        attrs = {
+            cfg.import_day_rates: {"rates": _bd_rates_attr()},
+            cfg.export_day_rates: {"rates": _bd_rates_attr()},
+            cfg.import_current_rate: {"tariff_code": "E-1R-INTELLI-VAR-22-10-14-M"},
+        }
+        g = _gatherer(states, attrs)
+        rates = await g.read_rates_live()
+
+        assert rates.import_current_pence == pytest.approx(28.5844)
+        assert rates.export_current_pence == pytest.approx(11.34)
+        assert rates.tariff_code == "E-1R-INTELLI-VAR-22-10-14-M"
+
+        assert len(rates.import_today) == 2
+        first = rates.import_today[0]
+        assert first.start == datetime(2026, 5, 9, 23, 0, tzinfo=timezone.utc)
+        assert first.rate_pence == pytest.approx(4.952)
+        assert first.end == datetime(2026, 5, 9, 23, 30, tzinfo=timezone.utc)
+
+    @pytest.mark.asyncio
+    async def test_no_bd_config_returns_empty(self):
+        g = _gatherer(bd=False)
+        rates = await g.read_rates_live()
+        assert rates.import_today == ()
+        assert rates.import_current_pence is None
+
+    @pytest.mark.asyncio
+    async def test_missing_attribute_returns_empty_list(self):
+        g = _gatherer({})  # no rates attr → empty
+        rates = await g.read_rates_live()
+        assert rates.import_today == ()
+        assert rates.export_today == ()
+
+    @pytest.mark.asyncio
+    async def test_malformed_rate_entries_skipped(self):
+        cfg = BDConfig.from_meter_key(METER_KEY)
+        attrs = {
+            cfg.import_day_rates: {
+                "rates": [
+                    {"start": "garbage", "end": "x", "value_inc_vat": 0.1},
+                    {  # valid
+                        "start": "2026-05-10T00:00:00+01:00",
+                        "end": "2026-05-10T00:30:00+01:00",
+                        "value_inc_vat": 0.05,
+                    },
+                ]
+            },
+        }
+        g = _gatherer({}, attrs)
+        rates = await g.read_rates_live()
+        # Only the valid one survived.
+        assert len(rates.import_today) == 1
+
+
+class TestReadRatesFreshness:
+    @pytest.mark.asyncio
+    async def test_event_state_iso_parsed(self):
+        cfg = BDConfig.from_meter_key(METER_KEY)
+        states = {
+            cfg.import_day_rates: "2026-05-10T15:19:59.663+00:00",
+            cfg.export_day_rates: "2026-05-10T15:19:59.664+00:00",
+        }
+        g = _gatherer(states)
+        freshness = await g.read_rates_freshness()
+        assert "import_today" in freshness
+        assert "export_today" in freshness
+        assert freshness["import_today"].tzinfo is not None
+        assert freshness["import_today"].year == 2026
+
+    @pytest.mark.asyncio
+    async def test_no_bd_returns_empty(self):
+        g = _gatherer(bd=False)
+        assert await g.read_rates_freshness() == {}
+
+    @pytest.mark.asyncio
+    async def test_unparseable_state_omitted(self):
+        cfg = BDConfig.from_meter_key(METER_KEY)
+        g = _gatherer({cfg.import_day_rates: "garbage"})
+        freshness = await g.read_rates_freshness()
+        assert "import_today" not in freshness
+
+
+class TestIGOAccessor:
+    def test_igo_property_returns_config(self):
+        g = _gatherer()
+        assert isinstance(g.igo, IGOConfig)
+        assert g.igo.peak_pence == pytest.approx(24.8423)
+
+
+# ── PredictedRates (AgilePredict) ──────────────────────────────────
+
+
+class _FakeAgilePredict:
+    """Predictable test double for AgilePredictClient.fetch_export_rates."""
+
+    def __init__(self, rates):
+        self._rates = rates
+
+    async def fetch_export_rates(self):
+        return list(self._rates)
+
+
+class TestReadRatesPredicted:
+    @pytest.mark.asyncio
+    async def test_no_client_returns_empty(self):
+        g = _gatherer()
+        predicted = await g.read_rates_predicted()
+        assert predicted.export_pence == ()
+        assert predicted.import_pence == ()
+
+    @pytest.mark.asyncio
+    async def test_passes_through_export_rates(self):
+        from heo3.types import RatePeriod
+
+        sample = [
+            RatePeriod(
+                start=datetime(2026, 5, 10, 12, 0, tzinfo=timezone.utc),
+                end=datetime(2026, 5, 10, 12, 30, tzinfo=timezone.utc),
+                rate_pence=15.5,
+            )
+        ]
+        g = WorldGatherer(
+            state_reader=MockStateReader(),
+            agilepredict_client=_FakeAgilePredict(sample),
+        )
+        predicted = await g.read_rates_predicted()
+        assert predicted.export_pence == tuple(sample)
+        assert predicted.import_pence == ()


### PR DESCRIPTION
## Summary

Stacks on #80. Implements §8 of the design. Tracking issue #75.

## Lands

- **\`RatePeriod\`** type — half-hour dataclass (start, end, rate_pence). Used by both LiveRates and PredictedRates.
- **\`LiveRates\` / \`PredictedRates\`** — real fields (were placeholders).
- **\`agilepredict_client.py\`** (new) — ported from heo2; produces RatePeriod; in-memory cache; returns [] on errors. Region-filtered (default M = NGED Yorkshire).
- **\`BDConfig.from_meter_key('mpan_serial')\`** — derives all 6 BD entity IDs from the {mpan}_{serial} key (matches octopus_energy HACS naming).
- **\`IGOConfig\`** — SPEC §1/§10 constants (peak 24.8423p, off-peak 4.9524p, 23:30–05:30).
- **\`WorldGatherer.read_rates_live()\`** — parses BD's \`attributes.rates\` list; converts GBP/kWh → pence at the boundary; pulls tariff_code; per-source freshness via \`read_rates_freshness()\` for SPEC H4.
- **\`WorldGatherer.read_rates_predicted()\`** — delegates to AgilePredictClient.
- **Operator** threads \`bd_config\`, \`igo_config\`, \`agilepredict_client\` to WorldGatherer.

Per SPEC H4: AgilePredict never reaches the inverter. Visualisation only.

## Tests
- 19 new across 2 files (incl. pytest-httpx mock for AgilePredict)
- Full suite: 715/715 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)