### PR TITLE
feat(heo3): P1.5 — world gatherer forecasts (Solcast + HEO-5 load model)

### DIFF
--- a/custom_components/heo3/adapters/world.py
+++ b/custom_components/heo3/adapters/world.py
@@ -13,11 +13,15 @@ collates their state into the operator's typed view.
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass, field
-from datetime import datetime, time, timezone
-from typing import Any
+from dataclasses import dataclass
+from datetime import datetime, time, timedelta, timezone
+from typing import Any, Protocol
+from zoneinfo import ZoneInfo
 
 from ..agilepredict_client import AgilePredictClient
+from ..load_history import learn_days_from_samples
+from ..load_profile import LoadProfile, LoadProfileBuilder
+from ..solar_forecast import solar_forecast_from_hacs
 from ..state_reader import StateReader, parse_float, parse_str
 from ..types import (
     LiveRates,
@@ -93,6 +97,55 @@ class IGOConfig:
     off_peak_end: time = time(5, 30)
 
 
+@dataclass(frozen=True)
+class SolcastConfig:
+    """Solcast HACS entity IDs."""
+
+    forecast_today: str = "sensor.solcast_pv_forecast_forecast_today"
+    forecast_tomorrow: str = "sensor.solcast_pv_forecast_forecast_tomorrow"
+    api_last_polled: str = "sensor.solcast_pv_forecast_api_last_polled"
+
+
+@dataclass(frozen=True)
+class LoadModelConfig:
+    """HEO-5 load model wiring.
+
+    `consumption_entity` is a household energy counter (state_class
+    total_increasing) for the cumulative-kwh aggregator, OR a power-
+    watts entity for the trapezoidal aggregator. Defaults to the SA
+    load_power sensor, treated as power_watts.
+    """
+
+    consumption_entity: str = "sensor.sa_inverter_1_load_power"
+    source_type: str = "power_watts"  # or "cumulative_kwh"
+    learn_days: int = 14
+    baseline_w: float = 1900.0
+
+
+class LoadHistoryReader(Protocol):
+    """Returns (timestamp, watts-or-kwh) samples for the past N days.
+
+    Real implementation in P1.7 wraps hass.history; tests inject a
+    canned list.
+    """
+
+    async def fetch(
+        self, entity_id: str, days_back: int
+    ) -> list[tuple[datetime, float]]: ...
+
+
+class MockLoadHistoryReader:
+    """Returns a pre-supplied sample list. For tests."""
+
+    def __init__(self, samples: list[tuple[datetime, float]] | None = None) -> None:
+        self._samples = list(samples or [])
+
+    async def fetch(
+        self, entity_id: str, days_back: int
+    ) -> list[tuple[datetime, float]]:
+        return list(self._samples)
+
+
 # ── WorldGatherer ─────────────────────────────────────────────────
 
 
@@ -106,12 +159,20 @@ class WorldGatherer:
         bd_config: BDConfig | None = None,
         igo_config: IGOConfig | None = None,
         agilepredict_client: AgilePredictClient | None = None,
+        solcast_config: SolcastConfig | None = None,
+        load_model_config: LoadModelConfig | None = None,
+        load_history_reader: LoadHistoryReader | None = None,
+        local_tz: str = "Europe/London",
         hass=None,  # type: ignore[no-untyped-def]
     ) -> None:
         self._state_reader = state_reader
         self._bd = bd_config
         self._igo = igo_config or IGOConfig()
         self._agilepredict = agilepredict_client
+        self._solcast = solcast_config or SolcastConfig()
+        self._load_model = load_model_config or LoadModelConfig()
+        self._load_history = load_history_reader
+        self._local_tz = ZoneInfo(local_tz)
         self._hass = hass
 
     # ── Rates (P1.4) ──────────────────────────────────────────────
@@ -201,10 +262,97 @@ class WorldGatherer:
     # ── Forecasts (P1.5) ──────────────────────────────────────────
 
     async def read_solar_forecast(self) -> SolarForecast:
-        raise NotImplementedError("P1.5 — World Gatherer forecasts")
+        """Pull P10 / P50 / P90 hourly forecasts from Solcast HACS.
+
+        Returns empty tuples when Solcast attributes are missing —
+        callers should treat empty as "no forecast" not "zero solar".
+        """
+        if self._state_reader is None:
+            return SolarForecast()
+        r = self._state_reader
+
+        today_attrs = r.get_attributes(self._solcast.forecast_today)
+        tomorrow_attrs = r.get_attributes(self._solcast.forecast_tomorrow)
+
+        today_hourly = today_attrs.get("detailedHourly", []) or []
+        tomorrow_hourly = tomorrow_attrs.get("detailedHourly", []) or []
+
+        today_local = datetime.now(self._local_tz).date()
+        tomorrow_local = today_local + timedelta(days=1)
+
+        last_polled = _try_parse_iso(r.get_state(self._solcast.api_last_polled))
+
+        return SolarForecast(
+            today_p50_kwh=tuple(
+                solar_forecast_from_hacs(today_hourly, today_local, "pv_estimate")
+            ),
+            tomorrow_p50_kwh=tuple(
+                solar_forecast_from_hacs(
+                    tomorrow_hourly, tomorrow_local, "pv_estimate"
+                )
+            ),
+            today_p10_kwh=tuple(
+                solar_forecast_from_hacs(today_hourly, today_local, "pv_estimate10")
+            ),
+            today_p90_kwh=tuple(
+                solar_forecast_from_hacs(today_hourly, today_local, "pv_estimate90")
+            ),
+            tomorrow_p10_kwh=tuple(
+                solar_forecast_from_hacs(
+                    tomorrow_hourly, tomorrow_local, "pv_estimate10"
+                )
+            ),
+            tomorrow_p90_kwh=tuple(
+                solar_forecast_from_hacs(
+                    tomorrow_hourly, tomorrow_local, "pv_estimate90"
+                )
+            ),
+            last_updated=last_polled,
+        )
 
     async def read_load_forecast(self) -> LoadForecast:
-        raise NotImplementedError("P1.5 — World Gatherer forecasts")
+        """Build the HEO-5 14-day median profile and return today/tomorrow.
+
+        Returns an empty LoadForecast if no history reader is wired
+        (e.g. P1.0-P1.6 standalone tests). The planner is expected to
+        treat empty-tuples as "no forecast".
+        """
+        today_local = datetime.now(self._local_tz).date()
+        tomorrow_local = today_local + timedelta(days=1)
+        weekday = today_local.weekday()
+
+        if self._load_history is None:
+            return LoadForecast(
+                day_of_week=weekday, is_weekend=weekday >= 5
+            )
+
+        samples = await self._load_history.fetch(
+            self._load_model.consumption_entity,
+            self._load_model.learn_days,
+        )
+        days = learn_days_from_samples(
+            samples, self._local_tz, source_type=self._load_model.source_type
+        )
+        builder = LoadProfileBuilder(baseline_w=self._load_model.baseline_w)
+        for d, hourly in days.items():
+            builder.add_day(
+                datetime(d.year, d.month, d.day, tzinfo=self._local_tz),
+                hourly,
+            )
+        profile: LoadProfile = builder.build()
+
+        today_dt = datetime(
+            today_local.year, today_local.month, today_local.day,
+            tzinfo=self._local_tz,
+        )
+        tomorrow_dt = today_dt + timedelta(days=1)
+
+        return LoadForecast(
+            today_hourly_kwh=tuple(profile.for_datetime(today_dt)),
+            tomorrow_hourly_kwh=tuple(profile.for_datetime(tomorrow_dt)),
+            day_of_week=weekday,
+            is_weekend=weekday >= 5,
+        )
 
     # ── Flags (P1.6) ──────────────────────────────────────────────
 

--- a/custom_components/heo3/load_history.py
+++ b/custom_components/heo3/load_history.py
@@ -1,0 +1,308 @@
+"""Pure aggregation functions that turn HA recorder state history into the
+(date, hourly_kwh_list) shape LoadProfileBuilder.add_day() expects.
+
+Ported as-is from heo2/load_history.py per the §21 resolution. The
+math has no Home Assistant imports so it can be unit-tested in
+isolation.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, date, timedelta, tzinfo
+
+
+SECONDS_PER_HOUR = 3600
+WH_PER_KWH = 1000
+
+# Intervals longer than this are treated as device-offline gaps, not flat
+# extrapolation. HA recorder writes at least hourly even for unchanged
+# values, so any gap longer than this almost certainly means the sensor
+# was unavailable.
+DEFAULT_MAX_INTERVAL_SECONDS = 2 * SECONDS_PER_HOUR
+
+
+def aggregate_samples_to_hourly_kwh(
+    samples: list[tuple[datetime, float]],
+    target_date: date,
+    tz: tzinfo,
+    max_interval_seconds: float = DEFAULT_MAX_INTERVAL_SECONDS,
+) -> list[float]:
+    """Aggregate (timestamp, watts) samples into 24 hourly kWh values for
+    ``target_date`` interpreted in ``tz``.
+
+    Uses trapezoidal integration between consecutive samples. Power is
+    assumed to ramp linearly between samples, which for trapezoidal
+    integration gives the exact integral. Intervals that span hour
+    boundaries are split at the boundary and each portion contributes
+    to its own hour bucket.
+
+    Negative power values (export periods) are clamped to zero because
+    a load profile represents consumption, not net flow.
+
+    Input samples are sorted defensively; caller need not pre-sort.
+    Samples with the same timestamp are collapsed to the first.
+
+    Args:
+        samples: list of (datetime_aware, watts) pairs.
+        target_date: the local date to aggregate for.
+        tz: timezone used to interpret ``target_date`` boundaries.
+
+    Returns:
+        24 floats, index 0 is 00:00 local of ``target_date``, etc.
+    """
+    if len(samples) < 2:
+        return [0.0] * 24
+
+    # Defensive sort and negative clamp
+    ordered = sorted(
+        ((ts, max(0.0, float(w))) for ts, w in samples),
+        key=lambda p: p[0],
+    )
+
+    # Local midnight boundaries for the target day
+    day_start_local = datetime(
+        target_date.year, target_date.month, target_date.day, tzinfo=tz,
+    )
+    day_end_local = day_start_local + timedelta(days=1)
+
+    hourly = [0.0] * 24
+
+    for (t1, w1), (t2, w2) in zip(ordered, ordered[1:]):
+        if t2 <= t1:
+            continue  # duplicate or reversed timestamp, skip
+        interval_seconds = (t2 - t1).total_seconds()
+        if interval_seconds <= 0:
+            continue
+        if interval_seconds > max_interval_seconds:
+            # Gap too large — sensor was probably unavailable. Don't
+            # invent energy by interpolating across the gap.
+            continue
+
+        # Skip intervals that don't touch the target day at all
+        if t2 <= day_start_local or t1 >= day_end_local:
+            continue
+
+        # Walk hour boundaries that fall inside this interval
+        _accumulate_interval(
+            hourly, t1, w1, t2, w2,
+            day_start_local, day_end_local, tz,
+        )
+
+    return hourly
+
+
+def _accumulate_interval(
+    hourly: list[float],
+    t1: datetime, w1: float,
+    t2: datetime, w2: float,
+    day_start: datetime, day_end: datetime,
+    tz: tzinfo,
+) -> None:
+    """Add the energy contribution of one (t1, w1) -> (t2, w2) interval
+    into ``hourly`` buckets, splitting at hour boundaries."""
+    interval_secs = (t2 - t1).total_seconds()
+    slope = (w2 - w1) / interval_secs  # watts per second
+
+    # Clamp the interval to the target day
+    a = max(t1, day_start)
+    b = min(t2, day_end)
+    if b <= a:
+        return
+
+    # Walk from a to b, stopping at every hour boundary in between
+    cursor = a
+    while cursor < b:
+        # Next hour boundary in local time
+        local_cursor = cursor.astimezone(tz)
+        next_hour_local = (local_cursor + timedelta(hours=1)).replace(
+            minute=0, second=0, microsecond=0,
+        )
+        next_boundary = min(next_hour_local, b)
+
+        # Integrate from cursor to next_boundary
+        # Power at cursor: linear interp between t1 and t2
+        dt_a = (cursor - t1).total_seconds()
+        dt_b = (next_boundary - t1).total_seconds()
+        p_a = w1 + slope * dt_a
+        p_b = w1 + slope * dt_b
+        # Clamp again after interpolation in case interval straddles zero
+        p_a = max(0.0, p_a)
+        p_b = max(0.0, p_b)
+
+        seg_secs = (next_boundary - cursor).total_seconds()
+        # Energy (Wh) = avg_W * hours = (p_a + p_b) / 2 * seg_secs / 3600
+        energy_wh = (p_a + p_b) / 2.0 * seg_secs / SECONDS_PER_HOUR
+        energy_kwh = energy_wh / WH_PER_KWH
+
+        # Which local hour does this segment belong to?
+        hour_index = local_cursor.hour
+        if 0 <= hour_index < 24:
+            hourly[hour_index] += energy_kwh
+
+        cursor = next_boundary
+
+
+def learn_days_from_samples(
+    samples: list[tuple[datetime, float]],
+    tz: tzinfo,
+    source_type: str = "power_watts",
+) -> dict[date, list[float]]:
+    """Group samples by local date and aggregate each into 24 hourly kWh buckets.
+
+    Returns a dict mapping each local date covered by the samples to its
+    24-element hourly kWh list. Convenience wrapper for the coordinator
+    so it can loop and call LoadProfileBuilder.add_day() per entry.
+
+    Args:
+        samples: list of (timestamp, value) pairs
+        tz: local timezone for day bucketing
+        source_type: either ``"power_watts"`` (the historical behaviour —
+            samples are instantaneous power readings in watts, integrated
+            trapezoidally) or ``"cumulative_kwh"`` (samples are a
+            monotonically-increasing kWh meter, aggregated by delta).
+    """
+    if not samples:
+        return {}
+
+    if source_type == "cumulative_kwh":
+        aggregator = aggregate_cumulative_kwh_to_hourly
+    elif source_type == "power_watts":
+        aggregator = aggregate_samples_to_hourly_kwh
+    else:
+        raise ValueError(f"Unknown source_type: {source_type!r}")
+
+    ordered = sorted(samples, key=lambda p: p[0])
+    first_local = ordered[0][0].astimezone(tz)
+    last_local = ordered[-1][0].astimezone(tz)
+    dates: list[date] = []
+    d = first_local.date()
+    while d <= last_local.date():
+        dates.append(d)
+        d = d + timedelta(days=1)
+
+    result: dict[date, list[float]] = {}
+    for d in dates:
+        result[d] = aggregator(ordered, d, tz)
+    return result
+
+
+def states_to_power_samples(states) -> list[tuple]:
+    """Convert HA recorder State-like objects into (datetime, watts) tuples.
+
+    Defensive against ``unknown`` / ``unavailable`` / ``None`` states and
+    malformed numeric values. Non-numeric states, states missing
+    attributes, and states with a None timestamp are all silently
+    skipped so one bad record cannot break the whole history fetch.
+
+    Returns the list ordered by ``last_changed`` ascending. Caller is
+    responsible for treating the returned watts as "load power" including
+    its sign (negative = export); the aggregator clamps to zero.
+    """
+    out: list[tuple] = []
+    for s in states:
+        try:
+            raw = s.state
+            ts = s.last_changed
+        except AttributeError:
+            continue
+        if raw in (None, "unknown", "unavailable"):
+            continue
+        try:
+            watts = float(raw)
+        except (ValueError, TypeError):
+            continue
+        if ts is None:
+            continue
+        out.append((ts, watts))
+    out.sort(key=lambda p: p[0])
+    return out
+
+
+def aggregate_cumulative_kwh_to_hourly(
+    samples: list[tuple[datetime, float]],
+    target_date: date,
+    tz: tzinfo,
+    max_interval_seconds: float = DEFAULT_MAX_INTERVAL_SECONDS,
+) -> list[float]:
+    """Aggregate (timestamp, cumulative_kwh) samples into 24 hourly kWh values.
+
+    For entities that expose total household consumption as a monotonically
+    increasing kWh counter (``state_class: total_increasing``). The aggregator
+    computes kWh deltas between consecutive samples and prorates them across
+    the hour buckets they span.
+
+    This is the correct entity shape for learning a true household load
+    profile. It captures all consumption regardless of source (grid import,
+    PV self-consumption, or battery discharge), which is exactly what the
+    LoadProfileBuilder's median needs.
+
+    Args:
+        samples: list of (datetime_aware, cumulative_kwh) pairs.
+        target_date: the local date to aggregate for.
+        tz: timezone used to interpret ``target_date`` boundaries.
+        max_interval_seconds: intervals longer than this are dropped,
+            assuming the sensor was offline rather than genuinely flat.
+
+    Returns:
+        24 floats, index 0 is 00:00 local of ``target_date``, etc.
+
+    Notes:
+        - Meter resets (counter going down) are silently skipped for the
+          interval containing the reset. Happens on inverter restart.
+        - The kWh delta is spread across the interval linearly (constant
+          power assumption within the interval). For sub-hour sampling this
+          is equivalent to trapezoidal integration.
+    """
+    if len(samples) < 2:
+        return [0.0] * 24
+
+    ordered = sorted(samples, key=lambda p: p[0])
+
+    day_start_local = datetime(
+        target_date.year, target_date.month, target_date.day, tzinfo=tz,
+    )
+    day_end_local = day_start_local + timedelta(days=1)
+
+    hourly = [0.0] * 24
+
+    for (t1, v1), (t2, v2) in zip(ordered, ordered[1:]):
+        if t2 <= t1:
+            continue
+        interval_seconds = (t2 - t1).total_seconds()
+        if interval_seconds <= 0 or interval_seconds > max_interval_seconds:
+            continue
+
+        delta_kwh = v2 - v1
+        if delta_kwh < 0:
+            # Meter reset (e.g. inverter restart). Don't invent energy.
+            continue
+        if delta_kwh == 0:
+            continue
+
+        # Clip interval to the target day
+        a = max(t1, day_start_local)
+        b = min(t2, day_end_local)
+        if b <= a:
+            continue
+
+        # kWh per second within this interval (constant-power assumption)
+        kwh_per_second = delta_kwh / interval_seconds
+
+        # Walk hour boundaries, prorating the energy
+        cursor = a
+        while cursor < b:
+            local_cursor = cursor.astimezone(tz)
+            next_hour_local = (local_cursor + timedelta(hours=1)).replace(
+                minute=0, second=0, microsecond=0,
+            )
+            next_boundary = min(next_hour_local, b)
+            seg_secs = (next_boundary - cursor).total_seconds()
+            seg_kwh = kwh_per_second * seg_secs
+
+            hour_index = local_cursor.hour
+            if 0 <= hour_index < 24:
+                hourly[hour_index] += seg_kwh
+
+            cursor = next_boundary
+
+    return hourly

--- a/custom_components/heo3/load_profile.py
+++ b/custom_components/heo3/load_profile.py
@@ -1,0 +1,71 @@
+"""HEO-5 load profile builder. No Home Assistant imports.
+
+Ported as-is from heo2/load_profile.py per the §21 resolution
+(port-as-is for P1; rewrite is a separate piece of work). Builds
+hourly median load profiles split by weekday/weekend from historical
+samples.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from statistics import median
+
+
+@dataclass
+class LoadProfile:
+    """Hourly load profiles for weekdays and weekends."""
+
+    weekday: list[float]
+    weekend: list[float]
+
+    def for_datetime(self, dt: datetime) -> list[float]:
+        """Return the appropriate profile for the given datetime."""
+        if dt.weekday() >= 5:
+            return list(self.weekend)
+        return list(self.weekday)
+
+    def with_appliance_overlay(
+        self,
+        base_profile: list[float],
+        start_hour: int,
+        duration_hours: int,
+        draw_kw: float,
+    ) -> list[float]:
+        """Add appliance draw on top of a base profile."""
+        result = list(base_profile)
+        for h in range(start_hour, min(start_hour + duration_hours, 24)):
+            result[h] += draw_kw
+        return result
+
+
+class LoadProfileBuilder:
+    """Builds hourly median load profiles from historical data."""
+
+    def __init__(self, baseline_w: float = 1900.0):
+        self._baseline_kwh = baseline_w / 1000.0
+        self._weekday_hours: list[list[float]] = [[] for _ in range(24)]
+        self._weekend_hours: list[list[float]] = [[] for _ in range(24)]
+
+    def add_day(self, date: datetime, hourly_kwh: list[float]) -> None:
+        """Add one day's hourly load data."""
+        if len(hourly_kwh) != 24:
+            return
+        target = (
+            self._weekend_hours if date.weekday() >= 5 else self._weekday_hours
+        )
+        for hour, kwh in enumerate(hourly_kwh):
+            target[hour].append(kwh)
+
+    def build(self) -> LoadProfile:
+        """Build the load profile from accumulated data."""
+        weekday = [
+            median(vals) if vals else self._baseline_kwh
+            for vals in self._weekday_hours
+        ]
+        weekend = [
+            median(vals) if vals else self._baseline_kwh
+            for vals in self._weekend_hours
+        ]
+        return LoadProfile(weekday=weekday, weekend=weekend)

--- a/custom_components/heo3/operator.py
+++ b/custom_components/heo3/operator.py
@@ -28,7 +28,14 @@ from .adapters.peripheral import (
     TeslaConfig,
     ZappiConfig,
 )
-from .adapters.world import BDConfig, IGOConfig, WorldGatherer
+from .adapters.world import (
+    BDConfig,
+    IGOConfig,
+    LoadHistoryReader,
+    LoadModelConfig,
+    SolcastConfig,
+    WorldGatherer,
+)
 from .agilepredict_client import AgilePredictClient
 from .build import ActionBuilder
 from .compute import Compute
@@ -74,6 +81,10 @@ class Operator:
         bd_config: BDConfig | None = None,
         igo_config: IGOConfig | None = None,
         agilepredict_client: AgilePredictClient | None = None,
+        solcast_config: SolcastConfig | None = None,
+        load_model_config: LoadModelConfig | None = None,
+        load_history_reader: LoadHistoryReader | None = None,
+        local_tz: str = "Europe/London",
     ) -> None:
         self._transport = transport
         self._hass = hass
@@ -101,6 +112,10 @@ class Operator:
             bd_config=bd_config,
             igo_config=igo_config,
             agilepredict_client=agilepredict_client,
+            solcast_config=solcast_config,
+            load_model_config=load_model_config,
+            load_history_reader=load_history_reader,
+            local_tz=local_tz,
             hass=hass,
         )
 

--- a/custom_components/heo3/solar_forecast.py
+++ b/custom_components/heo3/solar_forecast.py
@@ -1,0 +1,60 @@
+"""Solcast HACS attribute → 24-bucket hourly kWh list.
+
+Ported from heo2/solar_forecast.py. The HACS solcast_solar integration
+already converts kW to kWh correctly and exposes per-hour values as the
+`detailedHourly` attribute (or `detailedForecast` for half-hourly).
+This module consumes that attribute. No Home Assistant imports.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+
+
+def solar_forecast_from_hacs(
+    detailed_hourly: list[dict],
+    target_date: date,
+    key: str = "pv_estimate",
+) -> list[float]:
+    """Project a Solcast `detailedHourly` attribute into a 24-bucket
+    hourly kWh list for `target_date` local time.
+
+    Args:
+        detailed_hourly: list from `sensor.solcast_pv_forecast_forecast_today`'s
+            `detailedHourly` attribute. Each entry:
+            `{"period_start": "<ISO8601>", "pv_estimate": kWh, ...}`.
+        target_date: local date to filter to.
+        key: which value field to read.
+            - "pv_estimate" (default) = P50 median
+            - "pv_estimate10" = conservative
+            - "pv_estimate90" = optimistic
+
+    Returns:
+        24 floats, kWh per local hour. Missing entries default to 0.0.
+        Malformed entries silently skipped — one bad row doesn't break
+        the whole forecast.
+    """
+    hourly: list[float] = [0.0] * 24
+
+    for entry in detailed_hourly:
+        ts = entry.get("period_start", "")
+        # HA serialises period_start to ISO when read via REST; in-process
+        # via hass.states it's a datetime object. Accept both.
+        if isinstance(ts, datetime):
+            period_start = ts
+        else:
+            try:
+                period_start = datetime.fromisoformat(str(ts))
+            except (ValueError, TypeError):
+                continue
+
+        if period_start.date() != target_date:
+            continue
+
+        hour = period_start.hour
+        if not (0 <= hour < 24):
+            continue
+
+        hourly[hour] = float(entry.get(key, 0.0))
+
+    return hourly

--- a/custom_components/heo3/types.py
+++ b/custom_components/heo3/types.py
@@ -170,12 +170,34 @@ class PredictedRates:
 
 @dataclass(frozen=True)
 class SolarForecast:
-    """Solcast P10/P50/P90 today + tomorrow. Filled in P1.5."""
+    """Solcast hourly forecast — today + tomorrow, P10/P50/P90.
+
+    Each tuple is 24 floats (kWh per hour). Empty tuples mean the
+    Solcast attribute wasn't available; callers should treat this as
+    "no forecast" rather than "zero solar".
+    """
+
+    today_p50_kwh: tuple[float, ...] = ()
+    tomorrow_p50_kwh: tuple[float, ...] = ()
+    today_p10_kwh: tuple[float, ...] = ()
+    today_p90_kwh: tuple[float, ...] = ()
+    tomorrow_p10_kwh: tuple[float, ...] = ()
+    tomorrow_p90_kwh: tuple[float, ...] = ()
+    last_updated: datetime | None = None
 
 
 @dataclass(frozen=True)
 class LoadForecast:
-    """HEO-5 model output today + tomorrow. Filled in P1.5."""
+    """HEO-5 14-day learning model output.
+
+    24 hourly kWh values for today and tomorrow. Weekday vs weekend
+    profiles are distinct; the planner uses `is_weekend` to select.
+    """
+
+    today_hourly_kwh: tuple[float, ...] = ()
+    tomorrow_hourly_kwh: tuple[float, ...] = ()
+    day_of_week: int = 0  # 0=Monday
+    is_weekend: bool = False
 
 
 @dataclass(frozen=True)

--- a/tests/test_heo3_world_forecasts.py
+++ b/tests/test_heo3_world_forecasts.py
@@ -1,0 +1,173 @@
+"""WorldGatherer forecast tests — Solcast + HEO-5 load model."""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta, timezone
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from heo3.adapters.world import (
+    LoadModelConfig,
+    MockLoadHistoryReader,
+    SolcastConfig,
+    WorldGatherer,
+)
+from heo3.solar_forecast import solar_forecast_from_hacs
+from heo3.state_reader import MockStateReader
+
+
+TZ = ZoneInfo("Europe/London")
+
+
+# ── solar_forecast_from_hacs (port of heo2 helper) ─────────────────
+
+
+def _solcast_entries(target: date, key_value_pairs: list[tuple[int, float]]):
+    return [
+        {
+            "period_start": datetime(
+                target.year, target.month, target.day, h, 0, tzinfo=TZ
+            ).isoformat(),
+            "pv_estimate": v,
+            "pv_estimate10": v * 0.7,
+            "pv_estimate90": v * 1.3,
+        }
+        for h, v in key_value_pairs
+    ]
+
+
+class TestSolarForecastFromHacs:
+    def test_24_buckets_filled(self):
+        target = date(2026, 5, 10)
+        entries = _solcast_entries(target, [(h, float(h)) for h in range(24)])
+        out = solar_forecast_from_hacs(entries, target)
+        assert len(out) == 24
+        assert out[0] == 0.0
+        assert out[12] == 12.0
+        assert out[23] == 23.0
+
+    def test_other_dates_filtered(self):
+        target = date(2026, 5, 10)
+        entries = _solcast_entries(target, [(11, 5.0)])
+        # Add an entry on the next day — shouldn't appear in target's buckets.
+        entries.append(
+            {
+                "period_start": datetime(2026, 5, 11, 11, 0, tzinfo=TZ).isoformat(),
+                "pv_estimate": 99.0,
+            }
+        )
+        out = solar_forecast_from_hacs(entries, target)
+        assert out[11] == 5.0
+        # 99.0 didn't leak into the target day's hour 11.
+
+    def test_p10_p90_keys(self):
+        target = date(2026, 5, 10)
+        entries = _solcast_entries(target, [(11, 10.0)])
+        p10 = solar_forecast_from_hacs(entries, target, "pv_estimate10")
+        p90 = solar_forecast_from_hacs(entries, target, "pv_estimate90")
+        assert p10[11] == pytest.approx(7.0)
+        assert p90[11] == pytest.approx(13.0)
+
+    def test_malformed_entries_skipped(self):
+        target = date(2026, 5, 10)
+        entries = [
+            {"period_start": "garbage"},
+            {"period_start": datetime(2026, 5, 10, 9, 0, tzinfo=TZ).isoformat(), "pv_estimate": 4.0},
+        ]
+        out = solar_forecast_from_hacs(entries, target)
+        assert out[9] == 4.0
+
+
+# ── WorldGatherer.read_solar_forecast ──────────────────────────────
+
+
+class TestReadSolarForecast:
+    @pytest.mark.asyncio
+    async def test_no_state_reader_returns_empty(self):
+        g = WorldGatherer()
+        f = await g.read_solar_forecast()
+        assert f.today_p50_kwh == ()
+        assert f.tomorrow_p50_kwh == ()
+        assert f.last_updated is None
+
+    @pytest.mark.asyncio
+    async def test_full_forecast_parsed(self, monkeypatch):
+        cfg = SolcastConfig()
+        # Use today/tomorrow in UK time.
+        now_uk = datetime.now(TZ).date()
+        tomorrow_uk = now_uk + timedelta(days=1)
+        attrs = {
+            cfg.forecast_today: {
+                "detailedHourly": _solcast_entries(now_uk, [(11, 4.5), (12, 6.2)])
+            },
+            cfg.forecast_tomorrow: {
+                "detailedHourly": _solcast_entries(tomorrow_uk, [(13, 5.0)])
+            },
+        }
+        states = {cfg.api_last_polled: "2026-05-10T04:45:37+00:00"}
+        g = WorldGatherer(
+            state_reader=MockStateReader(states, attrs),
+            local_tz="Europe/London",
+        )
+        f = await g.read_solar_forecast()
+        assert f.today_p50_kwh[11] == 4.5
+        assert f.today_p50_kwh[12] == 6.2
+        assert f.tomorrow_p50_kwh[13] == 5.0
+        assert f.last_updated is not None
+        assert f.last_updated.year == 2026
+
+
+# ── LoadForecast (HEO-5 model) ─────────────────────────────────────
+
+
+class TestReadLoadForecast:
+    @pytest.mark.asyncio
+    async def test_no_history_returns_empty(self):
+        g = WorldGatherer(state_reader=MockStateReader())
+        f = await g.read_load_forecast()
+        assert f.today_hourly_kwh == ()
+        assert f.tomorrow_hourly_kwh == ()
+        assert isinstance(f.day_of_week, int)
+
+    @pytest.mark.asyncio
+    async def test_history_produces_24_buckets(self):
+        # Synthesise 14 days of evenly-spaced power samples so the
+        # aggregator has meaningful data.
+        start = datetime.now(TZ) - timedelta(days=14)
+        samples = []
+        for d in range(14):
+            day_start = start + timedelta(days=d)
+            for h in range(24):
+                samples.append(
+                    (day_start + timedelta(hours=h), 1500.0)  # 1.5 kW constant
+                )
+        # Sentinel sample at end of last day so trapezoidal sees a closing edge.
+        samples.append((start + timedelta(days=14), 1500.0))
+
+        history = MockLoadHistoryReader(samples)
+        g = WorldGatherer(
+            state_reader=MockStateReader(),
+            load_history_reader=history,
+            load_model_config=LoadModelConfig(
+                source_type="power_watts", learn_days=14
+            ),
+            local_tz="Europe/London",
+        )
+        f = await g.read_load_forecast()
+        assert len(f.today_hourly_kwh) == 24
+        assert len(f.tomorrow_hourly_kwh) == 24
+        # 1.5 kW for 1 hour = 1.5 kWh per bucket. Within rounding.
+        for kwh in f.today_hourly_kwh:
+            assert kwh == pytest.approx(1.5, abs=0.05)
+
+    @pytest.mark.asyncio
+    async def test_baseline_used_when_no_data_for_hour(self):
+        # No samples at all → builder uses baseline_w (1900 W → 1.9 kWh).
+        g = WorldGatherer(
+            state_reader=MockStateReader(),
+            load_history_reader=MockLoadHistoryReader([]),
+            load_model_config=LoadModelConfig(baseline_w=1900.0),
+        )
+        f = await g.read_load_forecast()
+        assert all(kwh == pytest.approx(1.9) for kwh in f.today_hourly_kwh)


### PR DESCRIPTION
## Summary

Stacks on #81. Implements §9. Tracking issue #75.

## Lands

**Ported from heo2 per §21 resolution (port-as-is, rewrite separate):**
- \`load_profile.py\` — LoadProfile + LoadProfileBuilder (24-hour median, weekday/weekend split)
- \`load_history.py\` — trapezoidal aggregation, cumulative-kwh aggregator, learn_days_from_samples
- \`solar_forecast.py\` — solar_forecast_from_hacs() projecting Solcast detailedHourly to 24-bucket list

**New types:**
- \`SolarForecast\` — today/tomorrow × P10/P50/P90 hourly tuples + last_updated
- \`LoadForecast\` — today/tomorrow hourly tuples + day_of_week + is_weekend

**WorldGatherer extensions:**
- \`SolcastConfig\` (entity IDs)
- \`LoadModelConfig\` (consumption_entity, source_type, learn_days, baseline_w)
- \`LoadHistoryReader\` Protocol + \`MockLoadHistoryReader\` for tests
- \`read_solar_forecast()\` — full P10/P50/P90 today + tomorrow
- \`read_load_forecast()\` — runs HEO-5 model end-to-end against the configured consumption entity

**Operator** threads solcast_config, load_model_config, load_history_reader, local_tz.

## Tests
- 9 new
- Full suite: 724/724 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)