### PR TITLE
feat(heo3): P1.6 — world gatherer flags + EPS detection

### DIFF
--- a/custom_components/heo3/adapters/world.py
+++ b/custom_components/heo3/adapters/world.py
@@ -23,13 +23,16 @@ from ..load_history import learn_days_from_samples
 from ..load_profile import LoadProfile, LoadProfileBuilder
 from ..solar_forecast import solar_forecast_from_hacs
 from ..state_reader import StateReader, parse_float, parse_str
+from ..state_reader import parse_bool
 from ..types import (
+    IGOPlannedDispatch,
     LiveRates,
     LoadForecast,
     PredictedRates,
     RatePeriod,
     SolarForecast,
     SystemFlags,
+    TimeRange,
 )
 
 logger = logging.getLogger(__name__)
@@ -107,6 +110,61 @@ class SolcastConfig:
 
 
 @dataclass(frozen=True)
+class FlagsConfig:
+    """HA entity IDs the WorldGatherer uses for flag detection.
+
+    Defaults match a typical install but every ID is overridable.
+    `None` for an entity skips that flag (it stays at its default).
+    """
+
+    # Octopus IGO smart-dispatch (binary_sensor.octopus_energy_..._intelligent_dispatching)
+    igo_dispatching_entity: str | None = None
+    # Octopus saving sessions (binary_sensor.octopus_energy_octoplus_saving_sessions)
+    saving_session_entity: str | None = None
+    # Inverter sensors used for derived flags
+    grid_voltage_entity: str = "sensor.sa_inverter_1_grid_voltage"
+    inverter_temperature_entity: str = (
+        "sensor.sa_inverter_1_inverter_temperature"
+    )
+    battery_temperature_entity: str = (
+        "sensor.sa_inverter_1_battery_temperature"
+    )
+    # User-set behavioural flag (HEO III's own switch)
+    defer_ev_eligible_entity: str = "switch.heo3_defer_ev_when_export_high"
+
+    # Thresholds for derived alarms
+    inverter_temperature_alarm_c: float = 65.0
+    battery_temperature_min_c: float = 5.0
+    battery_temperature_max_c: float = 50.0
+    eps_grid_voltage_threshold_v: float = 5.0  # below this counts as "0"
+    eps_debounce_s: float = 5.0
+
+
+class _EPSDetector:
+    """Tracks 'grid_voltage at zero for ≥ debounce_s seconds'.
+
+    Stateful — survives across read_flags() calls within the same
+    WorldGatherer instance. Reset whenever grid voltage rises above
+    the threshold.
+    """
+
+    def __init__(self, debounce_s: float = 5.0, threshold_v: float = 5.0) -> None:
+        self._debounce_s = debounce_s
+        self._threshold_v = threshold_v
+        self._first_zero_at: datetime | None = None
+
+    def update(self, grid_voltage_v: float | None, now: datetime) -> bool:
+        if grid_voltage_v is None or grid_voltage_v > self._threshold_v:
+            self._first_zero_at = None
+            return False
+        if self._first_zero_at is None:
+            self._first_zero_at = now
+            return False
+        elapsed = (now - self._first_zero_at).total_seconds()
+        return elapsed >= self._debounce_s
+
+
+@dataclass(frozen=True)
 class LoadModelConfig:
     """HEO-5 load model wiring.
 
@@ -162,6 +220,7 @@ class WorldGatherer:
         solcast_config: SolcastConfig | None = None,
         load_model_config: LoadModelConfig | None = None,
         load_history_reader: LoadHistoryReader | None = None,
+        flags_config: FlagsConfig | None = None,
         local_tz: str = "Europe/London",
         hass=None,  # type: ignore[no-untyped-def]
     ) -> None:
@@ -172,6 +231,11 @@ class WorldGatherer:
         self._solcast = solcast_config or SolcastConfig()
         self._load_model = load_model_config or LoadModelConfig()
         self._load_history = load_history_reader
+        self._flags_cfg = flags_config or FlagsConfig()
+        self._eps_detector = _EPSDetector(
+            debounce_s=self._flags_cfg.eps_debounce_s,
+            threshold_v=self._flags_cfg.eps_grid_voltage_threshold_v,
+        )
         self._local_tz = ZoneInfo(local_tz)
         self._hass = hass
 
@@ -356,8 +420,82 @@ class WorldGatherer:
 
     # ── Flags (P1.6) ──────────────────────────────────────────────
 
-    async def read_flags(self) -> SystemFlags:
-        raise NotImplementedError("P1.6 — World Gatherer flags")
+    async def read_flags(self, *, now: datetime | None = None) -> SystemFlags:
+        """Derive operational booleans + event windows from external state.
+
+        EPS detection requires temporal state (5s of grid_voltage at
+        zero); the WorldGatherer's _EPSDetector tracks this across
+        successive read_flags() calls.
+        """
+        if now is None:
+            now = datetime.now(timezone.utc)
+
+        if self._state_reader is None:
+            return SystemFlags()
+        r = self._state_reader
+        cfg = self._flags_cfg
+
+        # IGO smart-charge dispatch
+        igo_dispatching = None
+        igo_planned: tuple[IGOPlannedDispatch, ...] = ()
+        if cfg.igo_dispatching_entity is not None:
+            igo_dispatching = parse_bool(
+                r.get_state(cfg.igo_dispatching_entity)
+            )
+            attrs = r.get_attributes(cfg.igo_dispatching_entity)
+            igo_planned = _parse_igo_planned(attrs.get("planned_dispatches", []))
+
+        # Octoplus saving sessions
+        saving_active = None
+        saving_window: TimeRange | None = None
+        saving_price: float | None = None
+        if cfg.saving_session_entity is not None:
+            saving_active = parse_bool(r.get_state(cfg.saving_session_entity))
+            attrs = r.get_attributes(cfg.saving_session_entity)
+            saving_window = _parse_saving_window(attrs)
+            sp = attrs.get("octoplus_session_rewards_pence_per_kwh")
+            if sp is None:
+                sp = attrs.get("price")  # fallback if integration variant differs
+            try:
+                saving_price = float(sp) if sp is not None else None
+            except (TypeError, ValueError):
+                saving_price = None
+
+        # EPS via temporal detector
+        grid_voltage = parse_float(r.get_state(cfg.grid_voltage_entity))
+        eps = self._eps_detector.update(grid_voltage, now)
+
+        # Temperature alarms
+        inv_temp = parse_float(r.get_state(cfg.inverter_temperature_entity))
+        bat_temp = parse_float(r.get_state(cfg.battery_temperature_entity))
+        inv_alarm = (
+            None
+            if inv_temp is None
+            else inv_temp >= cfg.inverter_temperature_alarm_c
+        )
+        bat_alarm = (
+            None
+            if bat_temp is None
+            else (
+                bat_temp < cfg.battery_temperature_min_c
+                or bat_temp > cfg.battery_temperature_max_c
+            )
+        )
+
+        defer_ev = parse_bool(r.get_state(cfg.defer_ev_eligible_entity))
+
+        return SystemFlags(
+            igo_dispatching=igo_dispatching,
+            igo_planned=igo_planned,
+            saving_session_active=saving_active,
+            saving_session_window=saving_window,
+            saving_session_price_pence=saving_price,
+            eps_active=eps,
+            grid_connected=not eps,
+            inverter_temperature_alarm=inv_alarm,
+            battery_temperature_alarm=bat_alarm,
+            defer_ev_eligible=defer_ev if defer_ev is not None else False,
+        )
 
     # ── Convenience accessors for IGO config ──────────────────────
 
@@ -400,6 +538,53 @@ def _parse_rates_attr(raw: Any) -> tuple[RatePeriod, ...]:
         out.append(RatePeriod(start=start, end=end, rate_pence=pence))
     out.sort(key=lambda p: p.start)
     return tuple(out)
+
+
+def _parse_igo_planned(raw: Any) -> tuple[IGOPlannedDispatch, ...]:
+    """Parse the `planned_dispatches` attribute on the IGO binary_sensor."""
+    if not isinstance(raw, list):
+        return ()
+    out: list[IGOPlannedDispatch] = []
+    for entry in raw:
+        if not isinstance(entry, dict):
+            continue
+        start = _try_parse_iso(entry.get("start"))
+        end = _try_parse_iso(entry.get("end"))
+        if start is None or end is None:
+            continue
+        kwh = entry.get("charge_in_kwh")
+        if kwh is None:
+            kwh = entry.get("charge_kwh")
+        try:
+            kwh_val = float(kwh) if kwh is not None else None
+        except (TypeError, ValueError):
+            kwh_val = None
+        source = entry.get("source")
+        out.append(
+            IGOPlannedDispatch(
+                start=start,
+                end=end,
+                charge_kwh=kwh_val,
+                source=str(source) if source is not None else None,
+            )
+        )
+    return tuple(out)
+
+
+def _parse_saving_window(attrs: dict) -> TimeRange | None:
+    """Octoplus saving session window — try a few attribute name variants."""
+    # The integration exposes the active session in different shapes
+    # depending on version. Try common ones.
+    for start_key, end_key in (
+        ("current_session_start", "current_session_end"),
+        ("octoplus_session_start", "octoplus_session_end"),
+        ("start", "end"),
+    ):
+        s = _try_parse_iso(attrs.get(start_key))
+        e = _try_parse_iso(attrs.get(end_key))
+        if s is not None and e is not None:
+            return TimeRange(start=s, end=e)
+    return None
 
 
 def _try_parse_iso(raw: Any) -> datetime | None:

--- a/custom_components/heo3/compute.py
+++ b/custom_components/heo3/compute.py
@@ -19,13 +19,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 
-from .types import PlannedAction, Snapshot
-
-
-@dataclass(frozen=True)
-class TimeRange:
-    start: datetime
-    end: datetime
+from .types import PlannedAction, Snapshot, TimeRange
 
 
 @dataclass(frozen=True)

--- a/custom_components/heo3/operator.py
+++ b/custom_components/heo3/operator.py
@@ -30,6 +30,7 @@ from .adapters.peripheral import (
 )
 from .adapters.world import (
     BDConfig,
+    FlagsConfig,
     IGOConfig,
     LoadHistoryReader,
     LoadModelConfig,
@@ -84,6 +85,7 @@ class Operator:
         solcast_config: SolcastConfig | None = None,
         load_model_config: LoadModelConfig | None = None,
         load_history_reader: LoadHistoryReader | None = None,
+        flags_config: FlagsConfig | None = None,
         local_tz: str = "Europe/London",
     ) -> None:
         self._transport = transport
@@ -115,6 +117,7 @@ class Operator:
             solcast_config=solcast_config,
             load_model_config=load_model_config,
             load_history_reader=load_history_reader,
+            flags_config=flags_config,
             local_tz=local_tz,
             hass=hass,
         )

--- a/custom_components/heo3/types.py
+++ b/custom_components/heo3/types.py
@@ -201,8 +201,47 @@ class LoadForecast:
 
 
 @dataclass(frozen=True)
+class TimeRange:
+    """A start-end window. Used for saving sessions, off-peak windows, etc."""
+
+    start: datetime
+    end: datetime
+
+
+@dataclass(frozen=True)
+class IGOPlannedDispatch:
+    """One Octopus IGO smart-charge dispatch on the planned schedule."""
+
+    start: datetime
+    end: datetime
+    charge_kwh: float | None = None
+    source: str | None = None
+
+
+@dataclass(frozen=True)
 class SystemFlags:
-    """eps_active, igo_dispatching, saving_session, etc. Filled in P1.6."""
+    """Operational flags derived from external state.
+
+    Per §10. Numeric tunables (min_soc, cycle_budget, target_end_soc)
+    live in `SystemConfig`; this dataclass is for derived booleans
+    and event windows the planner reasons about each tick.
+    """
+
+    # Octopus / tariff events
+    igo_dispatching: bool | None = None
+    igo_planned: tuple[IGOPlannedDispatch, ...] = ()
+    saving_session_active: bool | None = None
+    saving_session_window: TimeRange | None = None
+    saving_session_price_pence: float | None = None
+
+    # Mechanical / safety
+    eps_active: bool = False  # derived: grid_voltage == 0 for ≥5s
+    grid_connected: bool = True  # inverse of eps_active
+    inverter_temperature_alarm: bool | None = None
+    battery_temperature_alarm: bool | None = None
+
+    # User-set behavioural flags
+    defer_ev_eligible: bool = False
 
 
 @dataclass(frozen=True)

--- a/tests/test_heo3_world_flags.py
+++ b/tests/test_heo3_world_flags.py
@@ -1,0 +1,235 @@
+"""WorldGatherer.read_flags + EPS detector tests."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from heo3.adapters.world import (
+    FlagsConfig,
+    WorldGatherer,
+    _EPSDetector,
+)
+from heo3.state_reader import MockStateReader
+
+
+# ── EPS detector unit tests ────────────────────────────────────────
+
+
+class TestEPSDetector:
+    def test_voltage_present_no_eps(self):
+        d = _EPSDetector()
+        assert d.update(240.0, datetime.now(timezone.utc)) is False
+
+    def test_voltage_zero_brief_no_eps(self):
+        d = _EPSDetector(debounce_s=5.0)
+        t0 = datetime(2026, 5, 10, 18, 0, 0, tzinfo=timezone.utc)
+        assert d.update(0.0, t0) is False
+        # Same instant — still not 5s
+        assert d.update(0.0, t0 + timedelta(seconds=2)) is False
+
+    def test_voltage_zero_for_5s_triggers(self):
+        d = _EPSDetector(debounce_s=5.0)
+        t0 = datetime(2026, 5, 10, 18, 0, 0, tzinfo=timezone.utc)
+        d.update(0.0, t0)
+        # 5s later it triggers.
+        assert d.update(0.0, t0 + timedelta(seconds=5)) is True
+
+    def test_voltage_recovers_resets(self):
+        d = _EPSDetector(debounce_s=5.0)
+        t0 = datetime(2026, 5, 10, 18, 0, 0, tzinfo=timezone.utc)
+        d.update(0.0, t0)
+        # Voltage comes back at 3s — clears the timer.
+        assert d.update(240.0, t0 + timedelta(seconds=3)) is False
+        # Next zero starts fresh.
+        d.update(0.0, t0 + timedelta(seconds=4))
+        # 4s after that is only 4s of zero — not enough.
+        assert d.update(0.0, t0 + timedelta(seconds=8)) is False
+        # 5s after the new start triggers.
+        assert d.update(0.0, t0 + timedelta(seconds=9)) is True
+
+    def test_voltage_unknown_resets(self):
+        d = _EPSDetector(debounce_s=5.0)
+        t0 = datetime(2026, 5, 10, 18, 0, 0, tzinfo=timezone.utc)
+        d.update(0.0, t0)
+        # Sensor goes unknown — treat as not-EPS (don't accumulate).
+        assert d.update(None, t0 + timedelta(seconds=3)) is False
+        # Even after another 5s of None, still no EPS (we don't know).
+        assert d.update(None, t0 + timedelta(seconds=10)) is False
+
+    def test_threshold_voltage_treated_as_zero(self):
+        d = _EPSDetector(debounce_s=5.0, threshold_v=10.0)
+        t0 = datetime(2026, 5, 10, 18, 0, 0, tzinfo=timezone.utc)
+        d.update(5.0, t0)  # below threshold counts as "0"
+        assert d.update(5.0, t0 + timedelta(seconds=5)) is True
+
+
+# ── read_flags ─────────────────────────────────────────────────────
+
+
+class TestReadFlagsEmpty:
+    @pytest.mark.asyncio
+    async def test_no_state_reader_returns_defaults(self):
+        g = WorldGatherer()
+        flags = await g.read_flags()
+        assert flags.eps_active is False
+        assert flags.grid_connected is True
+        assert flags.igo_dispatching is None
+        assert flags.saving_session_active is None
+        assert flags.defer_ev_eligible is False
+
+
+class TestIGOFlags:
+    @pytest.mark.asyncio
+    async def test_dispatching_and_planned(self):
+        cfg = FlagsConfig(
+            igo_dispatching_entity="binary_sensor.octopus_intelligent_dispatching"
+        )
+        attrs = {
+            cfg.igo_dispatching_entity: {
+                "planned_dispatches": [
+                    {
+                        "start": "2026-05-11T00:00:00+00:00",
+                        "end": "2026-05-11T03:00:00+00:00",
+                        "charge_in_kwh": 7.5,
+                        "source": "smart-charge",
+                    },
+                ]
+            }
+        }
+        g = WorldGatherer(
+            state_reader=MockStateReader(
+                {cfg.igo_dispatching_entity: "on"}, attrs
+            ),
+            flags_config=cfg,
+        )
+        flags = await g.read_flags()
+        assert flags.igo_dispatching is True
+        assert len(flags.igo_planned) == 1
+        assert flags.igo_planned[0].charge_kwh == 7.5
+        assert flags.igo_planned[0].source == "smart-charge"
+
+    @pytest.mark.asyncio
+    async def test_malformed_planned_entries_skipped(self):
+        cfg = FlagsConfig(igo_dispatching_entity="binary_sensor.x")
+        attrs = {
+            cfg.igo_dispatching_entity: {
+                "planned_dispatches": [
+                    {"start": "garbage", "end": "x"},
+                    {  # valid
+                        "start": "2026-05-11T00:00:00+00:00",
+                        "end": "2026-05-11T03:00:00+00:00",
+                    },
+                ]
+            }
+        }
+        g = WorldGatherer(
+            state_reader=MockStateReader({}, attrs),
+            flags_config=cfg,
+        )
+        flags = await g.read_flags()
+        assert len(flags.igo_planned) == 1
+
+
+class TestSavingSession:
+    @pytest.mark.asyncio
+    async def test_active_session_with_window(self):
+        cfg = FlagsConfig(
+            saving_session_entity="binary_sensor.octoplus_saving_sessions"
+        )
+        attrs = {
+            cfg.saving_session_entity: {
+                "current_session_start": "2026-05-10T17:00:00+00:00",
+                "current_session_end": "2026-05-10T18:00:00+00:00",
+                "octoplus_session_rewards_pence_per_kwh": 350.0,
+            }
+        }
+        g = WorldGatherer(
+            state_reader=MockStateReader(
+                {cfg.saving_session_entity: "on"}, attrs
+            ),
+            flags_config=cfg,
+        )
+        flags = await g.read_flags()
+        assert flags.saving_session_active is True
+        assert flags.saving_session_window is not None
+        assert flags.saving_session_window.start.hour == 17
+        assert flags.saving_session_price_pence == 350.0
+
+
+class TestTemperatureAlarms:
+    @pytest.mark.asyncio
+    async def test_inverter_alarm_above_threshold(self):
+        cfg = FlagsConfig(inverter_temperature_alarm_c=65.0)
+        g = WorldGatherer(
+            state_reader=MockStateReader(
+                {cfg.inverter_temperature_entity: "70"}
+            ),
+            flags_config=cfg,
+        )
+        flags = await g.read_flags()
+        assert flags.inverter_temperature_alarm is True
+
+    @pytest.mark.asyncio
+    async def test_battery_alarm_outside_safe_range(self):
+        cfg = FlagsConfig(
+            battery_temperature_min_c=5.0, battery_temperature_max_c=50.0
+        )
+        # Too cold:
+        g = WorldGatherer(
+            state_reader=MockStateReader(
+                {cfg.battery_temperature_entity: "2"}
+            ),
+            flags_config=cfg,
+        )
+        flags = await g.read_flags()
+        assert flags.battery_temperature_alarm is True
+
+        # In range:
+        g2 = WorldGatherer(
+            state_reader=MockStateReader(
+                {cfg.battery_temperature_entity: "25"}
+            ),
+            flags_config=cfg,
+        )
+        assert (await g2.read_flags()).battery_temperature_alarm is False
+
+
+class TestEPSIntegration:
+    @pytest.mark.asyncio
+    async def test_grid_voltage_at_zero_then_5s(self):
+        cfg = FlagsConfig(eps_debounce_s=5.0)
+        reader = MockStateReader({cfg.grid_voltage_entity: "0"})
+        g = WorldGatherer(state_reader=reader, flags_config=cfg)
+
+        t0 = datetime(2026, 5, 10, 18, 0, 0, tzinfo=timezone.utc)
+        first = await g.read_flags(now=t0)
+        assert first.eps_active is False
+        # 5s later: triggers.
+        triggered = await g.read_flags(now=t0 + timedelta(seconds=5))
+        assert triggered.eps_active is True
+        assert triggered.grid_connected is False
+
+
+class TestDeferEV:
+    @pytest.mark.asyncio
+    async def test_user_switch_on(self):
+        cfg = FlagsConfig()
+        g = WorldGatherer(
+            state_reader=MockStateReader(
+                {cfg.defer_ev_eligible_entity: "on"}
+            ),
+            flags_config=cfg,
+        )
+        flags = await g.read_flags()
+        assert flags.defer_ev_eligible is True
+
+    @pytest.mark.asyncio
+    async def test_user_switch_off_or_missing(self):
+        g = WorldGatherer(
+            state_reader=MockStateReader(),  # missing → False
+            flags_config=FlagsConfig(),
+        )
+        flags = await g.read_flags()
+        assert flags.defer_ev_eligible is False


### PR DESCRIPTION
## Summary

Stacks on #82. Implements §10. Tracking issue #75.

## Lands

**Types:**
- \`TimeRange\` (consolidated to types.py from compute.py)
- \`IGOPlannedDispatch\`
- \`SystemFlags\` (10 fields: tariff events + mechanical safety + user flags)

**\`FlagsConfig\`** — entity IDs for IGO + Octoplus + inverter sensors + the HEO III \`switch.heo3_defer_ev_when_export_high\` user toggle. None defaults for IGO/saving means missing-integration installs degrade gracefully. Configurable thresholds (inverter alarm 65°C, battery 5-50°C, EPS 5s debounce / 5V threshold).

**\`_EPSDetector\`** — stateful tracker for "grid_voltage at zero for ≥ debounce_s". Resets on any non-zero reading. Treats missing sensor as "not zero" (don't accumulate when blind).

**\`WorldGatherer.read_flags(now=None)\`** — derives all 10 fields. Pass explicit \`now\` for time-pinned tests; defaults to \`datetime.now(UTC)\`.

Handles real-world quirks:
- Octopus \`charge_in_kwh\` vs \`charge_kwh\` attribute name variants
- 3 saving-session window attribute naming variants

## Tests
- 15 new (EPS detector unit tests + read_flags integration)
- Full suite: 739/739 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)