### PR TITLE
fix(heo3): tick budget mitigation + auto-discovery

### DIFF
--- a/custom_components/heo3/__init__.py
+++ b/custom_components/heo3/__init__.py
@@ -3,11 +3,15 @@
 Tracking issue: https://github.com/a1acrity/heo2/issues/75
 Design doc: docs/HEO_III_DESIGN.md
 
-The integration constructs an Operator with the real PahoTransport
-(direct connection to SA's broker, bypassing HA's mqtt bridge —
-the bridge breaks SA telemetry on mosquitto 2.1.2). No coordinator
-or scheduler yet — the operator is callable but won't tick on its
-own. Manual one-shot scripts use it via hass.data[DOMAIN][entry_id].
+The integration constructs an Operator with:
+- PahoTransport (paho-MQTT direct to SA's broker)
+- HAStateReader / HAServiceCaller (HA-backed adapters)
+- BD / IGO / Saving-session / Tesla / Zappi / appliance entity IDs
+  AUTO-DISCOVERED from the live HA registry (see discovery.py)
+
+No coordinator or scheduler yet — the operator is callable but
+won't tick on its own. Manual one-shot scripts use it via
+hass.data[DOMAIN][entry_id].
 """
 
 from __future__ import annotations
@@ -15,7 +19,10 @@ from __future__ import annotations
 import asyncio
 import logging
 
+from .adapters.peripheral import TeslaConfig, ZappiConfig
+from .adapters.world import BDConfig, FlagsConfig
 from .const import DEFAULT_MQTT_HOST, DEFAULT_MQTT_PORT, DOMAIN
+from .discovery import discover_all
 from .operator import Operator
 from .service_caller_ha import HAServiceCaller
 from .services import async_register_services
@@ -30,6 +37,16 @@ CONF_PORT = "port"
 logger = logging.getLogger(__name__)
 
 PLATFORMS: list[str] = []  # Sensors/switches added in a later phase.
+
+# Default appliance switches. Stays as built-in for now (the only
+# discoverable hint is "switch.<name>" naming, which is too loose to
+# auto-detect reliably). Extend the config flow when the planner
+# needs different sets per install.
+DEFAULT_APPLIANCES = {
+    "washer": "switch.washer",
+    "dryer": "switch.dryer",
+    "dishwasher": "switch.dishwasher",
+}
 
 
 async def async_setup_entry(hass, entry) -> bool:  # type: ignore[no-untyped-def]
@@ -49,16 +66,51 @@ async def async_setup_entry(hass, entry) -> bool:  # type: ignore[no-untyped-def
         )
         raise
 
+    discovered = discover_all(hass)
+    logger.info("HEO III discovery: %s", discovered)
+
+    bd_config = (
+        BDConfig.from_meter_key(discovered["bd_meter_key"])
+        if discovered["bd_meter_key"]
+        else None
+    )
+    flags_config = FlagsConfig(
+        igo_dispatching_entity=discovered["igo_dispatching_entity"],
+        saving_session_entity=discovered["saving_session_entity"],
+    )
+    tesla_config = (
+        TeslaConfig.from_vehicle(discovered["tesla_vehicle"])
+        if discovered["tesla_vehicle"]
+        else None
+    )
+    zappi_prefix = discovered["zappi_prefix"]
+    zappi_config = (
+        ZappiConfig(
+            charge_mode=f"select.{zappi_prefix}_charge_mode",
+            charging_state=f"sensor.{zappi_prefix}_status",
+            charge_power=f"sensor.{zappi_prefix}_power_ct_internal_load",
+        )
+        if zappi_prefix
+        else None
+    )
+
     operator = Operator(
         transport=transport,
         hass=hass,
         state_reader=HAStateReader(hass),
         service_caller=HAServiceCaller(hass),
+        bd_config=bd_config,
+        flags_config=flags_config,
+        tesla_config=tesla_config,
+        zappi_config=zappi_config,
+        appliance_switches=DEFAULT_APPLIANCES,
+        inverter_sensor_overrides=discovered["inverter_sensor_overrides"],
     )
 
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {
         "operator": operator,
         "transport": transport,
+        "discovered": discovered,
     }
 
     await async_register_services(hass)

--- a/custom_components/heo3/adapters/inverter.py
+++ b/custom_components/heo3/adapters/inverter.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import time as _time
 from dataclasses import replace
 from typing import Iterable
 
@@ -56,7 +57,7 @@ from .inverter_validate import (
 logger = logging.getLogger(__name__)
 
 # Per-attempt response timeout. SA usually responds in 1-3s.
-RESPONSE_TIMEOUT_S = 5.0
+RESPONSE_TIMEOUT_S = 10.0
 
 # SA response payloads (per HEO-32 / reference_sa_mqtt.md).
 RESPONSE_OK = "Saved"
@@ -328,27 +329,33 @@ class InverterAdapter:
         """Publish one write, await SA response with retries.
 
         Retry policy:
-        - Up to WRITE_RETRY_LIMIT (3) attempts on TIMEOUT.
+        - Up to WRITE_RETRY_LIMIT attempts on TIMEOUT.
         - No retry on explicit `Error: ...` responses — those are
           vocabulary mismatches that won't fix on retry (HEO-32 lesson).
-        - WRITE_RETRY_BACKOFF_S (5s) between attempts.
+        - WRITE_RETRY_BACKOFF_S between attempts.
 
         Returns one of: VERIFY_OK_FROM_SA, VERIFY_FAILED, VERIFY_TIMEOUT.
+        Logs per-attempt duration at INFO so we can profile in
+        production where SA's actual response latency lives.
         """
         await self.ensure_subscribed()
 
         last_state = VERIFY_TIMEOUT
+        total_start = _time.monotonic()
         for attempt in range(1, WRITE_RETRY_LIMIT + 1):
             self._response_future = asyncio.get_event_loop().create_future()
+            attempt_start = _time.monotonic()
             try:
                 await self._transport.publish(write.topic, write.payload)
                 payload = await asyncio.wait_for(
                     self._response_future, timeout=RESPONSE_TIMEOUT_S
                 )
             except asyncio.TimeoutError:
+                elapsed_ms = (_time.monotonic() - attempt_start) * 1000.0
                 logger.warning(
-                    "SA response timeout on %s (attempt %d/%d)",
+                    "SA response timeout on %s after %.0fms (attempt %d/%d)",
                     write.topic,
+                    elapsed_ms,
                     attempt,
                     WRITE_RETRY_LIMIT,
                 )
@@ -359,18 +366,25 @@ class InverterAdapter:
             finally:
                 self._response_future = None
 
+            attempt_ms = (_time.monotonic() - attempt_start) * 1000.0
+            total_ms = (_time.monotonic() - total_start) * 1000.0
+
             if payload == RESPONSE_OK:
+                logger.info(
+                    "SA OK on %s in %.0fms (attempt %d, total %.0fms)",
+                    write.topic, attempt_ms, attempt, total_ms,
+                )
                 return VERIFY_OK_FROM_SA
             if payload.startswith(RESPONSE_ERROR_PREFIX):
                 logger.error(
-                    "SA returned %s for %s — not retrying (vocabulary mismatch)",
-                    payload,
-                    write.topic,
+                    "SA returned %s for %s in %.0fms — not retrying "
+                    "(vocabulary mismatch)",
+                    payload, write.topic, attempt_ms,
                 )
                 return VERIFY_FAILED
-            # Unexpected payload — treat as failure, don't retry.
             logger.error(
-                "Unexpected SA response %r for %s", payload, write.topic
+                "Unexpected SA response %r for %s in %.0fms",
+                payload, write.topic, attempt_ms,
             )
             return VERIFY_FAILED
 

--- a/custom_components/heo3/const.py
+++ b/custom_components/heo3/const.py
@@ -9,10 +9,16 @@ DEFAULT_MQTT_PORT = 1883
 # Inverter identity. Per SPEC §2: writes only ever go to inverter 1.
 DEFAULT_INVERTER_NAME = "inverter_1"
 
-# Tick latency budget (§21 resolution).
-TICK_HARD_BUDGET_S = 60.0
-TICK_WARNING_S = 30.0
+# Tick latency budget. Original §21 resolution was 60s/30s but live
+# observation showed ~6-10s per write under SA's actual response
+# latency, so 10 writes per tick saturated the budget. Bumped to give
+# the planner headroom; revisit once we have proper profiling.
+TICK_HARD_BUDGET_S = 120.0
+TICK_WARNING_S = 60.0
 
-# Verification cycle (§16).
+# Verification cycle (§16). RESPONSE_TIMEOUT_S bumped from 5s to 10s
+# because some SA responses arrive at the 5-7s mark on Paddy's install
+# (probably broker queueing or paho dispatch lag). 10s avoids spurious
+# retries that double the per-write cost.
 WRITE_RETRY_LIMIT = 3
-WRITE_RETRY_BACKOFF_S = 5.0
+WRITE_RETRY_BACKOFF_S = 2.0

--- a/custom_components/heo3/discovery.py
+++ b/custom_components/heo3/discovery.py
@@ -1,0 +1,183 @@
+"""Auto-discovery of HEO III config from HA entity registry.
+
+Each function scans hass.states for the right entity-name pattern and
+returns the discovered value (or None). Used by __init__.py at setup
+time so the user doesn't have to enter half a dozen entity IDs by
+hand.
+
+Discovery is best-effort. If an integration isn't installed or has
+unusual naming, the discovery returns None and the operator's
+adapter degrades gracefully (returns empty/None for that data).
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def _all_entity_ids(hass) -> list[str]:  # type: ignore[no-untyped-def]
+    return [s.entity_id for s in hass.states.async_all()]
+
+
+# ── BD (octopus_energy) ───────────────────────────────────────────
+
+
+_BD_DAY_RATES_PATTERN = re.compile(
+    r"^event\.octopus_energy_electricity_(?P<key>[^_]+_[^_]+)_current_day_rates$"
+)
+
+
+def discover_bd_meter_key(hass) -> str | None:  # type: ignore[no-untyped-def]
+    """Find the BD electricity import meter key {mpan}_{serial}.
+
+    Picks the import meter (no `_export_` infix). Returns None if
+    no event.octopus_energy_electricity_..._current_day_rates entity
+    exists.
+    """
+    candidates = []
+    for eid in _all_entity_ids(hass):
+        m = _BD_DAY_RATES_PATTERN.match(eid)
+        if m:
+            candidates.append(m.group("key"))
+    if not candidates:
+        return None
+    if len(candidates) > 1:
+        logger.warning(
+            "Multiple BD import meters detected: %s. Using first.",
+            candidates,
+        )
+    return candidates[0]
+
+
+# ── IGO smart-charge ──────────────────────────────────────────────
+
+
+def discover_igo_dispatching_entity(
+    hass,  # type: ignore[no-untyped-def]
+) -> str | None:
+    for eid in _all_entity_ids(hass):
+        if eid.startswith("binary_sensor.octopus_energy_") and eid.endswith(
+            "_intelligent_dispatching"
+        ):
+            return eid
+    return None
+
+
+# ── Octoplus saving sessions ──────────────────────────────────────
+
+
+def discover_saving_session_entity(
+    hass,  # type: ignore[no-untyped-def]
+) -> str | None:
+    for eid in _all_entity_ids(hass):
+        if (
+            eid.startswith("binary_sensor.octopus_energy_")
+            and eid.endswith("_octoplus_saving_sessions")
+        ):
+            return eid
+    return None
+
+
+# ── Zappi ─────────────────────────────────────────────────────────
+
+
+_ZAPPI_CHARGE_MODE_PATTERN = re.compile(
+    r"^select\.(myenergi_zappi_\d+)_charge_mode$"
+)
+
+
+def discover_zappi_prefix(hass) -> str | None:  # type: ignore[no-untyped-def]
+    """Returns e.g. 'myenergi_zappi_22752031' (no domain prefix)."""
+    for eid in _all_entity_ids(hass):
+        m = _ZAPPI_CHARGE_MODE_PATTERN.match(eid)
+        if m:
+            return m.group(1)
+    return None
+
+
+# ── Tesla (Teslemetry) ────────────────────────────────────────────
+
+
+_TESLA_LOCATED_PATTERN = re.compile(
+    r"^binary_sensor\.([a-z0-9_]+)_located_at_home$"
+)
+
+
+def discover_tesla_vehicle(hass) -> str | None:  # type: ignore[no-untyped-def]
+    """Returns the vehicle short-name (e.g. 'natalia') if Teslemetry
+    exposes a `binary_sensor.<vehicle>_located_at_home` paired with a
+    `switch.<vehicle>_charge`.
+    """
+    located_match = None
+    for eid in _all_entity_ids(hass):
+        m = _TESLA_LOCATED_PATTERN.match(eid)
+        if m:
+            located_match = m.group(1)
+            break
+    if located_match is None:
+        return None
+    # Confirm the matching charge switch exists — narrows away from
+    # non-Tesla "located_at_home" sensors (e.g. for Wi-Fi presence).
+    if f"switch.{located_match}_charge" in _all_entity_ids(hass):
+        return located_match
+    return None
+
+
+# ── Inverter sensor overrides ─────────────────────────────────────
+
+# Real SA naming on Paddy's install differs from the leaf names HEO III
+# uses internally. Discovery tries both the "expected" and the "real"
+# entity IDs and returns an override map for the ones that need it.
+
+_INVERTER_OVERRIDE_CANDIDATES: dict[str, list[str]] = {
+    "battery_soc": [
+        "sensor.sa_total_battery_state_of_charge",
+        "sensor.sa_inverter_1_battery_soc",
+    ],
+    "solar_power": [
+        "sensor.sa_inverter_1_pv_power",
+        "sensor.sa_inverter_1_solar_power",
+    ],
+    "inverter_temperature": [
+        "sensor.sa_inverter_1_temperature",
+        "sensor.sa_inverter_1_inverter_temperature",
+    ],
+}
+
+
+def discover_inverter_sensor_overrides(
+    hass,  # type: ignore[no-untyped-def]
+) -> dict[str, str]:
+    """Return {leaf: full_entity_id} for any leaf whose default name
+    doesn't exist on this install but a known alternative does.
+    """
+    states = set(_all_entity_ids(hass))
+    out: dict[str, str] = {}
+    for leaf, candidates in _INVERTER_OVERRIDE_CANDIDATES.items():
+        default = f"sensor.sa_inverter_1_{leaf}"
+        if default in states:
+            continue  # No override needed.
+        for alt in candidates:
+            if alt in states:
+                out[leaf] = alt
+                break
+    return out
+
+
+# ── Combined ──────────────────────────────────────────────────────
+
+
+def discover_all(hass) -> dict[str, Any]:  # type: ignore[no-untyped-def]
+    """Run every discoverer in one call, return a dict for logging."""
+    return {
+        "bd_meter_key": discover_bd_meter_key(hass),
+        "igo_dispatching_entity": discover_igo_dispatching_entity(hass),
+        "saving_session_entity": discover_saving_session_entity(hass),
+        "zappi_prefix": discover_zappi_prefix(hass),
+        "tesla_vehicle": discover_tesla_vehicle(hass),
+        "inverter_sensor_overrides": discover_inverter_sensor_overrides(hass),
+    }

--- a/custom_components/heo3/services.py
+++ b/custom_components/heo3/services.py
@@ -12,52 +12,19 @@ Two services exposed via standard HA service-call:
     summary on `sensor.heo3_last_apply`. THIS WRITES TO THE INVERTER.
 
 Both use the operator on hass.data[DOMAIN][<entry_id>]. If multiple
-entries exist (test installs), the first one is used.
-
-State sensors are set via hass.states.async_set rather than registered
-as a real platform — this keeps the diagnostic surface trivial to
-read via REST without adding a sensor.py.
+entries exist (test installs), the first one is used. The operator
+is fully configured at setup via discovery — no service-time
+patching needed (was a workaround before discovery.py landed).
 """
 
 from __future__ import annotations
 
-import json
 import logging
 from typing import Any
 
-from .adapters.peripheral import TeslaConfig
-from .adapters.world import BDConfig, FlagsConfig
 from .const import DOMAIN
 
 logger = logging.getLogger(__name__)
-
-# Paddy's house defaults — patched onto the operator at service time
-# until the config flow learns to ask for them.
-DEFAULT_BD_METER_KEY = "18p5009498_2372761090617"
-DEFAULT_IGO_DISPATCH_ENTITY = (
-    "binary_sensor.octopus_energy_00000000_0009_4000_8020_000000032ba2"
-    "_intelligent_dispatching"
-)
-DEFAULT_SAVING_SESSION_ENTITY = (
-    "binary_sensor.octopus_energy_a_8e04cfcf_octoplus_saving_sessions"
-)
-DEFAULT_TESLA_VEHICLE = "natalia"
-DEFAULT_APPLIANCES = {
-    "washer": "switch.washer",
-    "dryer": "switch.dryer",
-    "dishwasher": "switch.dishwasher",
-}
-
-# Real SA + zappi entity names on Paddy's install (verified via REST scan).
-# These differ from the leaf-name conventions HEO III's adapters use
-# internally — patched in here until the config flow learns to ask.
-DEFAULT_INVERTER_SENSOR_OVERRIDES = {
-    "battery_soc": "sensor.sa_total_battery_state_of_charge",
-    "solar_power": "sensor.sa_inverter_1_pv_power",
-    "inverter_temperature": "sensor.sa_inverter_1_temperature",
-}
-# Zappi entity ID prefix includes the device serial.
-DEFAULT_ZAPPI_PREFIX = "myenergi_zappi_22752031"
 
 
 async def async_register_services(hass) -> None:  # type: ignore[no-untyped-def]
@@ -69,7 +36,6 @@ async def async_register_services(hass) -> None:  # type: ignore[no-untyped-def]
             logger.error("heo3.snapshot_log: no HEO III config entry loaded")
             return
 
-        _patch_house_config(op)
         try:
             snap = await op.snapshot()
         except Exception as exc:
@@ -131,7 +97,6 @@ async def async_register_services(hass) -> None:  # type: ignore[no-untyped-def]
             logger.error("heo3.apply_baseline_static: no config entry loaded")
             return
 
-        _patch_house_config(op)
         try:
             snap = await op.snapshot()
             plan = op.build.baseline_static(snap)
@@ -191,46 +156,3 @@ def _get_operator(hass) -> Any | None:  # type: ignore[no-untyped-def]
         if isinstance(entry_data, dict) and "operator" in entry_data:
             return entry_data["operator"]
     return None
-
-
-def _patch_house_config(op) -> None:
-    """Monkey-patch BD/Flags/Tesla/appliance config onto the operator
-    until the config flow learns to ask for them.
-
-    Also patches inverter sensor overrides + zappi entity prefix
-    (real SA + zappi naming differs from the internal leaf-name
-    conventions). Idempotent — re-calling is safe.
-    """
-    from dataclasses import replace
-    from .adapters.peripheral import ZappiConfig
-
-    if op._world._bd is None:
-        op._world._bd = BDConfig.from_meter_key(DEFAULT_BD_METER_KEY)
-
-    if op._world._flags_cfg.igo_dispatching_entity is None:
-        op._world._flags_cfg = replace(
-            op._world._flags_cfg,
-            igo_dispatching_entity=DEFAULT_IGO_DISPATCH_ENTITY,
-            saving_session_entity=DEFAULT_SAVING_SESSION_ENTITY,
-        )
-
-    if op._peripheral._tesla is None:
-        op._peripheral._tesla = TeslaConfig.from_vehicle(DEFAULT_TESLA_VEHICLE)
-
-    # Real zappi entity naming includes the serial number.
-    op._peripheral._zappi = ZappiConfig(
-        charge_mode=f"select.{DEFAULT_ZAPPI_PREFIX}_charge_mode",
-        charging_state=f"sensor.{DEFAULT_ZAPPI_PREFIX}_status",
-        charge_power=f"sensor.{DEFAULT_ZAPPI_PREFIX}_power_ct_internal_load",
-    )
-
-    if not op._peripheral._appliance_switches:
-        op._peripheral._appliance_switches = dict(DEFAULT_APPLIANCES)
-        op._peripheral._appliance_running = {
-            name: f"binary_sensor.{name}_running"
-            for name in DEFAULT_APPLIANCES
-        }
-
-    # Patch the inverter sensor overrides for entity names that
-    # don't fit the sa_<inverter>_<leaf> convention.
-    op._inverter._sensor_overrides.update(DEFAULT_INVERTER_SENSOR_OVERRIDES)

--- a/tests/test_heo3_discovery.py
+++ b/tests/test_heo3_discovery.py
@@ -1,0 +1,197 @@
+"""Auto-discovery tests against a fake hass.states surface."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from heo3.discovery import (
+    discover_all,
+    discover_bd_meter_key,
+    discover_igo_dispatching_entity,
+    discover_inverter_sensor_overrides,
+    discover_saving_session_entity,
+    discover_tesla_vehicle,
+    discover_zappi_prefix,
+)
+
+
+def _hass(entity_ids):
+    """Build a fake hass with a given list of entity IDs."""
+    states = [SimpleNamespace(entity_id=eid) for eid in entity_ids]
+    hass = MagicMock()
+    hass.states.async_all.return_value = states
+    return hass
+
+
+# ── BD meter key ───────────────────────────────────────────────────
+
+
+class TestBDMeterKey:
+    def test_finds_import_meter(self):
+        hass = _hass([
+            "event.octopus_energy_electricity_18p5009498_2372761090617_current_day_rates",
+            "event.octopus_energy_electricity_18p5009498_2394300396097_export_current_day_rates",
+            "sensor.unrelated",
+        ])
+        assert (
+            discover_bd_meter_key(hass)
+            == "18p5009498_2372761090617"
+        )
+
+    def test_export_meter_skipped(self):
+        # Only export entity present — no import meter to discover.
+        hass = _hass([
+            "event.octopus_energy_electricity_X_Y_export_current_day_rates",
+        ])
+        assert discover_bd_meter_key(hass) is None
+
+    def test_no_octopus_returns_none(self):
+        hass = _hass(["sensor.foo", "sensor.bar"])
+        assert discover_bd_meter_key(hass) is None
+
+
+# ── IGO ────────────────────────────────────────────────────────────
+
+
+class TestIGODispatching:
+    def test_finds_intelligent_dispatching(self):
+        hass = _hass([
+            "binary_sensor.octopus_energy_00000000_intelligent_dispatching",
+            "sensor.unrelated",
+        ])
+        assert (
+            discover_igo_dispatching_entity(hass)
+            == "binary_sensor.octopus_energy_00000000_intelligent_dispatching"
+        )
+
+    def test_no_match_returns_none(self):
+        hass = _hass(["sensor.foo"])
+        assert discover_igo_dispatching_entity(hass) is None
+
+
+# ── Octoplus saving sessions ──────────────────────────────────────
+
+
+class TestSavingSession:
+    def test_finds_octoplus_saving_sessions(self):
+        hass = _hass([
+            "binary_sensor.octopus_energy_a_8e04cfcf_octoplus_saving_sessions",
+        ])
+        assert (
+            discover_saving_session_entity(hass)
+            == "binary_sensor.octopus_energy_a_8e04cfcf_octoplus_saving_sessions"
+        )
+
+
+# ── Zappi ─────────────────────────────────────────────────────────
+
+
+class TestZappi:
+    def test_finds_charge_mode_select(self):
+        hass = _hass([
+            "select.myenergi_zappi_22752031_charge_mode",
+            "sensor.myenergi_zappi_22752031_status",
+        ])
+        assert discover_zappi_prefix(hass) == "myenergi_zappi_22752031"
+
+    def test_no_zappi_returns_none(self):
+        hass = _hass(["sensor.foo"])
+        assert discover_zappi_prefix(hass) is None
+
+
+# ── Tesla ─────────────────────────────────────────────────────────
+
+
+class TestTesla:
+    def test_finds_natalia_when_paired(self):
+        hass = _hass([
+            "binary_sensor.natalia_located_at_home",
+            "switch.natalia_charge",
+        ])
+        assert discover_tesla_vehicle(hass) == "natalia"
+
+    def test_located_without_charge_switch_skipped(self):
+        # presence-only sensor (e.g. iBeacon) shouldn't match Tesla.
+        hass = _hass([
+            "binary_sensor.iphone_located_at_home",
+        ])
+        assert discover_tesla_vehicle(hass) is None
+
+    def test_no_tesla_returns_none(self):
+        hass = _hass(["sensor.foo"])
+        assert discover_tesla_vehicle(hass) is None
+
+
+# ── Inverter sensor overrides ─────────────────────────────────────
+
+
+class TestInverterOverrides:
+    def test_default_battery_soc_present_no_override(self):
+        hass = _hass([
+            "sensor.sa_inverter_1_battery_soc",  # default present
+            "sensor.sa_inverter_1_pv_power",  # solar override needed
+            "sensor.sa_inverter_1_temperature",  # temp override needed
+        ])
+        out = discover_inverter_sensor_overrides(hass)
+        assert "battery_soc" not in out
+        assert out["solar_power"] == "sensor.sa_inverter_1_pv_power"
+        assert out["inverter_temperature"] == "sensor.sa_inverter_1_temperature"
+
+    def test_total_state_of_charge_used_when_no_default(self):
+        hass = _hass([
+            "sensor.sa_total_battery_state_of_charge",
+            "sensor.sa_inverter_1_pv_power",
+            "sensor.sa_inverter_1_temperature",
+        ])
+        out = discover_inverter_sensor_overrides(hass)
+        assert (
+            out["battery_soc"]
+            == "sensor.sa_total_battery_state_of_charge"
+        )
+
+    def test_no_relevant_entities_empty_overrides(self):
+        # Default present for everything → no overrides.
+        hass = _hass([
+            "sensor.sa_inverter_1_battery_soc",
+            "sensor.sa_inverter_1_solar_power",
+            "sensor.sa_inverter_1_inverter_temperature",
+        ])
+        assert discover_inverter_sensor_overrides(hass) == {}
+
+
+# ── discover_all ──────────────────────────────────────────────────
+
+
+class TestDiscoverAll:
+    def test_paddy_install_shape(self):
+        # Realistic subset of paddy's install
+        hass = _hass([
+            "event.octopus_energy_electricity_18p5009498_2372761090617_current_day_rates",
+            "binary_sensor.octopus_energy_00000000_intelligent_dispatching",
+            "binary_sensor.octopus_energy_a_8e04cfcf_octoplus_saving_sessions",
+            "select.myenergi_zappi_22752031_charge_mode",
+            "binary_sensor.natalia_located_at_home",
+            "switch.natalia_charge",
+            "sensor.sa_total_battery_state_of_charge",
+            "sensor.sa_inverter_1_pv_power",
+            "sensor.sa_inverter_1_temperature",
+        ])
+        out = discover_all(hass)
+        assert out["bd_meter_key"] == "18p5009498_2372761090617"
+        assert out["igo_dispatching_entity"].endswith("_intelligent_dispatching")
+        assert out["saving_session_entity"].endswith("_octoplus_saving_sessions")
+        assert out["zappi_prefix"] == "myenergi_zappi_22752031"
+        assert out["tesla_vehicle"] == "natalia"
+        assert "battery_soc" in out["inverter_sensor_overrides"]
+
+    def test_empty_hass_all_none(self):
+        hass = _hass([])
+        out = discover_all(hass)
+        assert out["bd_meter_key"] is None
+        assert out["igo_dispatching_entity"] is None
+        assert out["zappi_prefix"] is None
+        assert out["tesla_vehicle"] is None
+        assert out["inverter_sensor_overrides"] == {}

--- a/tests/test_heo3_skeleton.py
+++ b/tests/test_heo3_skeleton.py
@@ -60,8 +60,8 @@ class TestPackageImports:
         assert const.DOMAIN == "heo3"
 
     def test_tick_budget_constants_present(self):
-        assert const.TICK_HARD_BUDGET_S == 60.0
-        assert const.TICK_WARNING_S == 30.0
+        assert const.TICK_HARD_BUDGET_S == 120.0
+        assert const.TICK_WARNING_S == 60.0
 
 
 class TestOperatorWiring:


### PR DESCRIPTION
## Summary

Two pre-planner polish fixes that bit during today's cutover.

### 1. Tick budget mitigation

First baseline_static apply hit the 60s budget after 6/10 writes (each took ~6s instead of the 1-3s assumed). 4 writes aborted; a retry completed them but in a planner-driven future this would happen every tick.

- \`TICK_HARD_BUDGET_S\` 60s → 120s (and warning 30s → 60s)
- \`RESPONSE_TIMEOUT_S\` 5s → 10s — some SA responses arrive at the 5-7s mark on Paddy's install, triggering spurious retries that double per-write cost
- \`WRITE_RETRY_BACKOFF_S\` 5s → 2s
- Per-attempt + total duration logged in \`publish_and_verify\` so we can profile real SA latency in production

Long-term fix deferred: proper FIFO response correlation. The current single-future pattern races when responses arrive after a timeout.

### 2. Auto-discovery (replaces service-time patching)

The hardcoded paddy-house entity IDs in \`services.py._patch_house_config\` were a workaround. Replaced with proper discovery in \`__init__.py\` that scans \`hass.states\` for:

- BD electricity import meter \`{mpan}_{serial}\`
- IGO \`intelligent_dispatching\` binary_sensor
- Octoplus \`saving_sessions\` binary_sensor
- zappi prefix from \`select.myenergi_zappi_*_charge_mode\`
- Tesla vehicle from \`binary_sensor.<v>_located_at_home\` paired with \`switch.<v>_charge\`
- Inverter sensor overrides where SA naming differs from defaults

New \`custom_components/heo3/discovery.py\` with one discoverer per type + \`discover_all()\`. Discovery results stored on \`hass.data\` for debugging, logged at INFO during setup.

\`services.py\` simplified — no more patching at service time, since the operator is fully wired at setup.

## Tests
- 16 new in \`test_heo3_discovery.py\` (per-discoverer cases + paddy-install integration shape + empty-hass returns all-None)
- 824/824 full suite pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)